### PR TITLE
Check warning on OAuth2Provider.scala

### DIFF
--- a/app/com/mohiva/play/silhouette/core/providers/OAuth2Provider.scala
+++ b/app/com/mohiva/play/silhouette/core/providers/OAuth2Provider.scala
@@ -84,7 +84,7 @@ abstract class OAuth2Provider(
           (State, state))
         settings.scope.foreach(s => { params = (Scope, s) :: params })
         val url = settings.authorizationURL + params.map(p => p._1 + "=" + URLEncoder.encode(p._2, "UTF-8")).mkString("?", "&", "")
-        val redirect = Results.Redirect(url).withSession(request.session + (CacheKey, cacheID))
+        val redirect = Results.Redirect(url).withSession(request.session + (CacheKey -> cacheID))
         if (Logger.isDebugEnabled) {
           Logger.debug("[Silhouette][%s] Use authorization URL: %s".format(id, settings.authorizationURL))
           Logger.debug("[Silhouette][%s] Redirecting to: %s".format(id, url))


### PR DESCRIPTION
Compiling with "-Xlint" produces this warning:

```
[error] /home/fernando/work/github/mohiva/play-silhouette/app/com/mohiva/play/silhouette/core/providers/OAuth2Provider.scala:87: Adapting argument list by creating a 2-tuple: this may not be what you want.
[error]         signature: Session.+(kv: (String, String)): play.api.mvc.Session
[error]   given arguments: CacheKey, cacheID
[error]  after adaptation: Session.+((CacheKey, cacheID): (String, String))
[error]         val redirect = Results.Redirect(url).withSession(request.session + (CacheKey, cacheID))
[error]                                                                          ^
```

What do you think? It is a hidden bug? Can we refactor it so the warning disappears?

I'd like to enable "-Xlint" by default.
