### PR TITLE
Add CacheAuthenticatorDAO

### DIFF
--- a/app/com/mohiva/play/silhouette/contrib/authenticators/BearerTokenAuthenticator.scala
+++ b/app/com/mohiva/play/silhouette/contrib/authenticators/BearerTokenAuthenticator.scala
@@ -21,7 +21,7 @@ import com.mohiva.play.silhouette.core.exceptions.AuthenticationException
 import com.mohiva.play.silhouette.core.services.AuthenticatorService
 import com.mohiva.play.silhouette.core.services.AuthenticatorService._
 import com.mohiva.play.silhouette.core.utils.{ Clock, IDGenerator }
-import com.mohiva.play.silhouette.core.{ Authenticator, Logger, LoginInfo }
+import com.mohiva.play.silhouette.core.{ StorableAuthenticator, Logger, LoginInfo }
 import org.joda.time.DateTime
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.mvc.{ RequestHeader, Result }
@@ -51,7 +51,7 @@ case class BearerTokenAuthenticator(
   lastUsedDate: DateTime,
   expirationDate: DateTime,
   idleTimeout: Option[Int])
-    extends Authenticator {
+    extends StorableAuthenticator {
 
   /**
    * Checks if the authenticator isn't expired and isn't timed out.

--- a/app/com/mohiva/play/silhouette/contrib/authenticators/CookieAuthenticator.scala
+++ b/app/com/mohiva/play/silhouette/contrib/authenticators/CookieAuthenticator.scala
@@ -25,7 +25,7 @@ import com.mohiva.play.silhouette.core.exceptions.AuthenticationException
 import com.mohiva.play.silhouette.core.services.AuthenticatorService
 import com.mohiva.play.silhouette.core.services.AuthenticatorService._
 import com.mohiva.play.silhouette.core.utils.{ Clock, FingerprintGenerator, IDGenerator }
-import com.mohiva.play.silhouette.core.{ Authenticator, Logger, LoginInfo }
+import com.mohiva.play.silhouette.core.{ StorableAuthenticator, Logger, LoginInfo }
 import org.joda.time.DateTime
 import play.api.Play
 import play.api.Play.current
@@ -59,7 +59,7 @@ case class CookieAuthenticator(
   expirationDate: DateTime,
   idleTimeout: Option[Int],
   fingerprint: Option[String])
-    extends Authenticator {
+    extends StorableAuthenticator {
 
   /**
    * Checks if the authenticator isn't expired and isn't timed out.

--- a/app/com/mohiva/play/silhouette/contrib/authenticators/JWTAuthenticator.scala
+++ b/app/com/mohiva/play/silhouette/contrib/authenticators/JWTAuthenticator.scala
@@ -23,7 +23,7 @@ import com.mohiva.play.silhouette.core.exceptions.AuthenticationException
 import com.mohiva.play.silhouette.core.services.AuthenticatorService
 import com.mohiva.play.silhouette.core.services.AuthenticatorService._
 import com.mohiva.play.silhouette.core.utils.{ Base64, Clock, IDGenerator }
-import com.mohiva.play.silhouette.core.{ Authenticator, Logger, LoginInfo }
+import com.mohiva.play.silhouette.core.{ StorableAuthenticator, Logger, LoginInfo }
 import com.nimbusds.jose.JWSObject
 import com.nimbusds.jose.crypto.MACVerifier
 import com.nimbusds.jwt.JWTClaimsSet
@@ -60,7 +60,7 @@ case class JWTAuthenticator(
   lastUsedDate: DateTime,
   expirationDate: DateTime,
   idleTimeout: Option[Int])
-    extends Authenticator {
+    extends StorableAuthenticator {
 
   /**
    * Checks if the authenticator isn't expired and isn't timed out.

--- a/app/com/mohiva/play/silhouette/contrib/daos/CacheAuthenticatorDAO.scala
+++ b/app/com/mohiva/play/silhouette/contrib/daos/CacheAuthenticatorDAO.scala
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2014 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mohiva.play.silhouette.contrib.daos
+
+import com.mohiva.play.silhouette.core.StorableAuthenticator
+import com.mohiva.play.silhouette.core.utils.CacheLayer
+import scala.concurrent.Future
+import scala.reflect.ClassTag
+
+/**
+ * Implementation of the authenticator DAO which uses the cache layer to persist the authenticator.
+ *
+ * @param cacheLayer The cache layer implementation.
+ * @tparam T The type of the authenticator to store.
+ */
+class CacheAuthenticatorDAO[T <: StorableAuthenticator: ClassTag](cacheLayer: CacheLayer) extends AuthenticatorDAO[T] {
+
+  /**
+   * Saves the authenticator.
+   *
+   * @param authenticator The authenticator to save.
+   * @return The saved auth info.
+   */
+  def save(authenticator: T): Future[T] = cacheLayer.save[T](authenticator.id, authenticator)
+
+  /**
+   * Finds the authenticator for the given ID.
+   *
+   * @param id The authenticator ID.
+   * @return The found authenticator or None if no authenticator could be found for the given ID.
+   */
+  def find(id: String): Future[Option[T]] = cacheLayer.find[T](id)
+
+  /**
+   * Removes the authenticator for the given ID.
+   *
+   * @param id The authenticator ID.
+   * @return An empty future.
+   */
+  def remove(id: String): Future[Unit] = cacheLayer.remove(id)
+}

--- a/app/com/mohiva/play/silhouette/core/Authenticator.scala
+++ b/app/com/mohiva/play/silhouette/core/Authenticator.scala
@@ -38,3 +38,16 @@ trait Authenticator {
    */
   def isValid: Boolean
 }
+
+/**
+ * An authenticator which can be stored in a backing store.
+ */
+trait StorableAuthenticator extends Authenticator {
+
+  /**
+   * Gets the ID to reference the authenticator in the backing store.
+   *
+   * @return The ID to reference the authenticator in the backing store.
+   */
+  def id: String
+}

--- a/test/com/mohiva/play/silhouette/contrib/daos/CacheAuthenticatorDAOSpec.scala
+++ b/test/com/mohiva/play/silhouette/contrib/daos/CacheAuthenticatorDAOSpec.scala
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2014 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mohiva.play.silhouette.contrib.daos
+
+import com.mohiva.play.silhouette.core.StorableAuthenticator
+import com.mohiva.play.silhouette.core.utils.CacheLayer
+import org.specs2.mock.Mockito
+import org.specs2.specification.Scope
+import play.api.test.{ PlaySpecification, WithApplication }
+import scala.concurrent.Future
+
+/**
+ * Test case for the [[com.mohiva.play.silhouette.contrib.daos.CacheAuthenticatorDAO]] class.
+ */
+class CacheAuthenticatorDAOSpec extends PlaySpecification with Mockito {
+
+  "The `save` method" should {
+    "save value in cache" in new WithApplication with Context {
+      authenticator.id returns "test-id"
+      cacheLayer.save("test-id", authenticator, 0) returns Future.successful(authenticator)
+
+      await(dao.save(authenticator)) must be equalTo authenticator
+      there was one(cacheLayer).save("test-id", authenticator, 0)
+    }
+  }
+
+  "The `find` method" should {
+    "return value from cache" in new WithApplication with Context {
+      cacheLayer.find[StorableAuthenticator]("test-id") returns Future.successful(Some(authenticator))
+
+      await(dao.find("test-id")) must beSome(authenticator)
+      there was one(cacheLayer).find[StorableAuthenticator]("test-id")
+    }
+
+    "return None if value couldn't be found in cache" in new WithApplication with Context {
+      cacheLayer.find[StorableAuthenticator]("test-id") returns Future.successful(None)
+
+      await(dao.find("test-id")) must beNone
+      there was one(cacheLayer).find[StorableAuthenticator]("test-id")
+    }
+  }
+
+  "The `remove` method" should {
+    "removes value from cache" in new WithApplication with Context {
+      cacheLayer.remove("test-id") returns Future.successful(())
+
+      await(dao.remove("test-id")) must be equalTo (())
+      there was one(cacheLayer).remove("test-id")
+    }
+  }
+
+  /**
+   * The context.
+   */
+  trait Context extends Scope {
+
+    /**
+     * A storable authenticator.
+     */
+    lazy val authenticator = mock[StorableAuthenticator]
+
+    /**
+     * The cache layer implementation.
+     */
+    lazy val cacheLayer = mock[CacheLayer]
+
+    /**
+     * The dAO to test.
+     */
+    lazy val dao = new CacheAuthenticatorDAO[StorableAuthenticator](cacheLayer)
+  }
+}


### PR DESCRIPTION
The CacheAuthenticatorDAO is the default implementation of the AuthenticatorDAO which can be used to store an Authenticator in cache.
