### PR TITLE
Default fallbacks should be media type-aware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ dist
 /.settings
 /.target
 /.cache
+/.target

--- a/app/com/mohiva/play/silhouette/core/Silhouette.scala
+++ b/app/com/mohiva/play/silhouette/core/Silhouette.scala
@@ -25,6 +25,7 @@ import play.api.i18n.Messages
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 import com.mohiva.play.silhouette.core.services.{ AuthenticatorService, IdentityService }
+import com.mohiva.play.silhouette.core.utils.DefaultActionHandler
 
 /**
  * Provides the actions that can be used to protect controllers and retrieve the current user
@@ -196,7 +197,7 @@ trait Silhouette[I <: Identity] extends Controller {
           case s: SecuredSettings => s.onNotAuthorized(request, lang)
           case _ => None
         }
-      }.getOrElse(Future.successful(Forbidden(Messages("silhouette.not.authorized"))))
+      }.getOrElse(DefaultActionHandler.handleForbidden)
     }
 
     /**
@@ -221,7 +222,7 @@ trait Silhouette[I <: Identity] extends Controller {
           case s: SecuredSettings => s.onNotAuthenticated(request, lang)
           case _ => None
         }
-      }.getOrElse(Future.successful(Unauthorized(Messages("silhouette.not.authenticated"))))
+      }.getOrElse(DefaultActionHandler.handleUnauthorized)
     }
 
     /**

--- a/app/com/mohiva/play/silhouette/core/utils/DefaultActionHandler.scala
+++ b/app/com/mohiva/play/silhouette/core/utils/DefaultActionHandler.scala
@@ -1,0 +1,73 @@
+package com.mohiva.play.silhouette.core.utils
+
+import play.api.{ Play, Logger }
+import play.api.i18n.Messages
+import play.api.libs.json.Json
+import play.api.mvc._
+import scala.concurrent._
+
+/**
+ * Provides default actions used by the core as a last fallback.
+ */
+object DefaultActionHandler extends Controller {
+
+  /**
+   * Handles forbidden requests in a default way.
+   *
+   * The HTTP status code of the response will be 403 Forbidden, complying with
+   * [[https://tools.ietf.org/html/rfc2616#section-10.4.4 RFC 2616]].
+   *
+   * @param request The request header.
+   * @return A response indicating that access is forbidden.
+   */
+  def handleForbidden(implicit request: RequestHeader): Future[SimpleResult] = {
+    produceResponse(Forbidden, "silhouette.not.authorized")
+  }
+
+  /**
+   * Handles unauthorized requests in a default way.
+   *
+   * The HTTP status code of the response will be 401 Unauthorized, complying with
+   * [[https://tools.ietf.org/html/rfc2616#section-10.4.2 RFC 2616]].
+   *
+   * @param request The request header.
+   * @return A response indicating that user authentication is required.
+   */
+  def handleUnauthorized(implicit request: RequestHeader): Future[SimpleResult] = {
+    produceResponse(Unauthorized, "silhouette.not.authenticated")
+  }
+
+  /**
+   * Returns an adequate response considering the required status code,
+   * the user-friendly message, and the requested media type.
+   *
+   * @param status The status code of the response.
+   * @param msg The user-friendly message.
+   * @param request The request header.
+   */
+  private def produceResponse[S <: Status](status: S, msg: String)(implicit request: RequestHeader): Future[SimpleResult] = {
+    val localized = Messages(msg)
+    Future.successful(render {
+      case Accepts.Html() => status(toHtmlError(localized)).as(HTML)
+      // This will also be the default content type if the client doesn't request a specific media type.
+      case Accepts.Json() => status(toJsonError(localized))
+      case Accepts.Xml() => status(toXmlError(localized))
+      case _ => status(toPlainTextError(localized))
+      // The correct HTTP status code must be returned in any situation.
+      // The response format will default to plain text in case the request does not specify one of known
+      // media types. The user agent is responsible for inspecting the response headers as specified in
+      // [[https://tools.ietf.org/html/rfc2616#section-10.4.7 RFC 2616]].
+    })
+  }
+
+  private def toHtmlError(message: String) =
+    s"<html><head><title>$message</title></head><body>$message</body></html>"
+
+  private def toJsonError(message: String) =
+    Json.toJson(Json.obj("success" -> false, "message" -> message))
+
+  private def toXmlError(message: String) =
+    <response><success>false</success><message>{ message }</message></response>
+
+  private def toPlainTextError(message: String) = message
+}

--- a/conf/messages
+++ b/conf/messages
@@ -1,2 +1,2 @@
-silhouette.credentials.required = Credentials required
+silhouette.not.authenticated = Authentication required
 silhouette.not.authorized = Not authorized

--- a/test/com/mohiva/play/silhouette/core/utils/DefaultActionHandlerSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/utils/DefaultActionHandlerSpec.scala
@@ -1,0 +1,158 @@
+package com.mohiva.play.silhouette.core.utils
+
+import play.api.mvc._
+import play.api.test._
+import play.api.http.ContentTypes._
+import play.api.i18n.Messages
+import scala.concurrent._
+
+/**
+ * Test case for the [[com.mohiva.play.silhouette.core.utils.DefaultActionHandler]] class.
+ */
+class DefaultActionHandlerSpec extends PlaySpecification {
+
+  "The handleForbidden method" should {
+    "return an HTML response for an HTML request" in new WithApplication {
+      testResponse(
+        acceptedMediaType = Some(HTML),
+        expectedStatus = FORBIDDEN,
+        expectedContentType = HTML,
+        expectedResponseFragment = "<html>",
+        expectedMessage = "silhouette.not.authorized",
+        f = { r: RequestHeader => DefaultActionHandler.handleForbidden(r) })
+    }
+
+    "return a JSON response for a JSON request" in new WithApplication {
+      testResponse(
+        acceptedMediaType = Some(JSON),
+        expectedStatus = FORBIDDEN,
+        expectedContentType = JSON,
+        expectedResponseFragment = "\"success\":false",
+        expectedMessage = "silhouette.not.authorized",
+        f = { r: RequestHeader => DefaultActionHandler.handleForbidden(r) })
+    }
+
+    "return a XML response for a XML request" in new WithApplication {
+      testResponse(
+        acceptedMediaType = Some(XML),
+        expectedStatus = FORBIDDEN,
+        expectedContentType = XML,
+        expectedResponseFragment = "<success>false</success>",
+        expectedMessage = "silhouette.not.authorized",
+        f = { r: RequestHeader => DefaultActionHandler.handleForbidden(r) })
+    }
+
+    "return a plain text response for a plain text request" in new WithApplication {
+      testResponse(
+        acceptedMediaType = Some(TEXT),
+        expectedStatus = FORBIDDEN,
+        expectedContentType = TEXT,
+        expectedResponseFragment = Messages("silhouette.not.authorized"),
+        expectedMessage = "silhouette.not.authorized",
+        f = { r: RequestHeader => DefaultActionHandler.handleForbidden(r) })
+    }
+
+    "return a plain text response for other requests" in new WithApplication {
+      testResponse(
+        acceptedMediaType = Some(BINARY),
+        expectedStatus = FORBIDDEN,
+        expectedContentType = TEXT,
+        expectedResponseFragment = Messages("silhouette.not.authorized"),
+        expectedMessage = "silhouette.not.authorized",
+        f = { r: RequestHeader => DefaultActionHandler.handleForbidden(r) })
+    }
+
+    "return an HTML response for a request without an Accept header" in new WithApplication {
+      testResponse(
+        acceptedMediaType = None,
+        expectedStatus = FORBIDDEN,
+        expectedContentType = HTML,
+        expectedResponseFragment = Messages("silhouette.not.authorized"),
+        expectedMessage = "silhouette.not.authorized",
+        f = { r: RequestHeader => DefaultActionHandler.handleForbidden(r) })
+    }
+  }
+
+  "The handleUnauthorized method" should {
+    "return an HTML response for an HTML request" in new WithApplication {
+      testResponse(
+        acceptedMediaType = Some(HTML),
+        expectedStatus = UNAUTHORIZED,
+        expectedContentType = HTML,
+        expectedResponseFragment = "<html>",
+        expectedMessage = "silhouette.not.authenticated",
+        f = { r: RequestHeader => DefaultActionHandler.handleUnauthorized(r) })
+    }
+
+    "return a JSON response for a JSON request" in new WithApplication {
+      testResponse(
+        acceptedMediaType = Some(JSON),
+        expectedStatus = UNAUTHORIZED,
+        expectedContentType = JSON,
+        expectedResponseFragment = "\"success\":false",
+        expectedMessage = "silhouette.not.authenticated",
+        f = { r: RequestHeader => DefaultActionHandler.handleUnauthorized(r) })
+    }
+
+    "return a XML response for a XML request" in new WithApplication {
+      testResponse(
+        acceptedMediaType = Some(XML),
+        expectedStatus = UNAUTHORIZED,
+        expectedContentType = XML,
+        expectedResponseFragment = "<success>false</success>",
+        expectedMessage = "silhouette.not.authenticated",
+        f = { r: RequestHeader => DefaultActionHandler.handleUnauthorized(r) })
+    }
+
+    "return a plain text response for a plain text request" in new WithApplication {
+      testResponse(
+        acceptedMediaType = Some(TEXT),
+        expectedStatus = UNAUTHORIZED,
+        expectedContentType = TEXT,
+        expectedResponseFragment = Messages("silhouette.not.authenticated"),
+        expectedMessage = "silhouette.not.authenticated",
+        f = { r: RequestHeader => DefaultActionHandler.handleUnauthorized(r) })
+    }
+
+    "return a plain text response for other requests" in new WithApplication {
+      testResponse(
+        acceptedMediaType = Some(BINARY),
+        expectedStatus = UNAUTHORIZED,
+        expectedContentType = TEXT,
+        expectedResponseFragment = Messages("silhouette.not.authenticated"),
+        expectedMessage = "silhouette.not.authenticated",
+        f = { r: RequestHeader => DefaultActionHandler.handleUnauthorized(r) })
+    }
+
+    "return an HTML response for a request without an Accept header" in new WithApplication {
+      testResponse(
+        acceptedMediaType = None,
+        expectedStatus = UNAUTHORIZED,
+        expectedContentType = HTML,
+        expectedResponseFragment = Messages("silhouette.not.authenticated"),
+        expectedMessage = "silhouette.not.authenticated",
+        f = { r: RequestHeader => DefaultActionHandler.handleUnauthorized(r) })
+    }
+  }
+
+  private def testResponse(
+      acceptedMediaType: Option[String],
+      expectedStatus: Int,
+      expectedContentType: String,
+      expectedResponseFragment: String,
+      expectedMessage: String,
+      f: RequestHeader => Future[SimpleResult]) = {
+    implicit val request = acceptedMediaType match {
+      case Some(mediaType) => FakeRequest().withHeaders(ACCEPT -> mediaType)
+      case None => FakeRequest()
+    }
+
+    val result = f(request)
+
+    status(result) must equalTo(expectedStatus)
+    header(CONTENT_TYPE, result) must beSome
+    header(CONTENT_TYPE, result).get must equalTo(expectedContentType)
+    contentAsString(result) must contain(expectedResponseFragment)
+    contentAsString(result) must contain(Messages(expectedMessage))
+  }
+}


### PR DESCRIPTION
The default fallbacks for unauthorized and forbidden requests should use content negotiation to produce a response with a content type adequate to the `Accept` request header.

At least the most common media types should be supported: `text/plain`, `text/html`, `application/json` and `application/xml`.

See [this discussion](https://github.com/mohiva/play-silhouette/issues/16#issuecomment-31771457).
