### PR TITLE
Fixed small but important typo in HeaderAuthenticatorSettings doc string

### DIFF
--- a/app/com/mohiva/play/silhouette/contrib/authenticators/HeaderAuthenticator.scala
+++ b/app/com/mohiva/play/silhouette/contrib/authenticators/HeaderAuthenticator.scala
@@ -176,7 +176,7 @@ object HeaderAuthenticatorService {
  *
  * @param headerName The header name.
  * @param authenticatorIdleTimeout The time in seconds an authenticator can be idle before it timed out. Defaults to 30 minutes.
- * @param authenticatorExpiry The expiry of the authenticator in minutes. Defaults to 12 hours.
+ * @param authenticatorExpiry The expiry of the authenticator in seconds. Defaults to 12 hours.
  */
 case class HeaderAuthenticatorSettings(
   headerName: String = "X-Auth-Token",


### PR DESCRIPTION
There is a small but important typo in the `HeaderAuthenticatorSettings` docs. The `authenticatorExpiry` is implemented in seconds (default is 12 \* 60 \* 60) but the docs say minutes.
