### PR TITLE
Move type definition for Identity in trait Authorization from method isAuthorized to head

### DIFF
--- a/app/com/mohiva/play/silhouette/core/Authorization.scala
+++ b/app/com/mohiva/play/silhouette/core/Authorization.scala
@@ -22,15 +22,16 @@ package com.mohiva.play.silhouette.core
 /**
  * A trait to define Authorization objects that let you hook
  * an authorization implementation in SecuredActions.
+ *
+ * @tparam I The type of the identity.
  */
-trait Authorization {
+trait Authorization[I <: Identity] {
 
   /**
    * Checks whether the user is authorized to execute an action or not.
    *
    * @param identity The identity to check for.
-   * @tparam I The type of the identity.
    * @return True if the user is authorized, false otherwise.
    */
-  def isAuthorized[I <: Identity](identity: I): Boolean
+  def isAuthorized(identity: I): Boolean
 }

--- a/app/com/mohiva/play/silhouette/core/Silhouette.scala
+++ b/app/com/mohiva/play/silhouette/core/Silhouette.scala
@@ -151,7 +151,7 @@ trait Silhouette[I <: Identity] extends Controller {
      *
      * @param authorize An Authorize object that checks if the user is authorized to invoke the action.
      */
-    def apply(authorize: Authorization) = new SecuredActionBuilder(Some(authorize))
+    def apply(authorize: Authorization[I]) = new SecuredActionBuilder(Some(authorize))
   }
 
   /**
@@ -159,7 +159,7 @@ trait Silhouette[I <: Identity] extends Controller {
    *
    * @param authorize An Authorize object that checks if the user is authorized to invoke the action.
    */
-  class SecuredActionBuilder(authorize: Option[Authorization] = None) extends ActionBuilder[SecuredRequest] {
+  class SecuredActionBuilder(authorize: Option[Authorization[I]] = None) extends ActionBuilder[SecuredRequest] {
 
     /**
      * Handles the not-authorized result.

--- a/test/com/mohiva/play/silhouette/core/SilhouetteSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/SilhouetteSpec.scala
@@ -409,7 +409,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
   class SecuredController(
       val identityService: IdentityService[SocialUser],
       val authenticatorService: AuthenticatorService,
-      val authorization: Authorization =  SimpleAuthorization()
+      val authorization: Authorization[SocialUser] =  SimpleAuthorization()
     )
     extends Silhouette[SocialUser] {
 
@@ -454,15 +454,14 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
    *
    * @param isAuthorized True if the access is authorized, false otherwise.
    */
-  case class SimpleAuthorization(isAuthorized: Boolean = true) extends Authorization {
+  case class SimpleAuthorization(isAuthorized: Boolean = true) extends Authorization[SocialUser] {
 
     /**
      * Checks whether the user is authorized to execute an action or not.
      *
      * @param identity The identity to check for.
-     * @tparam I The type of the identity.
      * @return True if the user is authorized, false otherwise.
      */
-    def isAuthorized[I <: Identity](identity: I): Boolean = isAuthorized
+    def isAuthorized(identity: SocialUser): Boolean = isAuthorized
   }
 }


### PR DESCRIPTION
With the old implementation the user must use pattern matching to get the type of the identity. With the new one the type is defined on the trait, so the user can only use this type of the identity.
