### PR TITLE
Pass implicit request to Authorization.isAuthorized method

### DIFF
--- a/app/com/mohiva/play/silhouette/core/Authorization.scala
+++ b/app/com/mohiva/play/silhouette/core/Authorization.scala
@@ -19,6 +19,9 @@
  */
 package com.mohiva.play.silhouette.core
 
+import play.api.mvc.RequestHeader
+import play.api.i18n.Lang
+
 /**
  * A trait to define Authorization objects that let you hook
  * an authorization implementation in SecuredActions.
@@ -31,7 +34,9 @@ trait Authorization[I <: Identity] {
    * Checks whether the user is authorized to execute an action or not.
    *
    * @param identity The identity to check for.
+   * @param request The current request header.
+   * @param lang The current lang.
    * @return True if the user is authorized, false otherwise.
    */
-  def isAuthorized(identity: I): Boolean
+  def isAuthorized(identity: I)(implicit request: RequestHeader, lang: Lang): Boolean
 }

--- a/app/com/mohiva/play/silhouette/core/Silhouette.scala
+++ b/app/com/mohiva/play/silhouette/core/Silhouette.scala
@@ -33,8 +33,8 @@ import com.mohiva.play.silhouette.core.utils.DefaultActionHandler
  * {{{
  * class MyController(
  *     val identityService: IdentityService[User],
- *     val authenticatorService: AuthenticatorService
- *   ) extends Silhouette[User] {
+ *     val authenticatorService: AuthenticatorService[CachedCookieAuthenticator]
+ *   ) extends Silhouette[User, CachedCookieAuthenticator] {
  *
  *   def protectedAction = SecuredAction { implicit request =>
  *     Ok("Hello %s".format(request.identity.fullName))
@@ -209,6 +209,7 @@ trait Silhouette[I <: Identity, T <: Authenticator] extends Controller with Logg
      * @return The result to send to the client.
      */
     def invokeBlock[A](request: Request[A], block: SecuredRequest[A] => Future[SimpleResult]) = {
+      implicit val r = request
       currentIdentity(request).flatMap {
         // A user is both authenticated and authorized. The request will be granted.
         case Some(identity) if authorize.isEmpty || authorize.get.isAuthorized(identity) =>

--- a/test/com/mohiva/play/silhouette/core/SilhouetteSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/SilhouetteSpec.scala
@@ -377,8 +377,10 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
      * Checks whether the user is authorized to execute an action or not.
      *
      * @param identity The identity to check for.
+     * @param request The current request header.
+     * @param lang The current lang.
      * @return True if the user is authorized, false otherwise.
      */
-    def isAuthorized(identity: TestIdentity): Boolean = isAuthorized
+    def isAuthorized(identity: TestIdentity)(implicit request: RequestHeader, lang: Lang): Boolean = isAuthorized
   }
 }


### PR DESCRIPTION
As described in [SecureSocial issue](https://github.com/jaliss/securesocial/issues/397) we should pass an implicit request to the [Authorization.isAuthorized](https://github.com/mohiva/play-silhouette/blob/master/app/com/mohiva/play/silhouette/core/Authorization.scala#L36) method.
