### PR TITLE
Log query string if authentication on social provider is denied

### DIFF
--- a/app/com/mohiva/play/silhouette/core/providers/OAuth1Provider.scala
+++ b/app/com/mohiva/play/silhouette/core/providers/OAuth1Provider.scala
@@ -54,6 +54,7 @@ abstract class OAuth1Provider(
    * @return Either a Result or the auth info from the provider.
    */
   protected def doAuth()(implicit request: RequestHeader): Future[Try[Either[SimpleResult, OAuth1Info]]] = {
+    logger.debug("[Silhouette][%s] Query string: %s".format(id, request.rawQueryString))
     request.queryString.get(Denied) match {
       case Some(_) => Future.failed(new AccessDeniedException(AuthorizationError.format(id, Denied)))
       case None => request.queryString.get(OAuthVerifier) match {

--- a/app/com/mohiva/play/silhouette/core/providers/OAuth2Provider.scala
+++ b/app/com/mohiva/play/silhouette/core/providers/OAuth2Provider.scala
@@ -90,6 +90,7 @@ abstract class OAuth2Provider(
    * @return Either a Result or the auth info from the provider.
    */
   protected def doAuth()(implicit request: RequestHeader): Future[Try[Either[SimpleResult, OAuth2Info]]] = {
+    logger.debug("[Silhouette][%s] Query string: %s".format(id, request.rawQueryString))
     request.queryString.get(Error).flatMap(_.headOption).map {
       case e @ AccessDenied => new AccessDeniedException(AuthorizationError.format(id, e))
       case e => new AuthenticationException(AuthorizationError.format(id, e))


### PR DESCRIPTION
To get more information about a denied authentication, we should also log the query string because it may contain additional information about the reason of the rejection.

Before we do that we must check the following things:
- Check if no sensitive data is available in the URL
