### PR TITLE
Consider enabling additional warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,10 +30,16 @@ publishTo <<= (version) { v: String =>
 playScalaSettings ++ ScoverageSbtPlugin.instrumentSettings
 
 scalacOptions ++= Seq(
-  "-deprecation",
-  "-feature",
-  "-unchecked",
-  "-Xfatal-warnings"
+  "-deprecation", // Emit warning and location for usages of deprecated APIs.
+  "-feature", // Emit warning and location for usages of features that should be imported explicitly.
+  "-unchecked", // Enable additional warnings where generated code depends on assumptions.
+  "-Xfatal-warnings", // Fail the compilation if there are any warnings.
+  "-Xlint", // Enable recommended additional warnings.
+  "-Ywarn-adapted-args", // Warn if an argument list is modified to match the receiver.
+  "-Ywarn-dead-code", // Warn when dead code is identified.
+  "-Ywarn-inaccessible", // Warn about inaccessible types in method signatures.
+  "-Ywarn-nullary-override", // Warn when non-nullary overrides nullary, e.g. def foo() over def foo.
+  "-Ywarn-numeric-widen" // Warn when numerics are widened.
 )
 
 CoverallsPlugin.singleProject


### PR DESCRIPTION
To ensure code quality, consider enabling additional warnings (if there are no false positives):

```
$  scalac -X |& grep warn
  -Xfatal-warnings               Fail the compilation if there are any warnings.
  -Xlint                         Enable recommended additional warnings.
$ scalac -Y |& grep warn
  -Yinline-warnings                   Emit inlining warnings. (Normally surpressed due to high volume)
  -Ywarn-adapted-args                 Warn if an argument list is modified to match the receiver.
  -Ywarn-all                          Enable all -Y warnings.
  -Ywarn-dead-code                    Warn when dead code is identified.
  -Ywarn-inaccessible                 Warn about inaccessible types in method signatures.
  -Ywarn-nullary-override             Warn when non-nullary overrides nullary, e.g. `def foo()` over `def foo`.
  -Ywarn-nullary-unit                 Warn when nullary methods return Unit.
  -Ywarn-numeric-widen                Warn when numerics are widened.
  -Ywarn-value-discard                Warn when non-Unit expression results are unused.
```
