### PR TITLE
Use implementation-independent names for service methods

### DIFF
--- a/app/com/mohiva/play/silhouette/core/Silhouette.scala
+++ b/app/com/mohiva/play/silhouette/core/Silhouette.scala
@@ -91,7 +91,7 @@ trait Silhouette[I <: Identity, T <: Authenticator] extends Controller {
    */
   protected def currentIdentity(implicit request: RequestHeader): Future[Option[I]] = {
     authenticatorService.retrieve.flatMap {
-      case Some(authenticator) => identityService.findByLoginInfo(authenticator.loginInfo).map(_.map { identity =>
+      case Some(authenticator) => identityService.retrieve(authenticator.loginInfo).map(_.map { identity =>
         authenticatorService.update(authenticator)
         identity
       })

--- a/app/com/mohiva/play/silhouette/core/providers/CredentialsProvider.scala
+++ b/app/com/mohiva/play/silhouette/core/providers/CredentialsProvider.scala
@@ -58,7 +58,7 @@ class CredentialsProvider(
    */
   def authenticate(credentials: Credentials): Future[Option[LoginInfo]] = {
     val loginInfo = new LoginInfo(id, credentials.identifier)
-    authInfoService.findByLoginInfo[PasswordInfo](loginInfo).map {
+    authInfoService.retrieve[PasswordInfo](loginInfo).map {
       case Some(authInfo) => passwordHasherList.find(_.id == authInfo.hasher) match {
         case Some(hasher) if hasher.matches(authInfo, credentials.password) =>
           if (hasher != passwordHasher) {

--- a/app/com/mohiva/play/silhouette/core/services/AuthInfoService.scala
+++ b/app/com/mohiva/play/silhouette/core/services/AuthInfoService.scala
@@ -44,10 +44,10 @@ trait AuthInfoService {
   def save[T](loginInfo: LoginInfo, authInfo: T): Future[Option[LoginInfo]]
 
   /**
-   * Finds the auth info which is linked with the specified login info.
+   * Retrieves the auth info which is linked with the specified login info.
    *
    * @param loginInfo The linked login info.
-   * @return The found auth info or None if no auth info could be found for the given login info.
+   * @return The retrieved auth info or None if no auth info could be retrieved for the given login info.
    */
-  def findByLoginInfo[T](loginInfo: LoginInfo): Future[Option[T]]
+  def retrieve[T](loginInfo: LoginInfo): Future[Option[T]]
 }

--- a/app/com/mohiva/play/silhouette/core/services/IdentityService.scala
+++ b/app/com/mohiva/play/silhouette/core/services/IdentityService.scala
@@ -29,21 +29,10 @@ import com.mohiva.play.silhouette.core.{ Identity, LoginInfo }
 trait IdentityService[T <: Identity] {
 
   /**
-   * Saves an identity.
+   * Retrieves an identity that matches the specified login info.
    *
-   * This method gets called when a user logs in(social auth) or registers.
-   * This is your chance to save the user information in your backing store.
-   *
-   * @param identity The identity to save.
-   * @return The saved identity or None if the identity couldn't be saved.
+   * @param loginInfo The login info to retrieve an identity.
+   * @return The retrieved identity or None if no identity could be retrieved for the given login info.
    */
-  def save(identity: T): Future[Option[T]]
-
-  /**
-   * Finds an identity that matches the specified login info.
-   *
-   * @param loginInfo The login info to find an identity.
-   * @return The found identity or None if no identity could be found for the given login info.
-   */
-  def findByLoginInfo(loginInfo: LoginInfo): Future[Option[T]]
+  def retrieve(loginInfo: LoginInfo): Future[Option[T]]
 }

--- a/test/com/mohiva/play/silhouette/core/SilhouetteSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/SilhouetteSpec.scala
@@ -48,7 +48,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
     "restrict access if no identity could be found for an authenticator" in new WithDefaultGlobal {
       authenticatorService.retrieve returns Future.successful(Some(authenticator))
       authenticatorService.discard(any) answers { r => r.asInstanceOf[SimpleResult] }
-      identityService.findByLoginInfo(identity.loginInfo) returns Future.successful(None)
+      identityService.retrieve(identity.loginInfo) returns Future.successful(None)
 
       val controller = new SecuredController(identityService, authenticatorService)
       val result = controller.protectedAction(request)
@@ -60,7 +60,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
     "update an authenticator if an identity could be found for it" in new WithDefaultGlobal {
       authenticatorService.retrieve returns Future.successful(Some(authenticator))
       authenticatorService.discard(any) answers { r => r.asInstanceOf[SimpleResult] }
-      identityService.findByLoginInfo(identity.loginInfo) returns Future.successful(Some(identity))
+      identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
       val controller = new SecuredController(identityService, authenticatorService)
       await(controller.protectedAction(request))
@@ -71,7 +71,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
     "display local not-authenticated result if user isn't authenticated" in new WithSecuredGlobal {
       authenticatorService.retrieve returns Future.successful(Some(authenticator))
       authenticatorService.discard(any) answers { r => r.asInstanceOf[SimpleResult] }
-      identityService.findByLoginInfo(identity.loginInfo) returns Future.successful(None)
+      identityService.retrieve(identity.loginInfo) returns Future.successful(None)
 
       val controller = new SecuredController(identityService, authenticatorService) {
         override def notAuthenticated(request: RequestHeader): Option[Future[SimpleResult]] = {
@@ -88,7 +88,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
     "display global not-authenticated result if user isn't authenticated" in new WithSecuredGlobal {
       authenticatorService.retrieve returns Future.successful(Some(authenticator))
       authenticatorService.discard(any) answers { r => r.asInstanceOf[SimpleResult] }
-      identityService.findByLoginInfo(identity.loginInfo) returns Future.successful(None)
+      identityService.retrieve(identity.loginInfo) returns Future.successful(None)
 
       val controller = new SecuredController(identityService, authenticatorService)
       val result = controller.protectedAction(request)
@@ -100,7 +100,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
     "display fallback message if user isn't authenticated and fallback methods aren't implemented" in new WithDefaultGlobal {
       authenticatorService.retrieve returns Future.successful(Some(authenticator))
       authenticatorService.discard(any) answers { r => r.asInstanceOf[SimpleResult] }
-      identityService.findByLoginInfo(identity.loginInfo) returns Future.successful(None)
+      identityService.retrieve(identity.loginInfo) returns Future.successful(None)
 
       val controller = new SecuredController(identityService, authenticatorService)
       val result = controller.protectedAction(request)
@@ -111,7 +111,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
 
     "display local not-authorized result if user isn't authorized" in new WithSecuredGlobal {
       authenticatorService.retrieve returns Future.successful(Some(authenticator))
-      identityService.findByLoginInfo(identity.loginInfo) returns Future.successful(Some(identity))
+      identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
       val controller = new SecuredController(identityService, authenticatorService, SimpleAuthorization(isAuthorized = false)) {
         override def notAuthorized(request: RequestHeader): Option[Future[SimpleResult]] = {
@@ -127,7 +127,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
 
     "display global not-authorized result if user isn't authorized" in new WithSecuredGlobal {
       authenticatorService.retrieve returns Future.successful(Some(authenticator))
-      identityService.findByLoginInfo(identity.loginInfo) returns Future.successful(Some(identity))
+      identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
       val controller = new SecuredController(identityService, authenticatorService, SimpleAuthorization(isAuthorized = false))
       val result = controller.protectedActionWithAuthorization(request)
@@ -138,7 +138,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
 
     "display fallback message if user isn't authorized and fallback methods aren't implemented" in new WithDefaultGlobal {
       authenticatorService.retrieve returns Future.successful(Some(authenticator))
-      identityService.findByLoginInfo(identity.loginInfo) returns Future.successful(Some(identity))
+      identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
       val controller = new SecuredController(identityService, authenticatorService, SimpleAuthorization(isAuthorized = false))
       val result = controller.protectedActionWithAuthorization(request)
@@ -149,7 +149,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
 
     "invoke action without authorization if user is authenticated" in new WithSecuredGlobal {
       authenticatorService.retrieve returns Future.successful(Some(authenticator))
-      identityService.findByLoginInfo(identity.loginInfo) returns Future.successful(Some(identity))
+      identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
       val controller = new SecuredController(identityService, authenticatorService)
       val result = controller.protectedAction(request)
@@ -160,7 +160,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
 
     "invoke action with authorization if user is authenticated but not authorized" in new WithSecuredGlobal {
       authenticatorService.retrieve returns Future.successful(Some(authenticator))
-      identityService.findByLoginInfo(identity.loginInfo) returns Future.successful(Some(identity))
+      identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
       val controller = new SecuredController(identityService, authenticatorService)
       val result = controller.protectedActionWithAuthorization(request)
@@ -185,7 +185,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       implicit val req = FakeRequest().withHeaders("Accept" -> "application/json")
 
       authenticatorService.retrieve returns Future.successful(Some(authenticator))
-      identityService.findByLoginInfo(identity.loginInfo) returns Future.successful(Some(identity))
+      identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
       val controller = new SecuredController(identityService, authenticatorService)
       val result = controller.protectedAction(req)
@@ -209,7 +209,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
 
     "restrict access if no identity could be found for an authenticator" in new WithDefaultGlobal {
       authenticatorService.retrieve returns Future.successful(Some(authenticator))
-      identityService.findByLoginInfo(identity.loginInfo) returns Future.successful(None)
+      identityService.retrieve(identity.loginInfo) returns Future.successful(None)
 
       val controller = new SecuredController(identityService, authenticatorService)
       val result = controller.userAwareAction(request)
@@ -220,7 +220,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
 
     "update an authenticator if an identity could be found for it" in new WithDefaultGlobal {
       authenticatorService.retrieve returns Future.successful(Some(authenticator))
-      identityService.findByLoginInfo(identity.loginInfo) returns Future.successful(Some(identity))
+      identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
       val controller = new SecuredController(identityService, authenticatorService)
       await(controller.userAwareAction(request))
@@ -230,7 +230,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
 
     "grant access if an identity could be found" in new WithDefaultGlobal {
       authenticatorService.retrieve returns Future.successful(Some(authenticator))
-      identityService.findByLoginInfo(identity.loginInfo) returns Future.successful(Some(identity))
+      identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
       val controller = new SecuredController(identityService, authenticatorService)
       val result = controller.userAwareAction(request)


### PR DESCRIPTION
Review and rename service methods so that they don't assume how persistence will be implemented. Use method names representing the domain logic operation that is being performed, instead of the datastore operation that is assumed to be implemented.

See [#46 comment](https://github.com/mohiva/play-silhouette/pull/46#issuecomment-32707393).
