### PR TITLE
Consider to also return the AuthInfo from the providers

### DIFF
--- a/app/com/mohiva/play/silhouette/core/providers/OAuth1Provider.scala
+++ b/app/com/mohiva/play/silhouette/core/providers/OAuth1Provider.scala
@@ -103,7 +103,7 @@ abstract class OAuth1Provider(
 }
 
 /**
- * The companion object.
+ * The OAuth1Provider companion object.
  */
 object OAuth1Provider {
 

--- a/app/com/mohiva/play/silhouette/core/providers/OAuth2Provider.scala
+++ b/app/com/mohiva/play/silhouette/core/providers/OAuth2Provider.scala
@@ -35,6 +35,36 @@ import com.mohiva.play.silhouette.core._
 import OAuth2Provider._
 
 /**
+ * The Oauth2 details.
+ *
+ * @param accessToken The access token.
+ * @param tokenType The token type.
+ * @param expiresIn The number of seconds before the token expires.
+ * @param refreshToken The refresh token.
+ */
+case class OAuth2Info(
+  accessToken: String,
+  tokenType: Option[String] = None,
+  expiresIn: Option[Int] = None,
+  refreshToken: Option[String] = None) extends AuthInfo
+
+/**
+ * The Oauth2 companion object.
+ */
+object OAuth2Info {
+
+  /**
+   * Converts the JSON into a [[com.mohiva.play.silhouette.core.providers.OAuth2Info]] object.
+   */
+  implicit val infoReads = (
+    (__ \ AccessToken).read[String] and
+    (__ \ TokenType).readNullable[String] and
+    (__ \ ExpiresIn).readNullable[Int] and
+    (__ \ RefreshToken).readNullable[String]
+  )(OAuth2Info.apply _)
+}
+
+/**
  * Base class for all OAuth2 providers.
  *
  * @param settings The provider settings.
@@ -52,16 +82,6 @@ abstract class OAuth2Provider(
    * A list with headers to send to the API.
    */
   protected val headers: Seq[(String, String)] = Seq()
-
-  /**
-   * Converts the JSON into a [[com.mohiva.play.silhouette.core.providers.OAuth2Info]] object.
-   */
-  private implicit val infoReads = (
-    (__ \ AccessToken).read[String] and
-    (__ \ TokenType).readNullable[String] and
-    (__ \ ExpiresIn).readNullable[Int] and
-    (__ \ RefreshToken).readNullable[String]
-  )(OAuth2Info.apply _)
 
   /**
    * Starts the authentication process.
@@ -165,7 +185,7 @@ abstract class OAuth2Provider(
 }
 
 /**
- * The companion object.
+ * The OAuth2Provider companion object.
  */
 object OAuth2Provider {
 
@@ -230,17 +250,3 @@ case class OAuth2Settings(
   authorizationParams: Map[String, String] = Map(),
   accessTokenParams: Map[String, String] = Map(),
   customProperties: Map[String, String] = Map())
-
-/**
- * The Oauth2 details.
- *
- * @param accessToken The access token.
- * @param tokenType The token type.
- * @param expiresIn The number of seconds before the token expires.
- * @param refreshToken The refresh token.
- */
-case class OAuth2Info(
-  accessToken: String,
-  tokenType: Option[String] = None,
-  expiresIn: Option[Int] = None,
-  refreshToken: Option[String] = None) extends AuthInfo

--- a/app/com/mohiva/play/silhouette/core/providers/helpers/LinkedInProfile.scala
+++ b/app/com/mohiva/play/silhouette/core/providers/helpers/LinkedInProfile.scala
@@ -27,6 +27,7 @@ import scala.util.{ Success, Failure, Try }
 import com.mohiva.play.silhouette.core.LoginInfo
 import com.mohiva.play.silhouette.core.providers.SocialProfile
 import com.mohiva.play.silhouette.core.exceptions.AuthenticationException
+import com.mohiva.play.silhouette.core.services.AuthInfo
 
 /**
  * Parses the JSON response for the LinkedIn OAuth1 and OAuth2 API.
@@ -64,9 +65,10 @@ object LinkedInProfile {
    * Builds the social profile from the JSON response.
    *
    * @param maybeResponse The response from the provider.
+   * @param authInfo The auth info received from the provider.
    * @return On success the build social profile, otherwise a failure.
    */
-  def build(maybeResponse: Future[Response]): Future[Try[SocialProfile]] = {
+  def build[A <: AuthInfo](maybeResponse: Future[Response], authInfo: A): Future[Try[SocialProfile[A]]] = {
     maybeResponse.map { response =>
       val json = response.json
       (json \ ErrorCode).asOpt[Int] match {
@@ -87,6 +89,7 @@ object LinkedInProfile {
 
           Success(SocialProfile(
             loginInfo = LoginInfo(LinkedIn, userID),
+            authInfo = authInfo,
             firstName = firstName,
             lastName = lastName,
             fullName = fullName,

--- a/app/com/mohiva/play/silhouette/core/providers/oauth1/LinkedInProvider.scala
+++ b/app/com/mohiva/play/silhouette/core/providers/oauth1/LinkedInProvider.scala
@@ -24,20 +24,17 @@ import scala.concurrent.Future
 import com.mohiva.play.silhouette.core.utils.{ HTTPLayer, CacheLayer }
 import com.mohiva.play.silhouette.core.providers._
 import com.mohiva.play.silhouette.core.providers.helpers.LinkedInProfile._
-import com.mohiva.play.silhouette.core.services.AuthInfoService
 import LinkedInProvider._
 
 /**
  * A LinkedIn OAuth1 Provider.
  *
- * @param authInfoService The auth info service.
  * @param cacheLayer The cache layer implementation.
  * @param httpLayer The HTTP layer implementation.
  * @param oAuth1Service The OAuth1 service implementation.
  * @param auth1Settings The OAuth1 provider settings.
  */
 class LinkedInProvider(
-  protected val authInfoService: AuthInfoService,
   cacheLayer: CacheLayer,
   httpLayer: HTTPLayer,
   oAuth1Service: OAuth1Service,
@@ -57,8 +54,8 @@ class LinkedInProvider(
    * @param authInfo The auth info received from the provider.
    * @return On success the build social profile, otherwise a failure.
    */
-  protected def buildProfile(authInfo: OAuth1Info): Future[Try[SocialProfile]] = {
-    build(httpLayer.url(API).sign(oAuth1Service.sign(authInfo)).get())
+  protected def buildProfile(authInfo: OAuth1Info): Future[Try[SocialProfile[OAuth1Info]]] = {
+    build(httpLayer.url(API).sign(oAuth1Service.sign(authInfo)).get(), authInfo)
   }
 }
 

--- a/app/com/mohiva/play/silhouette/core/providers/oauth1/TwitterProvider.scala
+++ b/app/com/mohiva/play/silhouette/core/providers/oauth1/TwitterProvider.scala
@@ -25,14 +25,12 @@ import scala.util.{ Success, Failure, Try }
 import com.mohiva.play.silhouette.core._
 import com.mohiva.play.silhouette.core.utils.{ HTTPLayer, CacheLayer }
 import com.mohiva.play.silhouette.core.providers._
-import com.mohiva.play.silhouette.core.services.AuthInfoService
 import com.mohiva.play.silhouette.core.exceptions.AuthenticationException
 import TwitterProvider._
 
 /**
  * A Twitter OAuth1 Provider.
  *
- * @param authInfoService The auth info service.
  * @param cacheLayer The cache layer implementation.
  * @param httpLayer The HTTP layer implementation.
  * @param oAuth1Service The OAuth1 service implementation.
@@ -42,7 +40,6 @@ import TwitterProvider._
  * @see https://dev.twitter.com/docs/entities#users
  */
 class TwitterProvider(
-  protected val authInfoService: AuthInfoService,
   cacheLayer: CacheLayer,
   httpLayer: HTTPLayer,
   oAuth1Service: OAuth1Service,
@@ -62,7 +59,7 @@ class TwitterProvider(
    * @param authInfo The auth info received from the provider.
    * @return On success the build social profile, otherwise a failure.
    */
-  protected def buildProfile(authInfo: OAuth1Info): Future[Try[SocialProfile]] = {
+  protected def buildProfile(authInfo: OAuth1Info): Future[Try[SocialProfile[OAuth1Info]]] = {
     httpLayer.url(API).sign(oAuth1Service.sign(authInfo)).get().map { response =>
       val json = response.json
       (json \ Errors \\ Code).headOption.map(_.as[Int]) match {
@@ -77,6 +74,7 @@ class TwitterProvider(
 
           Success(SocialProfile(
             loginInfo = LoginInfo(id, userId.toString),
+            authInfo = authInfo,
             fullName = name,
             avatarURL = avatarURL))
       }

--- a/app/com/mohiva/play/silhouette/core/providers/oauth1/XingProvider.scala
+++ b/app/com/mohiva/play/silhouette/core/providers/oauth1/XingProvider.scala
@@ -25,14 +25,12 @@ import scala.util.{ Success, Failure, Try }
 import com.mohiva.play.silhouette.core._
 import com.mohiva.play.silhouette.core.utils.{ HTTPLayer, CacheLayer }
 import com.mohiva.play.silhouette.core.providers._
-import com.mohiva.play.silhouette.core.services.AuthInfoService
 import com.mohiva.play.silhouette.core.exceptions.AuthenticationException
 import XingProvider._
 
 /**
  * A Xing OAuth1 Provider.
  *
- * @param authInfoService The auth info service.
  * @param cacheLayer The cache layer implementation.
  * @param httpLayer The HTTP layer implementation.
  * @param oAuth1Service The OAuth1 service implementation.
@@ -42,7 +40,6 @@ import XingProvider._
  * @see https://dev.xing.com/docs/error_responses
  */
 class XingProvider(
-  protected val authInfoService: AuthInfoService,
   cacheLayer: CacheLayer,
   httpLayer: HTTPLayer,
   oAuth1Service: OAuth1Service,
@@ -62,7 +59,7 @@ class XingProvider(
    * @param authInfo The auth info received from the provider.
    * @return On success the build social profile, otherwise a failure.
    */
-  protected def buildProfile(authInfo: OAuth1Info): Future[Try[SocialProfile]] = {
+  protected def buildProfile(authInfo: OAuth1Info): Future[Try[SocialProfile[OAuth1Info]]] = {
     httpLayer.url(API).sign(oAuth1Service.sign(authInfo)).get().map { response =>
       val json = response.json
       (json \ ErrorName).asOpt[String] match {
@@ -81,6 +78,7 @@ class XingProvider(
 
           Success(SocialProfile(
             loginInfo = LoginInfo(id, userID),
+            authInfo = authInfo,
             firstName = firstName,
             lastName = lastName,
             fullName = fullName,

--- a/app/com/mohiva/play/silhouette/core/providers/oauth2/FacebookProvider.scala
+++ b/app/com/mohiva/play/silhouette/core/providers/oauth2/FacebookProvider.scala
@@ -25,7 +25,6 @@ import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{ Success, Failure, Try }
 import com.mohiva.play.silhouette.core._
-import com.mohiva.play.silhouette.core.services.AuthInfoService
 import com.mohiva.play.silhouette.core.utils.{ HTTPLayer, CacheLayer }
 import com.mohiva.play.silhouette.core.providers.{ SocialProfile, OAuth2Info, OAuth2Settings, OAuth2Provider }
 import com.mohiva.play.silhouette.core.exceptions.AuthenticationException
@@ -35,7 +34,6 @@ import OAuth2Provider._
 /**
  * A Facebook OAuth2 Provider.
  *
- * @param authInfoService The auth info service.
  * @param cacheLayer The cache layer implementation.
  * @param httpLayer The HTTP layer implementation.
  * @param settings The provider settings.
@@ -45,7 +43,6 @@ import OAuth2Provider._
  * @see https://developers.facebook.com/docs/facebook-login/access-tokens
  */
 class FacebookProvider(
-  protected val authInfoService: AuthInfoService,
   cacheLayer: CacheLayer,
   httpLayer: HTTPLayer,
   settings: OAuth2Settings)
@@ -64,7 +61,7 @@ class FacebookProvider(
    * @param authInfo The auth info received from the provider.
    * @return On success the build social profile, otherwise a failure.
    */
-  protected def buildProfile(authInfo: OAuth2Info): Future[Try[SocialProfile]] = {
+  protected def buildProfile(authInfo: OAuth2Info): Future[Try[SocialProfile[OAuth2Info]]] = {
     httpLayer.url(API.format(authInfo.accessToken)).get().map { response =>
       val json = response.json
       (json \ Error).asOpt[JsObject] match {
@@ -84,6 +81,7 @@ class FacebookProvider(
 
           Success(SocialProfile(
             loginInfo = LoginInfo(id, userID),
+            authInfo = authInfo,
             firstName = firstName,
             lastName = lastName,
             fullName = fullName,

--- a/app/com/mohiva/play/silhouette/core/providers/oauth2/FoursquareProvider.scala
+++ b/app/com/mohiva/play/silhouette/core/providers/oauth2/FoursquareProvider.scala
@@ -23,7 +23,6 @@ import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{ Success, Failure, Try }
 import com.mohiva.play.silhouette.core._
-import com.mohiva.play.silhouette.core.services.AuthInfoService
 import com.mohiva.play.silhouette.core.utils.{ HTTPLayer, CacheLayer }
 import com.mohiva.play.silhouette.core.providers.{ SocialProfile, OAuth2Info, OAuth2Settings, OAuth2Provider }
 import com.mohiva.play.silhouette.core.exceptions.AuthenticationException
@@ -33,7 +32,6 @@ import OAuth2Provider._
 /**
  * A Foursquare OAuth2 provider.
  *
- * @param authInfoService The auth info service.
  * @param cacheLayer The cache layer implementation.
  * @param httpLayer The HTTP layer implementation.
  * @param settings The provider settings.
@@ -42,7 +40,6 @@ import OAuth2Provider._
  * @see https://developer.foursquare.com/docs/explore
  */
 class FoursquareProvider(
-  protected val authInfoService: AuthInfoService,
   cacheLayer: CacheLayer,
   httpLayer: HTTPLayer,
   settings: OAuth2Settings)
@@ -61,7 +58,7 @@ class FoursquareProvider(
    * @param authInfo The auth info received from the provider.
    * @return On success the build social profile, otherwise a failure.
    */
-  protected def buildProfile(authInfo: OAuth2Info): Future[Try[SocialProfile]] = {
+  protected def buildProfile(authInfo: OAuth2Info): Future[Try[SocialProfile[OAuth2Info]]] = {
     val version = settings.customProperties.getOrElse(APIVersion, DefaultAPIVersion)
     httpLayer.url(API.format(authInfo.accessToken, version)).get().map { response =>
       val json = response.json
@@ -88,6 +85,7 @@ class FoursquareProvider(
 
           Success(SocialProfile(
             loginInfo = LoginInfo(id, userID),
+            authInfo = authInfo,
             firstName = firstName,
             lastName = lastName,
             avatarURL = for (prefix <- avatarURLPart1; postfix <- avatarURLPart2) yield prefix + resolution + postfix,

--- a/app/com/mohiva/play/silhouette/core/providers/oauth2/GitHubProvider.scala
+++ b/app/com/mohiva/play/silhouette/core/providers/oauth2/GitHubProvider.scala
@@ -24,7 +24,6 @@ import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{ Success, Failure, Try }
 import com.mohiva.play.silhouette.core._
-import com.mohiva.play.silhouette.core.services.AuthInfoService
 import com.mohiva.play.silhouette.core.utils.{ HTTPLayer, CacheLayer }
 import com.mohiva.play.silhouette.core.providers.{ SocialProfile, OAuth2Info, OAuth2Settings, OAuth2Provider }
 import com.mohiva.play.silhouette.core.exceptions.AuthenticationException
@@ -33,14 +32,12 @@ import GitHubProvider._
 /**
  * A GitHub OAuth2 Provider.
  *
- * @param authInfoService The auth info service.
  * @param cacheLayer The cache layer implementation.
  * @param httpLayer The HTTP layer implementation.
  * @param settings The provider settings.
  * @see https://developer.github.com/v3/oauth/
  */
 class GitHubProvider(
-  protected val authInfoService: AuthInfoService,
   cacheLayer: CacheLayer,
   httpLayer: HTTPLayer,
   settings: OAuth2Settings)
@@ -69,7 +66,7 @@ class GitHubProvider(
    * @param authInfo The auth info received from the provider.
    * @return On success the build social profile, otherwise a failure.
    */
-  protected def buildProfile(authInfo: OAuth2Info): Future[Try[SocialProfile]] = {
+  protected def buildProfile(authInfo: OAuth2Info): Future[Try[SocialProfile[OAuth2Info]]] = {
     httpLayer.url(API.format(authInfo.accessToken)).get().map { response =>
       val json = response.json
       (json \ Message).asOpt[String] match {
@@ -85,6 +82,7 @@ class GitHubProvider(
 
           Success(SocialProfile(
             loginInfo = LoginInfo(id, userID.toString),
+            authInfo = authInfo,
             fullName = fullName,
             avatarURL = avatarUrl,
             email = email))

--- a/app/com/mohiva/play/silhouette/core/providers/oauth2/GoogleProvider.scala
+++ b/app/com/mohiva/play/silhouette/core/providers/oauth2/GoogleProvider.scala
@@ -24,7 +24,6 @@ import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{ Success, Failure, Try }
 import com.mohiva.play.silhouette.core._
-import com.mohiva.play.silhouette.core.services.AuthInfoService
 import com.mohiva.play.silhouette.core.utils.{ HTTPLayer, CacheLayer }
 import com.mohiva.play.silhouette.core.providers.{ SocialProfile, OAuth2Info, OAuth2Settings, OAuth2Provider }
 import com.mohiva.play.silhouette.core.exceptions.AuthenticationException
@@ -34,7 +33,6 @@ import OAuth2Provider._
 /**
  * A Google OAuth2 Provider.
  *
- * @param authInfoService The auth info service.
  * @param cacheLayer The cache layer implementation.
  * @param httpLayer The HTTP layer implementation.
  * @param settings The provider settings.
@@ -44,7 +42,6 @@ import OAuth2Provider._
  * @see https://developers.google.com/+/api/latest/people
  */
 class GoogleProvider(
-  protected val authInfoService: AuthInfoService,
   cacheLayer: CacheLayer,
   httpLayer: HTTPLayer,
   settings: OAuth2Settings)
@@ -63,7 +60,7 @@ class GoogleProvider(
    * @param authInfo The auth info received from the provider.
    * @return On success the build social profile, otherwise a failure.
    */
-  protected def buildProfile(authInfo: OAuth2Info): Future[Try[SocialProfile]] = {
+  protected def buildProfile(authInfo: OAuth2Info): Future[Try[SocialProfile[OAuth2Info]]] = {
     httpLayer.url(API.format(authInfo.accessToken)).get().map { response =>
       val json = response.json
       (json \ Error).asOpt[JsObject] match {
@@ -89,6 +86,7 @@ class GoogleProvider(
 
           Success(SocialProfile(
             loginInfo = LoginInfo(id, userID),
+            authInfo = authInfo,
             firstName = firstName,
             lastName = lastName,
             fullName = fullName,

--- a/app/com/mohiva/play/silhouette/core/providers/oauth2/InstagramProvider.scala
+++ b/app/com/mohiva/play/silhouette/core/providers/oauth2/InstagramProvider.scala
@@ -23,7 +23,6 @@ import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{ Success, Failure, Try }
 import com.mohiva.play.silhouette.core._
-import com.mohiva.play.silhouette.core.services.AuthInfoService
 import com.mohiva.play.silhouette.core.utils.{ HTTPLayer, CacheLayer }
 import com.mohiva.play.silhouette.core.providers.{ SocialProfile, OAuth2Info, OAuth2Settings, OAuth2Provider }
 import com.mohiva.play.silhouette.core.exceptions.AuthenticationException
@@ -33,7 +32,6 @@ import OAuth2Provider._
 /**
  * An Instagram OAuth2 provider.
  *
- * @param authInfoService The auth info service.
  * @param cacheLayer The cache layer implementation.
  * @param httpLayer The HTTP layer implementation.
  * @param settings The provider settings.
@@ -42,7 +40,6 @@ import OAuth2Provider._
  *
  */
 class InstagramProvider(
-  protected val authInfoService: AuthInfoService,
   cacheLayer: CacheLayer,
   httpLayer: HTTPLayer,
   settings: OAuth2Settings)
@@ -61,7 +58,7 @@ class InstagramProvider(
    * @param authInfo The auth info received from the provider.
    * @return On success the build social profile, otherwise a failure.
    */
-  protected def buildProfile(authInfo: OAuth2Info): Future[Try[SocialProfile]] = {
+  protected def buildProfile(authInfo: OAuth2Info): Future[Try[SocialProfile[OAuth2Info]]] = {
     httpLayer.url(API.format(authInfo.accessToken)).get().map { response =>
       val json = response.json
       (json \ Meta \ Code).asOpt[Int] match {
@@ -77,6 +74,7 @@ class InstagramProvider(
 
           Success(SocialProfile(
             loginInfo = LoginInfo(id, userID),
+            authInfo = authInfo,
             fullName = fullName,
             avatarURL = avatarURL))
       }

--- a/app/com/mohiva/play/silhouette/core/providers/oauth2/LinkedInProvider.scala
+++ b/app/com/mohiva/play/silhouette/core/providers/oauth2/LinkedInProvider.scala
@@ -24,19 +24,16 @@ import scala.concurrent.Future
 import com.mohiva.play.silhouette.core.utils.{ HTTPLayer, CacheLayer }
 import com.mohiva.play.silhouette.core.providers.{ SocialProfile, OAuth2Info, OAuth2Settings, OAuth2Provider }
 import com.mohiva.play.silhouette.core.providers.helpers.LinkedInProfile._
-import com.mohiva.play.silhouette.core.services.AuthInfoService
 import LinkedInProvider._
 
 /**
  * A LinkedIn OAuth2 Provider.
  *
- * @param authInfoService The auth info service.
  * @param cacheLayer The cache layer implementation.
  * @param httpLayer The HTTP layer implementation.
  * @param settings The provider settings.
  */
 class LinkedInProvider(
-  protected val authInfoService: AuthInfoService,
   cacheLayer: CacheLayer,
   httpLayer: HTTPLayer,
   settings: OAuth2Settings)
@@ -55,8 +52,8 @@ class LinkedInProvider(
    * @param authInfo The auth info received from the provider.
    * @return On success the build social profile, otherwise a failure.
    */
-  protected def buildProfile(authInfo: OAuth2Info): Future[Try[SocialProfile]] = {
-    build(httpLayer.url(API.format(authInfo.accessToken)).get())
+  protected def buildProfile(authInfo: OAuth2Info): Future[Try[SocialProfile[OAuth2Info]]] = {
+    build(httpLayer.url(API.format(authInfo.accessToken)).get(), authInfo)
   }
 }
 

--- a/app/com/mohiva/play/silhouette/core/providers/oauth2/VKProvider.scala
+++ b/app/com/mohiva/play/silhouette/core/providers/oauth2/VKProvider.scala
@@ -24,7 +24,6 @@ import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{ Success, Failure, Try }
 import com.mohiva.play.silhouette.core._
-import com.mohiva.play.silhouette.core.services.AuthInfoService
 import com.mohiva.play.silhouette.core.utils.{ HTTPLayer, CacheLayer }
 import com.mohiva.play.silhouette.core.providers.{ SocialProfile, OAuth2Info, OAuth2Settings, OAuth2Provider }
 import com.mohiva.play.silhouette.core.exceptions.AuthenticationException
@@ -34,7 +33,6 @@ import OAuth2Provider._
 /**
  * A Vk OAuth 2 provider.
  *
- * @param authInfoService The auth info service.
  * @param cacheLayer The cache layer implementation.
  * @param httpLayer The HTTP layer implementation.
  * @param settings The provider settings.
@@ -43,7 +41,6 @@ import OAuth2Provider._
  * @see http://vk.com/pages.php?o=-1&p=getProfiles
  */
 class VKProvider(
-  protected val authInfoService: AuthInfoService,
   cacheLayer: CacheLayer,
   httpLayer: HTTPLayer,
   settings: OAuth2Settings)
@@ -62,7 +59,7 @@ class VKProvider(
    * @param authInfo The auth info received from the provider.
    * @return On success the build social profile, otherwise a failure.
    */
-  protected def buildProfile(authInfo: OAuth2Info): Future[Try[SocialProfile]] = {
+  protected def buildProfile(authInfo: OAuth2Info): Future[Try[SocialProfile[OAuth2Info]]] = {
     httpLayer.url(API.format(authInfo.accessToken)).get().map { response =>
       val json = response.json
       (json \ Error).asOpt[JsObject] match {
@@ -80,6 +77,7 @@ class VKProvider(
 
           Success(SocialProfile(
             loginInfo = LoginInfo(id, userId.toString),
+            authInfo = authInfo,
             firstName = firstName,
             lastName = lastName,
             avatarURL = avatarURL))

--- a/test/com/mohiva/play/silhouette/core/providers/OAuth1ProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/providers/OAuth1ProviderSpec.scala
@@ -23,7 +23,6 @@ import org.specs2.specification.Scope
 import scala.util.{ Success, Failure }
 import scala.concurrent.Future
 import com.mohiva.play.silhouette.core.utils.{ CacheLayer, HTTPLayer }
-import com.mohiva.play.silhouette.core.services.AuthInfoService
 import com.mohiva.play.silhouette.core.exceptions._
 import OAuth1Provider._
 
@@ -32,7 +31,7 @@ import OAuth1Provider._
  *
  * These tests will be additionally executed before every OAuth1 provider spec.
  */
-abstract class OAuth1ProviderSpec extends ProviderSpec {
+abstract class OAuth1ProviderSpec extends ProviderSpec[OAuth1Info] {
   isolated
 
   "The authenticate method" should {
@@ -120,11 +119,6 @@ abstract class OAuth1ProviderSpec extends ProviderSpec {
  * Context for the OAuth1ProviderSpec.
  */
 trait OAuth1ProviderSpecContext extends Scope with Mockito with ThrownExpectations {
-
-  /**
-   * The auth info service mock.
-   */
-  lazy val authInfoService: AuthInfoService = mock[AuthInfoService]
 
   /**
    * The cache layer mock.

--- a/test/com/mohiva/play/silhouette/core/providers/OAuth2ProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/providers/OAuth2ProviderSpec.scala
@@ -25,7 +25,6 @@ import org.specs2.matcher.ThrownExpectations
 import org.specs2.mock.Mockito
 import org.specs2.specification.Scope
 import com.mohiva.play.silhouette.core.utils.{ CacheLayer, HTTPLayer }
-import com.mohiva.play.silhouette.core.services.AuthInfoService
 import com.mohiva.play.silhouette.core.exceptions._
 import OAuth2Provider._
 
@@ -34,7 +33,7 @@ import OAuth2Provider._
  *
  * These tests will be additionally executed before every OAuth2 provider spec.
  */
-abstract class OAuth2ProviderSpec extends ProviderSpec {
+abstract class OAuth2ProviderSpec extends ProviderSpec[OAuth2Info] {
   isolated
 
   "The authenticate method" should {
@@ -174,11 +173,6 @@ abstract class OAuth2ProviderSpec extends ProviderSpec {
  * Context for the OAuth2ProviderSpec.
  */
 trait OAuth2ProviderSpecContext extends Scope with Mockito with ThrownExpectations {
-
-  /**
-   * The auth info service mock.
-   */
-  lazy val authInfoService: AuthInfoService = mock[AuthInfoService]
 
   /**
    * The cache layer mock.

--- a/test/com/mohiva/play/silhouette/core/providers/ProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/providers/ProviderSpec.scala
@@ -22,18 +22,19 @@ import play.api.mvc.SimpleResult
 import play.api.test.PlaySpecification
 import org.specs2.matcher.{ MatchResult, JsonMatchers }
 import org.specs2.mock.Mockito
+import com.mohiva.play.silhouette.core.services.AuthInfo
 
 /**
  * Test case for the [[com.mohiva.play.silhouette.core.providers.OAuth1Provider]] class.
  *
  * These tests will be additionally executed before every OAuth1 provider spec.
  */
-abstract class ProviderSpec extends PlaySpecification with Mockito with JsonMatchers {
+abstract class ProviderSpec[A <: AuthInfo] extends PlaySpecification with Mockito with JsonMatchers {
 
   /**
    * The provider result.
    */
-  type ProviderResult = Future[Try[Either[SimpleResult, SocialProfile]]]
+  type ProviderResult = Future[Try[Either[SimpleResult, SocialProfile[A]]]]
 
   /**
    * Applies a matcher on a simple result.
@@ -43,7 +44,7 @@ abstract class ProviderSpec extends PlaySpecification with Mockito with JsonMatc
    * @return A specs2 match result.
    */
   def result(providerResult: ProviderResult)(b: Future[SimpleResult] => MatchResult[_]) = {
-    await(providerResult) must beSuccessfulTry[Either[SimpleResult, SocialProfile]].like {
+    await(providerResult) must beSuccessfulTry[Either[SimpleResult, SocialProfile[A]]].like {
       case e => e must beLeft[SimpleResult].like {
         case simpleResult => b(Future.successful(simpleResult))
       }
@@ -57,9 +58,9 @@ abstract class ProviderSpec extends PlaySpecification with Mockito with JsonMatc
    * @param b The matcher block to apply.
    * @return A specs2 match result.
    */
-  def profile(providerResult: ProviderResult)(b: SocialProfile => MatchResult[_]) = {
-    await(providerResult) must beSuccessfulTry[Either[SimpleResult, SocialProfile]].like {
-      case e => e must beRight[SocialProfile].like {
+  def profile(providerResult: ProviderResult)(b: SocialProfile[A] => MatchResult[_]) = {
+    await(providerResult) must beSuccessfulTry[Either[SimpleResult, SocialProfile[A]]].like {
+      case e => e must beRight[SocialProfile[A]].like {
         case socialProfile => b(socialProfile)
       }
     }

--- a/test/com/mohiva/play/silhouette/core/providers/oauth1/TwitterProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/providers/oauth1/TwitterProviderSpec.scala
@@ -92,28 +92,13 @@ class TwitterProviderSpec extends OAuth1ProviderSpec {
         case p =>
           p must be equalTo new SocialProfile(
             loginInfo = LoginInfo(provider.id, "6253282"),
+            authInfo = oAuthInfo,
             fullName = Some("Apollonia Vanova"),
             avatarURL = Some("https://pbs.twimg.com/profile_images/1209905677/appolonia_.jpg")
           )
       }
 
       there was one(cacheLayer).remove(cacheID)
-    }
-
-    "store the auth info if the authentication was successful" in new WithApplication with Context {
-      val cacheID = UUID.randomUUID().toString
-      val requestHolder = mock[WS.WSRequestHolder]
-      val response = mock[Response]
-      implicit val req = FakeRequest(GET, "?" + OAuthVerifier + "=my.verifier").withSession(CacheKey -> cacheID)
-      cacheLayer.get[OAuth1Info](cacheID) returns Future.successful(Some(oAuthInfo))
-      oAuthService.retrieveAccessToken(oAuthInfo, "my.verifier") returns Future.successful(Success(oAuthInfo))
-      requestHolder.sign(any) returns requestHolder
-      requestHolder.get() returns Future.successful(response)
-      response.json returns Helper.loadJson("providers/oauth1/twitter.success.json")
-      httpLayer.url(API) returns requestHolder
-
-      await(provider.authenticate())
-      there was one(authInfoService).save[OAuth1Info](LoginInfo(provider.id, "6253282"), oAuthInfo)
     }
   }
 
@@ -143,6 +128,6 @@ class TwitterProviderSpec extends OAuth1ProviderSpec {
     /**
      * The provider to test.
      */
-    lazy val provider = new TwitterProvider(authInfoService, cacheLayer, httpLayer, oAuthService, oAuthSettings)
+    lazy val provider = new TwitterProvider(cacheLayer, httpLayer, oAuthService, oAuthSettings)
   }
 }

--- a/test/com/mohiva/play/silhouette/core/providers/oauth1/XingProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/providers/oauth1/XingProviderSpec.scala
@@ -92,6 +92,7 @@ class XingProviderSpec extends OAuth1ProviderSpec {
         case p =>
           p must be equalTo new SocialProfile(
             loginInfo = LoginInfo(provider.id, "1235468792"),
+            authInfo = oAuthInfo,
             firstName = Some("Apollonia"),
             lastName = Some("Vanova"),
             fullName = Some("Apollonia Vanova"),
@@ -101,22 +102,6 @@ class XingProviderSpec extends OAuth1ProviderSpec {
       }
 
       there was one(cacheLayer).remove(cacheID)
-    }
-
-    "store the auth info if the authentication was successful" in new WithApplication with Context {
-      val cacheID = UUID.randomUUID().toString
-      val requestHolder = mock[WS.WSRequestHolder]
-      val response = mock[Response]
-      implicit val req = FakeRequest(GET, "?" + OAuthVerifier + "=my.verifier").withSession(CacheKey -> cacheID)
-      cacheLayer.get[OAuth1Info](cacheID) returns Future.successful(Some(oAuthInfo))
-      oAuthService.retrieveAccessToken(oAuthInfo, "my.verifier") returns Future.successful(Success(oAuthInfo))
-      requestHolder.sign(any) returns requestHolder
-      requestHolder.get() returns Future.successful(response)
-      response.json returns Helper.loadJson("providers/oauth1/xing.success.json")
-      httpLayer.url(API) returns requestHolder
-
-      await(provider.authenticate())
-      there was one(authInfoService).save[OAuth1Info](LoginInfo(provider.id, "1235468792"), oAuthInfo)
     }
   }
 
@@ -146,6 +131,6 @@ class XingProviderSpec extends OAuth1ProviderSpec {
     /**
      * The provider to test.
      */
-    lazy val provider = new XingProvider(authInfoService, cacheLayer, httpLayer, oAuthService, oAuthSettings)
+    lazy val provider = new XingProvider(cacheLayer, httpLayer, oAuthService, oAuthSettings)
   }
 }

--- a/test/com/mohiva/play/silhouette/core/providers/oauth2/FoursquareProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/providers/oauth2/FoursquareProviderSpec.scala
@@ -110,6 +110,7 @@ class FoursquareProviderSpec extends OAuth2ProviderSpec {
         case p =>
           p must be equalTo new SocialProfile(
             loginInfo = LoginInfo(provider.id, "13221052"),
+            authInfo = oAuthInfo.as[OAuth2Info],
             firstName = Some("Apollonia"),
             lastName = Some("Vanova"),
             email = Some("apollonia.vanova@watchmen.com"),
@@ -136,6 +137,7 @@ class FoursquareProviderSpec extends OAuth2ProviderSpec {
         case p =>
           p must be equalTo new SocialProfile(
             loginInfo = LoginInfo(provider.id, "13221052"),
+            authInfo = oAuthInfo.as[OAuth2Info],
             firstName = Some("Apollonia"),
             lastName = Some("Vanova"),
             email = Some("apollonia.vanova@watchmen.com"),
@@ -152,7 +154,6 @@ class FoursquareProviderSpec extends OAuth2ProviderSpec {
       val response = mock[Response]
       implicit val req = FakeRequest(GET, "?" + Code + "=my.code&" + State + "=" + state).withSession(CacheKey -> cacheID)
       override lazy val provider = new FoursquareProvider(
-        authInfoService,
         cacheLayer,
         httpLayer,
         oAuthSettings.copy(customProperties = customProperties)
@@ -170,6 +171,7 @@ class FoursquareProviderSpec extends OAuth2ProviderSpec {
         case p =>
           p must be equalTo new SocialProfile(
             loginInfo = LoginInfo(provider.id, "13221052"),
+            authInfo = oAuthInfo.as[OAuth2Info],
             firstName = Some("Apollonia"),
             lastName = Some("Vanova"),
             email = Some("apollonia.vanova@watchmen.com"),
@@ -186,7 +188,6 @@ class FoursquareProviderSpec extends OAuth2ProviderSpec {
       val response = mock[Response]
       implicit val req = FakeRequest(GET, "?" + Code + "=my.code&" + State + "=" + state).withSession(CacheKey -> cacheID)
       override lazy val provider = new FoursquareProvider(
-        authInfoService,
         cacheLayer,
         httpLayer,
         oAuthSettings.copy(customProperties = customProperties)
@@ -204,6 +205,7 @@ class FoursquareProviderSpec extends OAuth2ProviderSpec {
         case p =>
           p must be equalTo new SocialProfile(
             loginInfo = LoginInfo(provider.id, "13221052"),
+            authInfo = oAuthInfo.as[OAuth2Info],
             firstName = Some("Apollonia"),
             lastName = Some("Vanova"),
             email = Some("apollonia.vanova@watchmen.com"),
@@ -238,6 +240,6 @@ class FoursquareProviderSpec extends OAuth2ProviderSpec {
     /**
      * The provider to test.
      */
-    lazy val provider = new FoursquareProvider(authInfoService, cacheLayer, httpLayer, oAuthSettings)
+    lazy val provider = new FoursquareProvider(cacheLayer, httpLayer, oAuthSettings)
   }
 }

--- a/test/com/mohiva/play/silhouette/core/providers/oauth2/GitHubProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/providers/oauth2/GitHubProviderSpec.scala
@@ -110,6 +110,7 @@ class GitHubProviderSpec extends OAuth2ProviderSpec {
         case p =>
           p must be equalTo new SocialProfile(
             loginInfo = LoginInfo(provider.id, "1"),
+            authInfo = oAuthInfo.as[OAuth2Info],
             fullName = Some("Apollonia Vanova"),
             email = Some("apollonia.vanova@watchmen.com"),
             avatarURL = Some("https://github.com/images/error/apollonia_vanova.gif")
@@ -154,6 +155,6 @@ class GitHubProviderSpec extends OAuth2ProviderSpec {
     /**
      * The provider to test.
      */
-    lazy val provider = new GitHubProvider(authInfoService, cacheLayer, httpLayer, oAuthSettings)
+    lazy val provider = new GitHubProvider(cacheLayer, httpLayer, oAuthSettings)
   }
 }

--- a/test/com/mohiva/play/silhouette/core/providers/oauth2/GoogleProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/providers/oauth2/GoogleProviderSpec.scala
@@ -109,6 +109,7 @@ class GoogleProviderSpec extends OAuth2ProviderSpec {
         case p =>
           p must be equalTo new SocialProfile(
             loginInfo = LoginInfo(provider.id, "109476598527568979481"),
+            authInfo = oAuthInfo.as[OAuth2Info],
             firstName = Some("Apollonia"),
             lastName = Some("Vanova"),
             fullName = Some("Apollonia Vanova"),
@@ -136,6 +137,7 @@ class GoogleProviderSpec extends OAuth2ProviderSpec {
         case p =>
           p must be equalTo new SocialProfile(
             loginInfo = LoginInfo(provider.id, "109476598527568979481"),
+            authInfo = oAuthInfo.as[OAuth2Info],
             firstName = Some("Apollonia"),
             lastName = Some("Vanova"),
             fullName = Some("Apollonia Vanova"),
@@ -172,6 +174,6 @@ class GoogleProviderSpec extends OAuth2ProviderSpec {
     /**
      * The provider to test.
      */
-    lazy val provider = new GoogleProvider(authInfoService, cacheLayer, httpLayer, oAuthSettings)
+    lazy val provider = new GoogleProvider(cacheLayer, httpLayer, oAuthSettings)
   }
 }

--- a/test/com/mohiva/play/silhouette/core/providers/oauth2/InstagramProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/providers/oauth2/InstagramProviderSpec.scala
@@ -110,6 +110,7 @@ class InstagramProviderSpec extends OAuth2ProviderSpec {
         case p =>
           p must be equalTo new SocialProfile(
             loginInfo = LoginInfo(provider.id, "1574083"),
+            authInfo = oAuthInfo.as[OAuth2Info],
             fullName = Some("Apollonia Vanova"),
             avatarURL = Some("http://distillery.s3.amazonaws.com/profiles/profile_1574083_75sq_1295469061.jpg")
           )
@@ -150,6 +151,6 @@ class InstagramProviderSpec extends OAuth2ProviderSpec {
     /**
      * The provider to test.
      */
-    lazy val provider = new InstagramProvider(authInfoService, cacheLayer, httpLayer, oAuthSettings)
+    lazy val provider = new InstagramProvider(cacheLayer, httpLayer, oAuthSettings)
   }
 }

--- a/test/com/mohiva/play/silhouette/core/providers/oauth2/LinkedInProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/providers/oauth2/LinkedInProviderSpec.scala
@@ -113,6 +113,7 @@ class LinkedInProviderSpec extends OAuth2ProviderSpec {
         case p =>
           p must be equalTo new SocialProfile(
             loginInfo = LoginInfo(provider.id, "NhZXBl_O6f"),
+            authInfo = oAuthInfo.as[OAuth2Info],
             firstName = Some("Apollonia"),
             lastName = Some("Vanova"),
             fullName = Some("Apollonia Vanova"),
@@ -156,6 +157,6 @@ class LinkedInProviderSpec extends OAuth2ProviderSpec {
     /**
      * The provider to test.
      */
-    lazy val provider = new LinkedInProvider(authInfoService, cacheLayer, httpLayer, oAuthSettings)
+    lazy val provider = new LinkedInProvider(cacheLayer, httpLayer, oAuthSettings)
   }
 }

--- a/test/com/mohiva/play/silhouette/core/providers/oauth2/VKProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/providers/oauth2/VKProviderSpec.scala
@@ -109,6 +109,7 @@ class VKProviderSpec extends OAuth2ProviderSpec {
         case p =>
           p must be equalTo new SocialProfile(
             loginInfo = LoginInfo(provider.id, "66748"),
+            authInfo = oAuthInfo.as[OAuth2Info],
             firstName = Some("Apollonia"),
             lastName = Some("Vanova"),
             avatarURL = Some("http://vk.com/images/camera_b.gif")
@@ -150,6 +151,6 @@ class VKProviderSpec extends OAuth2ProviderSpec {
     /**
      * The provider to test.
      */
-    lazy val provider = new VKProvider(authInfoService, cacheLayer, httpLayer, oAuthSettings)
+    lazy val provider = new VKProvider(cacheLayer, httpLayer, oAuthSettings)
   }
 }


### PR DESCRIPTION
In the current implementation we do not return the `AuthInfo` from the providers, instead the providers stores the information after a successful authentication. I think this is a problem if a user uses a relational database with referential integrity to store the data, because the authentication information gets stored before the user will be stored. Maybe we should also return the `AuthInfo` from the provider and then delegate the storage of the data to the user.

What do you think @fernandoacorreia?
