### PR TITLE
Publish events

### DIFF
--- a/app/com/mohiva/play/silhouette/core/Environment.scala
+++ b/app/com/mohiva/play/silhouette/core/Environment.scala
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2014 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mohiva.play.silhouette.core
+
+import com.mohiva.play.silhouette.core.services.{ AuthenticatorService, IdentityService }
+
+/**
+ * The environment needed to instantiate a Silhouette controller.
+ */
+trait Environment[I <: Identity, T <: Authenticator] {
+
+  /**
+   * Gets the identity service implementation.
+   *
+   * @return The identity service implementation.
+   */
+  def identityService: IdentityService[I]
+
+  /**
+   * Gets the authenticator service implementation.
+   *
+   * @return The authenticator service implementation.
+   */
+  def authenticatorService: AuthenticatorService[T]
+
+  /**
+   * The event bus implementation.
+   *
+   * @return The event bus implementation.
+   */
+  def eventBus: EventBus
+}

--- a/app/com/mohiva/play/silhouette/core/EventBus.scala
+++ b/app/com/mohiva/play/silhouette/core/EventBus.scala
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2014 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mohiva.play.silhouette.core
+
+import akka.event.{ LookupClassification, ActorEventBus }
+import play.api.mvc.RequestHeader
+import play.api.i18n.Lang
+
+/**
+ * The base event.
+ */
+trait SilhouetteEvent
+
+/**
+ * An event which will be published after an identity signed up.
+ *
+ * @param identity The newly created identity.
+ * @param request The request header for the associated request.
+ * @param lang The lang associated for the current request.
+ * @tparam I The type of the identity.
+ */
+case class SignUpEvent[I <: Identity](identity: I, request: RequestHeader, lang: Lang) extends SilhouetteEvent
+
+/**
+ * An event which will be published after an identity logged in.
+ *
+ * @param identity The logged in identity.
+ * @param request The request header for the associated request.
+ * @param lang The lang associated for the current request.
+ * @tparam I The type of the identity.
+ */
+case class LoginEvent[I <: Identity](identity: I, request: RequestHeader, lang: Lang) extends SilhouetteEvent
+
+/**
+ * An event which will be published after an identity logged out.
+ *
+ * @param identity The logged out identity.
+ * @param request The request header for the associated request.
+ * @param lang The lang associated for the current request.
+ * @tparam I The type of the identity.
+ */
+case class LogoutEvent[I <: Identity](identity: I, request: RequestHeader, lang: Lang) extends SilhouetteEvent
+
+/**
+ * An event which will be published after the access was denied to an identity.
+ *
+ * @param request The request header for the associated request.
+ * @param lang The lang associated for the current request.
+ */
+case class AccessDeniedEvent(request: RequestHeader, lang: Lang) extends SilhouetteEvent
+
+/**
+ * An event which will be published if a request passes authentication.
+ *
+ * @param identity The logged in identity.
+ * @param request The request header for the associated request.
+ * @param lang The lang associated for the current request.
+ * @tparam I The type of the identity.
+ */
+case class AuthenticatedEvent[I <: Identity](identity: I, request: RequestHeader, lang: Lang) extends SilhouetteEvent
+
+/**
+ * An event which will be published if a request did not pass authentication.
+ *
+ * @param request The request header for the associated request.
+ * @param lang The lang associated for the current request.
+ */
+case class NotAuthenticatedEvent(request: RequestHeader, lang: Lang) extends SilhouetteEvent
+
+/**
+ * An event which will be published if a request did not pass authorization.
+ *
+ * @param identity The logged in identity.
+ * @param request The request header for the associated request.
+ * @param lang The lang associated for the current request.
+ * @tparam I The type of the identity.
+ */
+case class NotAuthorizedEvent[I <: Identity](identity: I, request: RequestHeader, lang: Lang) extends SilhouetteEvent
+
+/**
+ * An event bus implementation which uses a class based lookup classification.
+ */
+class EventBus extends ActorEventBus with LookupClassification {
+  override type Classifier = Class[_]
+  override type Event = SilhouetteEvent
+
+  /**
+   * This is a size hint for the number of Classifiers you expect to have (use powers of 2).
+   */
+  protected def mapSize(): Int = 10
+
+  /**
+   * Publishes the given Event to the given Subscriber.
+   *
+   * @param event The Event to publish.
+   * @param subscriber The Subscriber to which the Event should be published.
+   */
+  protected def publish(event: Event, subscriber: Subscriber): Unit = subscriber ! event
+
+  /**
+   * Returns the Classifier associated with the given Event.
+   *
+   * @param event The event for which the Classifier should be returned.
+   * @return The Classifier for the given Event..
+   */
+  protected def classify(event: Event): Classifier = event.getClass
+}
+
+/**
+ * A global event bus instance.
+ */
+object EventBus {
+
+  /**
+   * Holds the global event bus instance.
+   */
+  private lazy val instance = new EventBus
+
+  /**
+   * Gets a global event bus instance.
+   *
+   * @return A global event bus instance.
+   */
+  def apply() = instance
+}

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,8 @@ libraryDependencies ++= Seq(
   "org.mindrot" % "jbcrypt" % "0.3m",
   "org.mockito" % "mockito-core" % "1.9.5" % "test",
   "com.google.inject" % "guice" % "4.0-beta" % "test",
-  "net.codingwell" %% "scala-guice" % "4.0.0-beta" % "test"
+  "net.codingwell" %% "scala-guice" % "4.0.0-beta" % "test",
+  "com.typesafe.akka" %% "akka-testkit" % "2.2.0" % "test"
 )
 
 playScalaSettings

--- a/test/com/mohiva/play/silhouette/core/EventBusSpec.scala
+++ b/test/com/mohiva/play/silhouette/core/EventBusSpec.scala
@@ -1,0 +1,152 @@
+/**
+ * Copyright 2014 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mohiva.play.silhouette.core
+
+import play.api.i18n.Lang
+import play.api.test.{ FakeRequest, PlaySpecification, WithApplication }
+import play.api.libs.concurrent.Akka
+import akka.actor.{ Actor, Props }
+import akka.testkit.TestProbe
+import scala.concurrent.duration._
+import org.specs2.specification.Scope
+
+/**
+ * Test case for the [[com.mohiva.play.silhouette.core.EventBus]] class.
+ */
+class EventBusSpec extends PlaySpecification {
+
+  "The event bus" should {
+    "handle an event" in new WithApplication with Context {
+      val eventBus = new EventBus
+      val listener = system.actorOf(Props(new Actor {
+        def receive = {
+          case e @ LoginEvent(_, _, _) => theProbe.ref ! e
+        }
+      }))
+
+      eventBus.subscribe(listener, classOf[LoginEvent[TestIdentity]])
+      eventBus.publish(loginEvent)
+
+      theProbe.expectMsg(500 millis, loginEvent)
+    }
+
+    "handle multiple events" in new WithApplication with Context {
+      val eventBus = new EventBus
+      val listener = system.actorOf(Props(new Actor {
+        def receive = {
+          case e @ LoginEvent(_, _, _) => theProbe.ref ! e
+          case e @ LogoutEvent(_, _, _) => theProbe.ref ! e
+        }
+      }))
+
+      eventBus.subscribe(listener, classOf[LoginEvent[TestIdentity]])
+      eventBus.subscribe(listener, classOf[LogoutEvent[TestIdentity]])
+      eventBus.publish(loginEvent)
+      eventBus.publish(logoutEvent)
+
+      theProbe.expectMsg(500 millis, loginEvent)
+      theProbe.expectMsg(500 millis, logoutEvent)
+    }
+
+    "differentiate between event classes" in new WithApplication with Context {
+      val eventBus = new EventBus
+      val listener = system.actorOf(Props(new Actor {
+        def receive = {
+          case e @ LoginEvent(_, _, _) => theProbe.ref ! e
+        }
+      }))
+
+      eventBus.subscribe(listener, classOf[LogoutEvent[TestIdentity]])
+      eventBus.publish(logoutEvent)
+
+      theProbe.expectNoMsg(500 millis)
+    }
+
+    "not handle not subscribed events" in new WithApplication with Context {
+      val eventBus = new EventBus
+      val listener = system.actorOf(Props(new Actor {
+        def receive = {
+          case e @ LoginEvent(_, _, _) => theProbe.ref ! e
+        }
+      }))
+
+      eventBus.publish(loginEvent)
+
+      theProbe.expectNoMsg(500 millis)
+    }
+
+    "not handle events between different event buses" in new WithApplication with Context {
+      val eventBus1 = new EventBus
+      val eventBus2 = new EventBus
+
+      val listener = system.actorOf(Props(new Actor {
+        def receive = {
+          case e @ LoginEvent(_, _, _) => theProbe.ref ! e
+        }
+      }))
+
+      eventBus1.subscribe(listener, classOf[LoginEvent[TestIdentity]])
+      eventBus2.publish(loginEvent)
+
+      theProbe.expectNoMsg(500 millis)
+    }
+  }
+
+  /**
+   * An identity implementation.
+   *
+   * @param loginInfo The linked login info.
+   */
+  case class TestIdentity(loginInfo: LoginInfo) extends Identity
+
+  /**
+   * The context.
+   */
+  trait Context extends Scope {
+    self: WithApplication =>
+
+    /**
+     * An identity implementation.
+     */
+    lazy val identity = TestIdentity(LoginInfo("test", "apollonia.vanova@watchmen.com"))
+
+    /**
+     * A fake request.
+     */
+    lazy val request = FakeRequest()
+
+    /**
+     * A language.
+     */
+    lazy val lang = Lang("en-US")
+
+    /**
+     * The Play actor system.
+     */
+    lazy implicit val system = Akka.system
+
+    /**
+     * The test probe.
+     */
+    lazy val theProbe = TestProbe()
+
+    /**
+     * Some events.
+     */
+    lazy val loginEvent = new LoginEvent[TestIdentity](identity, request, lang)
+    lazy val logoutEvent = new LogoutEvent[TestIdentity](identity, request, lang)
+  }
+}


### PR DESCRIPTION
Publish relevant events that can be consumed by the application in a [publish-subscribe pattern](http://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern).

These events are not meant for customization of the authentication and authorization logic. The library's extension points are meant for that, via method overriding and dependency injection.

They're meant for loosely-coupled, system-wide integration, in the spirit of [The Reactive Manifesto](http://www.reactivemanifesto.org/#event-driven).

These events will broadcast the occurrence of significant facts related to authentication and authorization, such as:
- A new user was created.
- A user logged in.
- A user logged out.
- A user attempted to log in with invalid credentials.
- A user attempted to reuse a consumed token.
- A request passed authentication.
- A request did not pass authentication.
- A request did not pass authorization.

Application (or contrib) code can listen to some of these events and take action such as logging, notification, metrics, etc.

We should consider using Akka for this task. Maybe we can use the event bus implementation from Akka:
- http://stackoverflow.com/a/14892971/2153190
- http://doc.akka.io/docs/akka/2.1-M2/scala/event-bus.html
