### PR TITLE
Try to use the format of the original access token returned from OAuth2 providers for unit testing

### DIFF
--- a/test/com/mohiva/play/silhouette/core/providers/oauth2/FoursquareProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/providers/oauth2/FoursquareProviderSpec.scala
@@ -238,6 +238,13 @@ class FoursquareProviderSpec extends OAuth2ProviderSpec {
       clientSecret = "my.client.secret")
 
     /**
+     * The OAuth2 info returned by Foursquare.
+     *
+     * @see https://developer.foursquare.com/overview/auth
+     */
+    override lazy val oAuthInfo = Helper.loadJson("providers/oauth2/foursquare.access.token.json")
+
+    /**
      * The provider to test.
      */
     lazy val provider = new FoursquareProvider(cacheLayer, httpLayer, oAuthSettings)

--- a/test/com/mohiva/play/silhouette/core/providers/oauth2/GitHubProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/providers/oauth2/GitHubProviderSpec.scala
@@ -143,14 +143,11 @@ class GitHubProviderSpec extends OAuth2ProviderSpec {
       scope = Some("repo,gist"))
 
     /**
-     * The OAuth2 info returned by GutHub
+     * The OAuth2 info returned by GitHub.
      *
-     * @see https://developer.github.com/v3/oauth/#response
+     * @see http://vk.com/dev/auth_sites
      */
-    override lazy val oAuthInfo: JsValue = Json.obj(
-      "access_token" -> "my.access.token",
-      "scope" -> "repo,gist",
-      "token_type" -> "bearer")
+    override lazy val oAuthInfo = Helper.loadJson("providers/oauth2/github.access.token.json")
 
     /**
      * The provider to test.

--- a/test/com/mohiva/play/silhouette/core/providers/oauth2/GoogleProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/providers/oauth2/GoogleProviderSpec.scala
@@ -172,6 +172,13 @@ class GoogleProviderSpec extends OAuth2ProviderSpec {
       scope = Some("profile,email"))
 
     /**
+     * The OAuth2 info returned by Google.
+     *
+     * @see https://developers.google.com/accounts/docs/OAuth2Login#sendauthrequest
+     */
+    override lazy val oAuthInfo = Helper.loadJson("providers/oauth2/google.access.token.json")
+
+    /**
      * The provider to test.
      */
     lazy val provider = new GoogleProvider(cacheLayer, httpLayer, oAuthSettings)

--- a/test/com/mohiva/play/silhouette/core/providers/oauth2/InstagramProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/providers/oauth2/InstagramProviderSpec.scala
@@ -142,7 +142,7 @@ class InstagramProviderSpec extends OAuth2ProviderSpec {
       scope = Some("basic"))
 
     /**
-     * The OAuth2 info returned by GutHub
+     * The OAuth2 info returned by Instagram.
      *
      * @see http://instagram.com/developer/authentication/
      */

--- a/test/com/mohiva/play/silhouette/core/providers/oauth2/LinkedInProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/providers/oauth2/LinkedInProviderSpec.scala
@@ -148,7 +148,7 @@ class LinkedInProviderSpec extends OAuth2ProviderSpec {
       scope = None)
 
     /**
-     * The OAuth2 info returned by GutHub
+     * The OAuth2 info returned by LinkedIn.
      *
      * @see https://developer.linkedin.com/documents/authentication
      */

--- a/test/com/mohiva/play/silhouette/core/providers/oauth2/VKProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/providers/oauth2/VKProviderSpec.scala
@@ -142,7 +142,7 @@ class VKProviderSpec extends OAuth2ProviderSpec {
       scope = None)
 
     /**
-     * The OAuth2 info returned by GutHub
+     * The OAuth2 info returned by VK.
      *
      * @see http://vk.com/dev/auth_sites
      */

--- a/test/resources/providers/oauth2/foursquare.access.token.json
+++ b/test/resources/providers/oauth2/foursquare.access.token.json
@@ -1,0 +1,3 @@
+{
+    "access_token": "my.access.token"
+}

--- a/test/resources/providers/oauth2/github.access.token.json
+++ b/test/resources/providers/oauth2/github.access.token.json
@@ -1,0 +1,5 @@
+{
+    "access_token": "my.access.token",
+    "scope": "repo,gist",
+    "token_type": "bearer"
+}

--- a/test/resources/providers/oauth2/google.access.token.json
+++ b/test/resources/providers/oauth2/google.access.token.json
@@ -1,0 +1,5 @@
+{
+    "access_token": "my.access.token",
+    "expires_in": 5184000,
+    "token_type": "Bearer"
+}


### PR DESCRIPTION
Some providers document the original format of an access token. We should use this format for unit testing.
