### PR TITLE
Normalize FORBIDDEN vs UNAUTHORIZED responses

### DIFF
--- a/app/com/mohiva/play/silhouette/core/SecuredSettings.scala
+++ b/app/com/mohiva/play/silhouette/core/SecuredSettings.scala
@@ -28,19 +28,23 @@ trait SecuredSettings {
   this: GlobalSettings =>
 
   /**
-   * Called when a user isn't authenticated.
+   * Called when a user is not authenticated.
+   *
+   * As defined by RFC 2616, the status code of the response should be 401 Unauthorized.
    *
    * @param request The request header.
-   * @param lang The current selected lang.
+   * @param lang The currently selected language.
    * @return The result to send to the client.
    */
   def onNotAuthenticated(request: RequestHeader, lang: Lang): Option[Future[SimpleResult]] = None
 
   /**
-   * Called when a user isn't authorized.
+   * Called when a user is authenticated but not authorized.
+   *
+   * As defined by RFC 2616, the status code of the response should be 403 Forbidden.
    *
    * @param request The request header.
-   * @param lang The current selected lang.
+   * @param lang The currently selected language.
    * @return The result to send to the client.
    */
   def onNotAuthorized(request: RequestHeader, lang: Lang): Option[Future[SimpleResult]] = None

--- a/test/com/mohiva/play/silhouette/core/SilhouetteSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/SilhouetteSpec.scala
@@ -40,7 +40,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       val controller = new SecuredController(identityService, authenticatorService)
       val result = controller.protectedAction(FakeRequest())
 
-      status(result) must equalTo(FORBIDDEN)
+      status(result) must equalTo(UNAUTHORIZED)
       contentAsString(result) must contain(Messages("silhouette.not.authenticated"))
     }
 
@@ -50,7 +50,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       val controller = new SecuredController(identityService, authenticatorService)
       val result = controller.protectedAction(FakeRequest().withCookies(Cookie(Authenticator.cookieName, authenticatorID)))
 
-      status(result) must equalTo(FORBIDDEN)
+      status(result) must equalTo(UNAUTHORIZED)
       contentAsString(result) must contain(Messages("silhouette.not.authenticated"))
     }
 
@@ -62,7 +62,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       val controller = new SecuredController(identityService, authenticatorService)
       val result = controller.protectedAction(FakeRequest().withCookies(Cookie(Authenticator.cookieName, authenticatorID)))
 
-      status(result) must equalTo(FORBIDDEN)
+      status(result) must equalTo(UNAUTHORIZED)
       contentAsString(result) must contain(Messages("silhouette.not.authenticated"))
     }
 
@@ -74,7 +74,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       val controller = new SecuredController(identityService, authenticatorService)
       val result = controller.protectedAction(FakeRequest().withCookies(Cookie(Authenticator.cookieName, authenticatorID)))
 
-      status(result) must equalTo(FORBIDDEN)
+      status(result) must equalTo(UNAUTHORIZED)
       contentAsString(result) must contain(Messages("silhouette.not.authenticated"))
     }
 
@@ -96,7 +96,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       val controller = new SecuredController(identityService, authenticatorService)
       val result = controller.protectedAction(FakeRequest().withCookies(Cookie(Authenticator.cookieName, authenticatorID)))
 
-      status(result) must equalTo(FORBIDDEN)
+      status(result) must equalTo(UNAUTHORIZED)
       contentAsString(result) must contain(Messages("silhouette.not.authenticated"))
     }
 
@@ -116,13 +116,13 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
 
       val controller = new SecuredController(identityService, authenticatorService) {
         override def notAuthenticated(request: RequestHeader): Option[Future[SimpleResult]] = {
-          Some(Future.successful(Forbidden("local.not.authenticated")))
+          Some(Future.successful(Unauthorized("local.not.authenticated")))
         }
       }
 
       val result = controller.protectedAction(FakeRequest().withCookies(Cookie(Authenticator.cookieName, authenticatorID)))
 
-      status(result) must equalTo(FORBIDDEN)
+      status(result) must equalTo(UNAUTHORIZED)
       contentAsString(result) must contain("local.not.authenticated")
     }
 
@@ -133,7 +133,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       val controller = new SecuredController(identityService, authenticatorService)
       val result = controller.protectedAction(FakeRequest().withCookies(Cookie(Authenticator.cookieName, authenticatorID)))
 
-      status(result) must equalTo(FORBIDDEN)
+      status(result) must equalTo(UNAUTHORIZED)
       contentAsString(result) must contain("global.not.authenticated")
     }
 
@@ -144,7 +144,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       val controller = new SecuredController(identityService, authenticatorService)
       val result = controller.protectedAction(FakeRequest().withCookies(Cookie(Authenticator.cookieName, authenticatorID)))
 
-      status(result) must equalTo(FORBIDDEN)
+      status(result) must equalTo(UNAUTHORIZED)
       contentAsString(result) must contain(Messages("silhouette.not.authenticated"))
     }
 
@@ -154,13 +154,13 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
 
       val controller = new SecuredController(identityService, authenticatorService, SimpleAuthorization(isAuthorized = false)) {
         override def notAuthorized(request: RequestHeader): Option[Future[SimpleResult]] = {
-          Some(Future.successful(Unauthorized("local.not.authorized")))
+          Some(Future.successful(Forbidden("local.not.authorized")))
         }
       }
 
       val result = controller.protectedActionWithAuthorization(FakeRequest().withCookies(Cookie(Authenticator.cookieName, authenticatorID)))
 
-      status(result) must equalTo(UNAUTHORIZED)
+      status(result) must equalTo(FORBIDDEN)
       contentAsString(result) must contain("local.not.authorized")
     }
 
@@ -171,7 +171,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       val controller = new SecuredController(identityService, authenticatorService, SimpleAuthorization(isAuthorized = false))
       val result = controller.protectedActionWithAuthorization(FakeRequest().withCookies(Cookie(Authenticator.cookieName, authenticatorID)))
 
-      status(result) must equalTo(UNAUTHORIZED)
+      status(result) must equalTo(FORBIDDEN)
       contentAsString(result) must contain("global.not.authorized")
     }
 
@@ -182,11 +182,11 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       val controller = new SecuredController(identityService, authenticatorService, SimpleAuthorization(isAuthorized = false))
       val result = controller.protectedActionWithAuthorization(FakeRequest().withCookies(Cookie(Authenticator.cookieName, authenticatorID)))
 
-      status(result) must equalTo(UNAUTHORIZED)
+      status(result) must equalTo(FORBIDDEN)
       contentAsString(result) must contain(Messages("silhouette.not.authorized"))
     }
 
-    "invoke action without authorization if user is authorized" in new WithSecuredGlobal {
+    "invoke action without authorization if user is authenticated" in new WithSecuredGlobal {
       authenticatorService.findByID(authenticatorID) returns Future.successful(Some(authenticator))
       identityService.findByLoginInfo(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -197,7 +197,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       contentAsString(result) must contain("full.access")
     }
 
-    "invoke action with authorization if user is authorized" in new WithSecuredGlobal {
+    "invoke action with authorization if user is authenticated but not authorized" in new WithSecuredGlobal {
       authenticatorService.findByID(authenticatorID) returns Future.successful(Some(authenticator))
       identityService.findByLoginInfo(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -240,7 +240,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       val controller = new SecuredController(identityService, authenticatorService)
       val result = controller.userAwareAction(FakeRequest())
 
-      status(result) must equalTo(FORBIDDEN)
+      status(result) must equalTo(UNAUTHORIZED)
       contentAsString(result) must contain(Messages("not.authenticated"))
     }
 
@@ -250,7 +250,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       val controller = new SecuredController(identityService, authenticatorService)
       val result = controller.userAwareAction(FakeRequest().withCookies(Cookie(Authenticator.cookieName, authenticatorID)))
 
-      status(result) must equalTo(FORBIDDEN)
+      status(result) must equalTo(UNAUTHORIZED)
       contentAsString(result) must contain(Messages("not.authenticated"))
     }
 
@@ -262,7 +262,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       val controller = new SecuredController(identityService, authenticatorService)
       val result = controller.userAwareAction(FakeRequest().withCookies(Cookie(Authenticator.cookieName, authenticatorID)))
 
-      status(result) must equalTo(FORBIDDEN)
+      status(result) must equalTo(UNAUTHORIZED)
       contentAsString(result) must contain(Messages("not.authenticated"))
     }
 
@@ -274,7 +274,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       val controller = new SecuredController(identityService, authenticatorService)
       val result = controller.userAwareAction(FakeRequest().withCookies(Cookie(Authenticator.cookieName, authenticatorID)))
 
-      status(result) must equalTo(FORBIDDEN)
+      status(result) must equalTo(UNAUTHORIZED)
       contentAsString(result) must contain(Messages("not.authenticated"))
     }
 
@@ -296,7 +296,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       val controller = new SecuredController(identityService, authenticatorService)
       val result = controller.userAwareAction(FakeRequest().withCookies(Cookie(Authenticator.cookieName, authenticatorID)))
 
-      status(result) must equalTo(FORBIDDEN)
+      status(result) must equalTo(UNAUTHORIZED)
       contentAsString(result) must contain(Messages("not.authenticated"))
     }
 
@@ -379,7 +379,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
      * @return The result to send to the client.
      */
     override def onNotAuthenticated(request: RequestHeader, lang: Lang) = {
-      Some(Future.successful(Forbidden("global.not.authenticated")))
+      Some(Future.successful(Unauthorized("global.not.authenticated")))
     }
 
     /**
@@ -390,7 +390,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
      * @return The result to send to the client.
      */
     override def onNotAuthorized(request: RequestHeader, lang: Lang) = {
-      Some(Future.successful(Unauthorized("global.not.authorized")))
+      Some(Future.successful(Forbidden("global.not.authorized")))
     }
 
   }))) with Context
@@ -443,7 +443,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       if (request.identity.isDefined) {
         Ok("full.access")
       } else {
-        Forbidden("not.authenticated")
+        Unauthorized("not.authenticated")
       }
     }
   }


### PR DESCRIPTION
I believe in some situations the code is returning status code FORBIDDEN when it should be UNAUTHORIZED.

I'll review the code and propose a fix.

The name of these status codes can be misleading. UNAUTHORIZED is related to **authentication** and FORBIDDEN is related to **authorization**.

For reference reviewing this issue:

401 Unauthorized means "The request requires user authentication." The client MAY repeat the request with a suitable Authorization header field. It's a temporary condition.

403 Forbidden means "The server is refusing to fulfill the request." Authorization will not help and the request SHOULD NOT be repeated. It's a permanent condition.

In summary, a 401 Unauthorized response should be used for missing or bad authentication, and a 403 Forbidden response should be used afterwards, when the user is authenticated but isn’t authorized to perform the requested operation on the given resource.
- http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
- http://danielirvine.com/blog/2011/07/18/understanding-403-forbidden/
- http://stackoverflow.com/a/6937030/376366
