### PR TITLE
Allow reflective access of structural type member method

### DIFF
--- a/app/com/mohiva/play/silhouette/core/providers/utils/RoutesHelper.scala
+++ b/app/com/mohiva/play/silhouette/core/providers/utils/RoutesHelper.scala
@@ -16,6 +16,7 @@
  */
 package com.mohiva.play.silhouette.core.providers.utils
 
+import scala.language.reflectiveCalls
 import play.api.mvc.Call
 import play.Play
 import play.Logger


### PR DESCRIPTION
This clears warnings by accepting this coding style, but should be
changed in the future to avoid reflection.
