### PR TITLE
Integrate Scalariform

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,3 +36,5 @@ scalacOptions ++= Seq(
 )
 
 CoverallsPlugin.singleProject
+
+defaultScalariformSettings

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,3 +10,5 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.2.1")
 addSbtPlugin("com.sksamuel.scoverage" %% "sbt-scoverage" % "0.95.1")
 
 addSbtPlugin("com.sksamuel.scoverage" %% "sbt-coveralls" % "0.0.5")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.2.1")


### PR DESCRIPTION
This pull request integrates Scalariform into the Play tasks, in preparation for resolving #29. 

The default configuration is used, which is the same configuration used by the Play Framework project and which follows the Scala Style Guide.

This pull request does **not** enforce following this style, will not fail commits or builds, and does **not** include 
reformatting of existing code.

It just makes available two reformatting commands:

`play scalariformFormat` to reformat main source code

`play test:scalariformFormat` to reformat test source code

That is the same formatting done by other Scala tools such as the Scala IDE for Eclipse.
