### PR TITLE
Use Future error handling instead of the additional Try type

### DIFF
--- a/app/com/mohiva/play/silhouette/contrib/services/PlayOAuth1Service.scala
+++ b/app/com/mohiva/play/silhouette/contrib/services/PlayOAuth1Service.scala
@@ -21,7 +21,6 @@ package com.mohiva.play.silhouette.contrib.services
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.util.{ Success, Failure, Try }
 import play.api.libs.oauth._
 import play.api.libs.ws.SignatureCalculator
 import play.api.libs.oauth.ConsumerKey
@@ -51,12 +50,12 @@ class PlayOAuth1Service(service: OAuth, settings: OAuth1Settings) extends OAuth1
    * Retrieves the request info and secret.
    *
    * @param callbackURL The URL where the provider should redirect to (usually a URL on the current app).
-   * @return A Success(OAuth1Info) in case of success, Failure(Exception) otherwise.
+   * @return A OAuth1Info in case of success, Exception otherwise.
    */
-  def retrieveRequestToken(callbackURL: String): Future[Try[OAuth1Info]] = {
+  def retrieveRequestToken(callbackURL: String): Future[OAuth1Info] = {
     Future(service.retrieveRequestToken(settings.callbackURL)).map(_.fold(
-      exception => Failure(exception),
-      token => Success(OAuth1Info(token.token, token.secret))))
+      e => throw e,
+      t => OAuth1Info(t.token, t.secret)))
   }
 
   /**
@@ -64,12 +63,12 @@ class PlayOAuth1Service(service: OAuth, settings: OAuth1Settings) extends OAuth1
    *
    * @param oAuthInfo The info/secret pair obtained from a previous call.
    * @param verifier A string you got through your user, with redirection.
-   * @return A Success(OAuth1Info) in case of success, Failure(Exception) otherwise.
+   * @return A OAuth1Info in case of success, Exception otherwise.
    */
-  def retrieveAccessToken(oAuthInfo: OAuth1Info, verifier: String): Future[Try[OAuth1Info]] = {
+  def retrieveAccessToken(oAuthInfo: OAuth1Info, verifier: String): Future[OAuth1Info] = {
     Future(service.retrieveAccessToken(RequestToken(oAuthInfo.token, oAuthInfo.secret), verifier)).map(_.fold(
-      exception => Failure(exception),
-      token => Success(OAuth1Info(token.token, token.secret))))
+      e => throw e,
+      t => OAuth1Info(t.token, t.secret)))
   }
 
   /**

--- a/app/com/mohiva/play/silhouette/core/providers/oauth1/LinkedInProvider.scala
+++ b/app/com/mohiva/play/silhouette/core/providers/oauth1/LinkedInProvider.scala
@@ -19,7 +19,6 @@
  */
 package com.mohiva.play.silhouette.core.providers.oauth1
 
-import scala.util.Try
 import scala.concurrent.Future
 import com.mohiva.play.silhouette.core.utils.{ HTTPLayer, CacheLayer }
 import com.mohiva.play.silhouette.core.providers._
@@ -54,7 +53,7 @@ class LinkedInProvider(
    * @param authInfo The auth info received from the provider.
    * @return On success the build social profile, otherwise a failure.
    */
-  protected def buildProfile(authInfo: OAuth1Info): Future[Try[SocialProfile[OAuth1Info]]] = {
+  protected def buildProfile(authInfo: OAuth1Info): Future[SocialProfile[OAuth1Info]] = {
     build(httpLayer.url(API).sign(oAuth1Service.sign(authInfo)).get(), authInfo)
   }
 }

--- a/app/com/mohiva/play/silhouette/core/providers/oauth2/GitHubProvider.scala
+++ b/app/com/mohiva/play/silhouette/core/providers/oauth2/GitHubProvider.scala
@@ -22,7 +22,6 @@ package com.mohiva.play.silhouette.core.providers.oauth2
 import play.api.http.HeaderNames
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.util.{ Success, Failure, Try }
 import com.mohiva.play.silhouette.core._
 import com.mohiva.play.silhouette.core.utils.{ HTTPLayer, CacheLayer }
 import com.mohiva.play.silhouette.core.providers.{ SocialProfile, OAuth2Info, OAuth2Settings, OAuth2Provider }
@@ -66,29 +65,30 @@ class GitHubProvider(
    * @param authInfo The auth info received from the provider.
    * @return On success the build social profile, otherwise a failure.
    */
-  protected def buildProfile(authInfo: OAuth2Info): Future[Try[SocialProfile[OAuth2Info]]] = {
+  protected def buildProfile(authInfo: OAuth2Info): Future[SocialProfile[OAuth2Info]] = {
     httpLayer.url(API.format(authInfo.accessToken)).get().map { response =>
       val json = response.json
       (json \ Message).asOpt[String] match {
         case Some(msg) =>
           val docURL = (json \ DocURL).asOpt[String]
 
-          Failure(new AuthenticationException(SpecifiedProfileError.format(id, msg, docURL)))
+          throw new AuthenticationException(SpecifiedProfileError.format(id, msg, docURL))
         case _ =>
           val userID = (json \ ID).as[Long]
           val fullName = (json \ Name).asOpt[String]
           val avatarUrl = (json \ AvatarURL).asOpt[String]
           val email = (json \ Email).asOpt[String].filter(!_.isEmpty)
 
-          Success(SocialProfile(
+          SocialProfile(
             loginInfo = LoginInfo(id, userID.toString),
             authInfo = authInfo,
             fullName = fullName,
             avatarURL = avatarUrl,
-            email = email))
+            email = email)
       }
     }.recover {
-      case e => Failure(new AuthenticationException(UnspecifiedProfileError.format(id), e))
+      case e if !e.isInstanceOf[AuthenticationException] =>
+        throw new AuthenticationException(UnspecifiedProfileError.format(id), e)
     }
   }
 }

--- a/app/com/mohiva/play/silhouette/core/providers/oauth2/GoogleProvider.scala
+++ b/app/com/mohiva/play/silhouette/core/providers/oauth2/GoogleProvider.scala
@@ -22,7 +22,6 @@ package com.mohiva.play.silhouette.core.providers.oauth2
 import play.api.libs.json.JsObject
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.util.{ Success, Failure, Try }
 import com.mohiva.play.silhouette.core._
 import com.mohiva.play.silhouette.core.utils.{ HTTPLayer, CacheLayer }
 import com.mohiva.play.silhouette.core.providers.{ SocialProfile, OAuth2Info, OAuth2Settings, OAuth2Provider }
@@ -60,7 +59,7 @@ class GoogleProvider(
    * @param authInfo The auth info received from the provider.
    * @return On success the build social profile, otherwise a failure.
    */
-  protected def buildProfile(authInfo: OAuth2Info): Future[Try[SocialProfile[OAuth2Info]]] = {
+  protected def buildProfile(authInfo: OAuth2Info): Future[SocialProfile[OAuth2Info]] = {
     httpLayer.url(API.format(authInfo.accessToken)).get().map { response =>
       val json = response.json
       (json \ Error).asOpt[JsObject] match {
@@ -68,7 +67,7 @@ class GoogleProvider(
           val errorCode = (error \ Code).as[Int]
           val errorMsg = (error \ Message).as[String]
 
-          Failure(new AuthenticationException(SpecifiedProfileError.format(id, errorCode, errorMsg)))
+          throw new AuthenticationException(SpecifiedProfileError.format(id, errorCode, errorMsg))
         case _ =>
           val userID = (json \ ID).as[String]
           val firstName = (json \ Name \ GivenName).asOpt[String]
@@ -84,17 +83,18 @@ class GoogleProvider(
             None
           }
 
-          Success(SocialProfile(
+          SocialProfile(
             loginInfo = LoginInfo(id, userID),
             authInfo = authInfo,
             firstName = firstName,
             lastName = lastName,
             fullName = fullName,
             avatarURL = avatarURL,
-            email = emailValue))
+            email = emailValue)
       }
     }.recover {
-      case e => Failure(new AuthenticationException(UnspecifiedProfileError.format(id), e))
+      case e if !e.isInstanceOf[AuthenticationException] =>
+        throw new AuthenticationException(UnspecifiedProfileError.format(id), e)
     }
   }
 }

--- a/app/com/mohiva/play/silhouette/core/providers/oauth2/LinkedInProvider.scala
+++ b/app/com/mohiva/play/silhouette/core/providers/oauth2/LinkedInProvider.scala
@@ -19,7 +19,6 @@
  */
 package com.mohiva.play.silhouette.core.providers.oauth2
 
-import scala.util.Try
 import scala.concurrent.Future
 import com.mohiva.play.silhouette.core.utils.{ HTTPLayer, CacheLayer }
 import com.mohiva.play.silhouette.core.providers.{ SocialProfile, OAuth2Info, OAuth2Settings, OAuth2Provider }
@@ -52,7 +51,7 @@ class LinkedInProvider(
    * @param authInfo The auth info received from the provider.
    * @return On success the build social profile, otherwise a failure.
    */
-  protected def buildProfile(authInfo: OAuth2Info): Future[Try[SocialProfile[OAuth2Info]]] = {
+  protected def buildProfile(authInfo: OAuth2Info): Future[SocialProfile[OAuth2Info]] = {
     build(httpLayer.url(API.format(authInfo.accessToken)).get(), authInfo)
   }
 }

--- a/test/com/mohiva/play/silhouette/contrib/services/PlayOAuth1ServiceSpec.scala
+++ b/test/com/mohiva/play/silhouette/contrib/services/PlayOAuth1ServiceSpec.scala
@@ -35,30 +35,30 @@ class PlayOAuth1ServiceSpec extends PlaySpecification with Mockito {
   }
 
   "The retrieveRequestToken method" should {
-    "return Failure if the token couldn't be retrieved" in new Context {
+    "throw exception if the token couldn't be retrieved" in new Context {
       oauth.retrieveRequestToken(settings.callbackURL) returns Left(new OAuthMessageSignerException(""))
 
-      await(service.retrieveRequestToken(settings.callbackURL)) must beFailedTry.withThrowable[OAuthException]
+      await(service.retrieveRequestToken(settings.callbackURL)) must throwA[OAuthException]
     }
 
-    "return Success if the token could be retrieved" in new Context {
+    "return request token" in new Context {
       oauth.retrieveRequestToken(settings.callbackURL) returns Right(token)
 
-      await(service.retrieveRequestToken(settings.callbackURL)) must beSuccessfulTry.withValue(info)
+      await(service.retrieveRequestToken(settings.callbackURL)) must be equalTo info
     }
   }
 
   "The retrieveAccessToken method" should {
-    "return Failure if the token couldn't be retrieved" in new Context {
+    "throw Exception if the token couldn't be retrieved" in new Context {
       oauth.retrieveAccessToken(token, "") returns Left(new OAuthMessageSignerException(""))
 
-      await(service.retrieveAccessToken(info, "")) must beFailedTry.withThrowable[OAuthException]
+      await(service.retrieveAccessToken(info, "")) must throwA[OAuthException]
     }
 
-    "return Success if the token could be retrieved" in new Context {
+    "return access token" in new Context {
       oauth.retrieveAccessToken(token, "") returns Right(token)
 
-      await(service.retrieveAccessToken(info, "")) must beSuccessfulTry.withValue(info)
+      await(service.retrieveAccessToken(info, "")) must be equalTo info
     }
   }
 

--- a/test/com/mohiva/play/silhouette/core/providers/oauth1/LinkedInProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/providers/oauth1/LinkedInProviderSpec.scala
@@ -40,14 +40,14 @@ class LinkedInProviderSpec extends OAuth1ProviderSpec {
       val response = mock[Response]
       implicit val req = FakeRequest(GET, "?" + OAuthVerifier + "=my.verifier").withSession(CacheKey -> cacheID)
       cacheLayer.get[OAuth1Info](cacheID) returns Future.successful(Some(oAuthInfo))
-      oAuthService.retrieveAccessToken(oAuthInfo, "my.verifier") returns Future.successful(Success(oAuthInfo))
+      oAuthService.retrieveAccessToken(oAuthInfo, "my.verifier") returns Future.successful(oAuthInfo)
       requestHolder.sign(any) returns requestHolder
       requestHolder.get() returns Future.successful(response)
       response.json returns Helper.loadJson("providers/oauth1/linkedin.error.json")
       httpLayer.url(API) returns requestHolder
 
-      failedTry[AuthenticationException](provider.authenticate()) {
-        mustEqualTo(SpecifiedProfileError.format(
+      failed[AuthenticationException](provider.authenticate()) {
+        case e => e.getMessage must equalTo(SpecifiedProfileError.format(
           provider.id,
           0,
           Some("Unknown authentication scheme"),
@@ -65,14 +65,14 @@ class LinkedInProviderSpec extends OAuth1ProviderSpec {
       val response = mock[Response]
       implicit val req = FakeRequest(GET, "?" + OAuthVerifier + "=my.verifier").withSession(CacheKey -> cacheID)
       cacheLayer.get[OAuth1Info](cacheID) returns Future.successful(Some(oAuthInfo))
-      oAuthService.retrieveAccessToken(oAuthInfo, "my.verifier") returns Future.successful(Success(oAuthInfo))
+      oAuthService.retrieveAccessToken(oAuthInfo, "my.verifier") returns Future.successful(oAuthInfo)
       requestHolder.sign(any) returns requestHolder
       requestHolder.get() returns Future.successful(response)
       response.json throws new RuntimeException("")
       httpLayer.url(API) returns requestHolder
 
-      failedTry[AuthenticationException](provider.authenticate()) {
-        mustEqualTo(UnspecifiedProfileError.format(provider.id))
+      failed[AuthenticationException](provider.authenticate()) {
+        case e => e.getMessage must equalTo(UnspecifiedProfileError.format(provider.id))
       }
 
       there was one(cacheLayer).remove(cacheID)
@@ -84,7 +84,7 @@ class LinkedInProviderSpec extends OAuth1ProviderSpec {
       val response = mock[Response]
       implicit val req = FakeRequest(GET, "?" + OAuthVerifier + "=my.verifier").withSession(CacheKey -> cacheID)
       cacheLayer.get[OAuth1Info](cacheID) returns Future.successful(Some(oAuthInfo))
-      oAuthService.retrieveAccessToken(oAuthInfo, "my.verifier") returns Future.successful(Success(oAuthInfo))
+      oAuthService.retrieveAccessToken(oAuthInfo, "my.verifier") returns Future.successful(oAuthInfo)
       requestHolder.sign(any) returns requestHolder
       requestHolder.get() returns Future.successful(response)
       response.json returns Helper.loadJson("providers/oauth1/linkedin.success.json")

--- a/test/com/mohiva/play/silhouette/core/providers/oauth1/TwitterProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/providers/oauth1/TwitterProviderSpec.scala
@@ -41,14 +41,14 @@ class TwitterProviderSpec extends OAuth1ProviderSpec {
       val response = mock[Response]
       implicit val req = FakeRequest(GET, "?" + OAuthVerifier + "=my.verifier").withSession(CacheKey -> cacheID)
       cacheLayer.get[OAuth1Info](cacheID) returns Future.successful(Some(oAuthInfo))
-      oAuthService.retrieveAccessToken(oAuthInfo, "my.verifier") returns Future.successful(Success(oAuthInfo))
+      oAuthService.retrieveAccessToken(oAuthInfo, "my.verifier") returns Future.successful(oAuthInfo)
       requestHolder.sign(any) returns requestHolder
       requestHolder.get() returns Future.successful(response)
       response.json returns Helper.loadJson("providers/oauth1/twitter.error.json")
       httpLayer.url(API) returns requestHolder
 
-      failedTry[AuthenticationException](provider.authenticate()) {
-        mustEqualTo(SpecifiedProfileError.format(
+      failed[AuthenticationException](provider.authenticate()) {
+        case e => e.getMessage must equalTo(SpecifiedProfileError.format(
           provider.id,
           215,
           Some("Bad Authentication data")))
@@ -63,14 +63,14 @@ class TwitterProviderSpec extends OAuth1ProviderSpec {
       val response = mock[Response]
       implicit val req = FakeRequest(GET, "?" + OAuthVerifier + "=my.verifier").withSession(CacheKey -> cacheID)
       cacheLayer.get[OAuth1Info](cacheID) returns Future.successful(Some(oAuthInfo))
-      oAuthService.retrieveAccessToken(oAuthInfo, "my.verifier") returns Future.successful(Success(oAuthInfo))
+      oAuthService.retrieveAccessToken(oAuthInfo, "my.verifier") returns Future.successful(oAuthInfo)
       requestHolder.sign(any) returns requestHolder
       requestHolder.get() returns Future.successful(response)
       response.json throws new RuntimeException("")
       httpLayer.url(API) returns requestHolder
 
-      failedTry[AuthenticationException](provider.authenticate()) {
-        mustEqualTo(UnspecifiedProfileError.format(provider.id))
+      failed[AuthenticationException](provider.authenticate()) {
+        case e => e.getMessage must equalTo(UnspecifiedProfileError.format(provider.id))
       }
 
       there was one(cacheLayer).remove(cacheID)
@@ -82,7 +82,7 @@ class TwitterProviderSpec extends OAuth1ProviderSpec {
       val response = mock[Response]
       implicit val req = FakeRequest(GET, "?" + OAuthVerifier + "=my.verifier").withSession(CacheKey -> cacheID)
       cacheLayer.get[OAuth1Info](cacheID) returns Future.successful(Some(oAuthInfo))
-      oAuthService.retrieveAccessToken(oAuthInfo, "my.verifier") returns Future.successful(Success(oAuthInfo))
+      oAuthService.retrieveAccessToken(oAuthInfo, "my.verifier") returns Future.successful(oAuthInfo)
       requestHolder.sign(any) returns requestHolder
       requestHolder.get() returns Future.successful(response)
       response.json returns Helper.loadJson("providers/oauth1/twitter.success.json")

--- a/test/com/mohiva/play/silhouette/core/providers/oauth1/XingProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/providers/oauth1/XingProviderSpec.scala
@@ -41,14 +41,14 @@ class XingProviderSpec extends OAuth1ProviderSpec {
       val response = mock[Response]
       implicit val req = FakeRequest(GET, "?" + OAuthVerifier + "=my.verifier").withSession(CacheKey -> cacheID)
       cacheLayer.get[OAuth1Info](cacheID) returns Future.successful(Some(oAuthInfo))
-      oAuthService.retrieveAccessToken(oAuthInfo, "my.verifier") returns Future.successful(Success(oAuthInfo))
+      oAuthService.retrieveAccessToken(oAuthInfo, "my.verifier") returns Future.successful(oAuthInfo)
       requestHolder.sign(any) returns requestHolder
       requestHolder.get() returns Future.successful(response)
       response.json returns Helper.loadJson("providers/oauth1/xing.error.json")
       httpLayer.url(API) returns requestHolder
 
-      failedTry[AuthenticationException](provider.authenticate()) {
-        mustEqualTo(SpecifiedProfileError.format(
+      failed[AuthenticationException](provider.authenticate()) {
+        case e => e.getMessage must equalTo(SpecifiedProfileError.format(
           provider.id,
           "INVALID_PARAMETERS",
           "Invalid parameters (Limit must be a non-negative number.)"))
@@ -63,14 +63,14 @@ class XingProviderSpec extends OAuth1ProviderSpec {
       val response = mock[Response]
       implicit val req = FakeRequest(GET, "?" + OAuthVerifier + "=my.verifier").withSession(CacheKey -> cacheID)
       cacheLayer.get[OAuth1Info](cacheID) returns Future.successful(Some(oAuthInfo))
-      oAuthService.retrieveAccessToken(oAuthInfo, "my.verifier") returns Future.successful(Success(oAuthInfo))
+      oAuthService.retrieveAccessToken(oAuthInfo, "my.verifier") returns Future.successful(oAuthInfo)
       requestHolder.sign(any) returns requestHolder
       requestHolder.get() returns Future.successful(response)
       response.json throws new RuntimeException("")
       httpLayer.url(API) returns requestHolder
 
-      failedTry[AuthenticationException](provider.authenticate()) {
-        mustEqualTo(UnspecifiedProfileError.format(provider.id))
+      failed[AuthenticationException](provider.authenticate()) {
+        case e => e.getMessage must equalTo(UnspecifiedProfileError.format(provider.id))
       }
 
       there was one(cacheLayer).remove(cacheID)
@@ -82,7 +82,7 @@ class XingProviderSpec extends OAuth1ProviderSpec {
       val response = mock[Response]
       implicit val req = FakeRequest(GET, "?" + OAuthVerifier + "=my.verifier").withSession(CacheKey -> cacheID)
       cacheLayer.get[OAuth1Info](cacheID) returns Future.successful(Some(oAuthInfo))
-      oAuthService.retrieveAccessToken(oAuthInfo, "my.verifier") returns Future.successful(Success(oAuthInfo))
+      oAuthService.retrieveAccessToken(oAuthInfo, "my.verifier") returns Future.successful(oAuthInfo)
       requestHolder.sign(any) returns requestHolder
       requestHolder.get() returns Future.successful(response)
       response.json returns Helper.loadJson("providers/oauth1/xing.success.json")

--- a/test/com/mohiva/play/silhouette/core/providers/oauth2/FacebookProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/providers/oauth2/FacebookProviderSpec.scala
@@ -44,8 +44,8 @@ class FacebookProviderSpec extends OAuth2ProviderSpec {
       cacheLayer.get[String](cacheID) returns Future.successful(Some(state))
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
 
-      failedTry[AuthenticationException](provider.authenticate()) {
-        mustEqualTo(InvalidResponseFormat.format(provider.id, ""))
+      failed[AuthenticationException](provider.authenticate()) {
+        case e => e.getMessage must equalTo(InvalidResponseFormat.format(provider.id, ""))
       }
     }
 
@@ -64,8 +64,8 @@ class FacebookProviderSpec extends OAuth2ProviderSpec {
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
       httpLayer.url(API.format("my.access.token")) returns requestHolder
 
-      failedTry[AuthenticationException](provider.authenticate()) {
-        mustEqualTo(SpecifiedProfileError.format(
+      failed[AuthenticationException](provider.authenticate()) {
+        case e => e.getMessage must equalTo(SpecifiedProfileError.format(
           provider.id,
           "An active access token must be used to query information about the current user.",
           "OAuthException",
@@ -88,8 +88,8 @@ class FacebookProviderSpec extends OAuth2ProviderSpec {
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
       httpLayer.url(API.format("my.access.token")) returns requestHolder
 
-      failedTry[AuthenticationException](provider.authenticate()) {
-        mustEqualTo(UnspecifiedProfileError.format(provider.id))
+      failed[AuthenticationException](provider.authenticate()) {
+        case e => e.getMessage must equalTo(UnspecifiedProfileError.format(provider.id))
       }
     }
 

--- a/test/com/mohiva/play/silhouette/core/providers/oauth2/FoursquareProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/providers/oauth2/FoursquareProviderSpec.scala
@@ -45,8 +45,8 @@ class FoursquareProviderSpec extends OAuth2ProviderSpec {
       cacheLayer.get[String](cacheID) returns Future.successful(Some(state))
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
 
-      failedTry[AuthenticationException](provider.authenticate()) {
-        mustStartWith(InvalidResponseFormat.format(provider.id, ""))
+      failed[AuthenticationException](provider.authenticate()) {
+        case e => e.getMessage must startWith(InvalidResponseFormat.format(provider.id, ""))
       }
     }
 
@@ -64,8 +64,8 @@ class FoursquareProviderSpec extends OAuth2ProviderSpec {
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
       httpLayer.url(API.format("my.access.token", DefaultAPIVersion)) returns requestHolder
 
-      failedTry[AuthenticationException](provider.authenticate()) {
-        mustEqualTo(SpecifiedProfileError.format(
+      failed[AuthenticationException](provider.authenticate()) {
+        case e => e.getMessage must equalTo(SpecifiedProfileError.format(
           provider.id,
           400,
           Some("param_error"),
@@ -87,8 +87,8 @@ class FoursquareProviderSpec extends OAuth2ProviderSpec {
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
       httpLayer.url(API.format("my.access.token", DefaultAPIVersion)) returns requestHolder
 
-      failedTry[AuthenticationException](provider.authenticate()) {
-        mustEqualTo(UnspecifiedProfileError.format(provider.id))
+      failed[AuthenticationException](provider.authenticate()) {
+        case e => e.getMessage must equalTo(UnspecifiedProfileError.format(provider.id))
       }
     }
 

--- a/test/com/mohiva/play/silhouette/core/providers/oauth2/GitHubProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/providers/oauth2/GitHubProviderSpec.scala
@@ -46,8 +46,8 @@ class GitHubProviderSpec extends OAuth2ProviderSpec {
       cacheLayer.get[String](cacheID) returns Future.successful(Some(state))
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
 
-      failedTry[AuthenticationException](provider.authenticate()) {
-        mustStartWith(InvalidResponseFormat.format(provider.id, ""))
+      failed[AuthenticationException](provider.authenticate()) {
+        case e => e.getMessage must startWith(InvalidResponseFormat.format(provider.id, ""))
       }
     }
 
@@ -65,8 +65,8 @@ class GitHubProviderSpec extends OAuth2ProviderSpec {
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
       httpLayer.url(API.format("my.access.token")) returns requestHolder
 
-      failedTry[AuthenticationException](provider.authenticate()) {
-        mustEqualTo(SpecifiedProfileError.format(
+      failed[AuthenticationException](provider.authenticate()) {
+        case e => e.getMessage must equalTo(SpecifiedProfileError.format(
           provider.id,
           "Bad credentials",
           Some("http://developer.github.com/v3")))
@@ -87,8 +87,8 @@ class GitHubProviderSpec extends OAuth2ProviderSpec {
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
       httpLayer.url(API.format("my.access.token")) returns requestHolder
 
-      failedTry[AuthenticationException](provider.authenticate()) {
-        mustEqualTo(UnspecifiedProfileError.format(provider.id))
+      failed[AuthenticationException](provider.authenticate()) {
+        case e => e.getMessage must equalTo(UnspecifiedProfileError.format(provider.id))
       }
     }
 

--- a/test/com/mohiva/play/silhouette/core/providers/oauth2/GoogleProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/providers/oauth2/GoogleProviderSpec.scala
@@ -45,8 +45,8 @@ class GoogleProviderSpec extends OAuth2ProviderSpec {
       cacheLayer.get[String](cacheID) returns Future.successful(Some(state))
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
 
-      failedTry[AuthenticationException](provider.authenticate()) {
-        mustStartWith(InvalidResponseFormat.format(provider.id, ""))
+      failed[AuthenticationException](provider.authenticate()) {
+        case e => e.getMessage must startWith(InvalidResponseFormat.format(provider.id, ""))
       }
     }
 
@@ -64,8 +64,8 @@ class GoogleProviderSpec extends OAuth2ProviderSpec {
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
       httpLayer.url(API.format("my.access.token")) returns requestHolder
 
-      failedTry[AuthenticationException](provider.authenticate()) {
-        mustEqualTo(SpecifiedProfileError.format(
+      failed[AuthenticationException](provider.authenticate()) {
+        case e => e.getMessage must equalTo(SpecifiedProfileError.format(
           provider.id,
           401,
           "Invalid Credentials"))
@@ -86,8 +86,8 @@ class GoogleProviderSpec extends OAuth2ProviderSpec {
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
       httpLayer.url(API.format("my.access.token")) returns requestHolder
 
-      failedTry[AuthenticationException](provider.authenticate()) {
-        mustEqualTo(UnspecifiedProfileError.format(provider.id))
+      failed[AuthenticationException](provider.authenticate()) {
+        case e => e.getMessage must equalTo(UnspecifiedProfileError.format(provider.id))
       }
     }
 

--- a/test/com/mohiva/play/silhouette/core/providers/oauth2/InstagramProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/providers/oauth2/InstagramProviderSpec.scala
@@ -45,8 +45,8 @@ class InstagramProviderSpec extends OAuth2ProviderSpec {
       cacheLayer.get[String](cacheID) returns Future.successful(Some(state))
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
 
-      failedTry[AuthenticationException](provider.authenticate()) {
-        mustStartWith(InvalidResponseFormat.format(provider.id, ""))
+      failed[AuthenticationException](provider.authenticate()) {
+        case e => e.getMessage must startWith(InvalidResponseFormat.format(provider.id, ""))
       }
     }
 
@@ -64,8 +64,8 @@ class InstagramProviderSpec extends OAuth2ProviderSpec {
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
       httpLayer.url(API.format("my.access.token")) returns requestHolder
 
-      failedTry[AuthenticationException](provider.authenticate()) {
-        mustEqualTo(SpecifiedProfileError.format(
+      failed[AuthenticationException](provider.authenticate()) {
+        case e => e.getMessage must equalTo(SpecifiedProfileError.format(
           provider.id,
           400,
           Some("OAuthAccessTokenException"),
@@ -87,8 +87,8 @@ class InstagramProviderSpec extends OAuth2ProviderSpec {
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
       httpLayer.url(API.format("my.access.token")) returns requestHolder
 
-      failedTry[AuthenticationException](provider.authenticate()) {
-        mustEqualTo(UnspecifiedProfileError.format(provider.id))
+      failed[AuthenticationException](provider.authenticate()) {
+        case e => e.getMessage must equalTo(UnspecifiedProfileError.format(provider.id))
       }
     }
 

--- a/test/com/mohiva/play/silhouette/core/providers/oauth2/LinkedInProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/providers/oauth2/LinkedInProviderSpec.scala
@@ -46,8 +46,8 @@ class LinkedInProviderSpec extends OAuth2ProviderSpec {
       cacheLayer.get[String](cacheID) returns Future.successful(Some(state))
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
 
-      failedTry[AuthenticationException](provider.authenticate()) {
-        mustStartWith(InvalidResponseFormat.format(provider.id, ""))
+      failed[AuthenticationException](provider.authenticate()) {
+        case e => e.getMessage must startWith(InvalidResponseFormat.format(provider.id, ""))
       }
     }
 
@@ -65,8 +65,8 @@ class LinkedInProviderSpec extends OAuth2ProviderSpec {
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
       httpLayer.url(API.format("my.access.token")) returns requestHolder
 
-      failedTry[AuthenticationException](provider.authenticate()) {
-        mustEqualTo(SpecifiedProfileError.format(
+      failed[AuthenticationException](provider.authenticate()) {
+        case e => e.getMessage must equalTo(SpecifiedProfileError.format(
           provider.id,
           0,
           Some("Unknown authentication scheme"),
@@ -90,8 +90,8 @@ class LinkedInProviderSpec extends OAuth2ProviderSpec {
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
       httpLayer.url(API.format("my.access.token")) returns requestHolder
 
-      failedTry[AuthenticationException](provider.authenticate()) {
-        mustEqualTo(UnspecifiedProfileError.format(provider.id))
+      failed[AuthenticationException](provider.authenticate()) {
+        case e => e.getMessage must equalTo(UnspecifiedProfileError.format(provider.id))
       }
     }
 

--- a/test/com/mohiva/play/silhouette/core/providers/oauth2/VKProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/providers/oauth2/VKProviderSpec.scala
@@ -45,8 +45,8 @@ class VKProviderSpec extends OAuth2ProviderSpec {
       cacheLayer.get[String](cacheID) returns Future.successful(Some(state))
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
 
-      failedTry[AuthenticationException](provider.authenticate()) {
-        mustStartWith(InvalidResponseFormat.format(provider.id, ""))
+      failed[AuthenticationException](provider.authenticate()) {
+        case e => e.getMessage must startWith(InvalidResponseFormat.format(provider.id, ""))
       }
     }
 
@@ -64,8 +64,8 @@ class VKProviderSpec extends OAuth2ProviderSpec {
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
       httpLayer.url(API.format("my.access.token")) returns requestHolder
 
-      failedTry[AuthenticationException](provider.authenticate()) {
-        mustEqualTo(SpecifiedProfileError.format(
+      failed[AuthenticationException](provider.authenticate()) {
+        case e => e.getMessage must equalTo(SpecifiedProfileError.format(
           provider.id,
           10,
           "Internal server error: could not get application"))
@@ -86,8 +86,8 @@ class VKProviderSpec extends OAuth2ProviderSpec {
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
       httpLayer.url(API.format("my.access.token")) returns requestHolder
 
-      failedTry[AuthenticationException](provider.authenticate()) {
-        mustEqualTo(UnspecifiedProfileError.format(provider.id))
+      failed[AuthenticationException](provider.authenticate()) {
+        case e => e.getMessage must equalTo(UnspecifiedProfileError.format(provider.id))
       }
     }
 


### PR DESCRIPTION
As noticed by @jeantil in the [Future[Try[T]] api signatures](https://groups.google.com/d/msg/play-silhouette/5apL4RzVPpQ/9zNq1ROFHwsJ) thread on the mailing list, the additional Try bloats the client code and the Silhouette provider implementations. Furthermore it isn't necessary to use an additional error handling layer on top of a Future, because a Future has its own error handling by the usage of Try.
