### PR TITLE
Use strong typing for token ID

### DIFF
--- a/app/com/mohiva/play/silhouette/core/Token.scala
+++ b/app/com/mohiva/play/silhouette/core/Token.scala
@@ -25,5 +25,12 @@ trait Token {
    *
    * @return The token ID.
    */
-  def id: String
+  def id: TokenID
 }
+
+/**
+ * A strongly-typed token ID.
+ *
+ * It might be implemented as a UUID value, a String value, etc.
+ */
+trait TokenID

--- a/app/com/mohiva/play/silhouette/core/services/TokenService.scala
+++ b/app/com/mohiva/play/silhouette/core/services/TokenService.scala
@@ -20,7 +20,7 @@
 package com.mohiva.play.silhouette.core.services
 
 import scala.concurrent.Future
-import com.mohiva.play.silhouette.core.Token
+import com.mohiva.play.silhouette.core.{ Token, TokenID }
 
 /**
  * A trait that provides the means to handle auth tokens for the Silhouette module.
@@ -46,7 +46,7 @@ trait TokenService[T <: Token] {
    * @param id The token ID.
    * @return The retrieved token or None if no token could be retrieved for the given ID.
    */
-  def retrieve(id: String): Future[Option[T]]
+  def retrieve(id: TokenID): Future[Option[T]]
 
   /**
    * Consumes a token.
@@ -59,5 +59,5 @@ trait TokenService[T <: Token] {
    *
    * @param id The ID of the token to consume.
    */
-  def consume(id: String)
+  def consume(id: TokenID)
 }


### PR DESCRIPTION
Allow for Token implementations to use strongly-typed IDs instead of weakly-typed Strings. This should help prevent errors such as passing the wrong value.
