### PR TITLE
Should we use silhouette or play-silhouette as name in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import play.Project._
 import mohiva.sbt.Helper._
 
-name := "silhouette"
+name := "play-silhouette"
 
 version := "1.0-SNAPSHOT"
 


### PR DESCRIPTION
Currently in build.sbt the name is defined as silhouette. So we must define the dependencies as:

```
"com.mohiva" %% "silhouette" % "1.0-SNAPSHOT"
```

Or should we rather define the name as play-silhouette so we can define the dependency as:

```
"com.mohiva" %% "play-silhouette" % "1.0-SNAPSHOT"
```
