### PR TITLE
OAuth2Provider does not use an expiration time when caching the state

### DIFF
--- a/app/com/mohiva/play/silhouette/core/providers/OAuth1Provider.scala
+++ b/app/com/mohiva/play/silhouette/core/providers/OAuth1Provider.scala
@@ -80,7 +80,7 @@ abstract class OAuth1Provider(
           if (Logger.isDebugEnabled) {
             Logger.debug("[Silhouette][%s] Redirecting to: %s".format(id, url))
           }
-          cacheLayer.set(cacheID, token, 600) // set it for 10 minutes, plenty of time to log in
+          cacheLayer.set(cacheID, token, 300) // set it for 5 minutes, plenty of time to log in
           Left(redirect)
         }))
     }

--- a/app/com/mohiva/play/silhouette/core/providers/OAuth2Provider.scala
+++ b/app/com/mohiva/play/silhouette/core/providers/OAuth2Provider.scala
@@ -89,7 +89,7 @@ abstract class OAuth2Provider(
           Logger.debug("[Silhouette][%s] Use authorization URL: %s".format(id, settings.authorizationURL))
           Logger.debug("[Silhouette][%s] Redirecting to: %s".format(id, url))
         }
-        cacheLayer.set(cacheID, state)
+        cacheLayer.set(cacheID, state, 300) // set it for 5 minutes, plenty of time to log in
         Future.successful(Left(redirect))
     }
   }


### PR DESCRIPTION
The [OAuth1Provider](https://github.com/mohiva/play-silhouette/blob/master/app/com/mohiva/play/silhouette/core/providers/OAuth1Provider.scala#L83) uses an expiration time from 10 minutes when caching the request token. But the [OAuth2Provider](https://github.com/mohiva/play-silhouette/blob/master/app/com/mohiva/play/silhouette/core/providers/OAuth2Provider.scala#L92) doesn't use an expiration time. In SecureSocial this is equally implemented. Is there a reason for this?
