### PR TITLE
Better typing for providers

### DIFF
--- a/app/com/mohiva/play/silhouette/impl/providers/SocialProvider.scala
+++ b/app/com/mohiva/play/silhouette/impl/providers/SocialProvider.scala
@@ -27,10 +27,13 @@ import scala.util.Try
 
 /**
  * The base interface for all social providers.
- *
- * @tparam A The type of the auth info.
  */
-trait SocialProvider[A <: AuthInfo] extends Provider with SocialProfileBuilder[A] {
+trait SocialProvider extends Provider with SocialProfileBuilder {
+
+  /**
+   * The type of the auth info.
+   */
+  type A <: AuthInfo
 
   /**
    * Authenticates the user and returns the auth information.
@@ -42,7 +45,7 @@ trait SocialProvider[A <: AuthInfo] extends Provider with SocialProfileBuilder[A
    * @param request The request header.
    * @return Either a Result or the AuthInfo from the provider.
    */
-  def authenticate()(implicit request: RequestHeader): Future[AuthenticationResult]
+  def authenticate()(implicit request: RequestHeader): Future[Either[Result, A]]
 
   /**
    * Retrieves the user profile for the given auth info.
@@ -62,21 +65,6 @@ trait SocialProvider[A <: AuthInfo] extends Provider with SocialProfileBuilder[A
 }
 
 /**
- * The result of a request to Provider.authenticate().
- */
-sealed trait AuthenticationResult
-
-/**
- * Wraps a redirect response in the authentication flow.
- */
-case class AuthenticationOngoing(result: Result) extends AuthenticationResult
-
-/**
- * Means the authentication has been completed, the auth info is available.
- */
-case class AuthenticationCompleted[A <: AuthInfo](authInfo: A) extends AuthenticationResult
-
-/**
  * The social profile contains all the data returned from the social providers after authentication.
  */
 trait SocialProfile {
@@ -91,11 +79,9 @@ trait SocialProfile {
 
 /**
  * Builds the social profile.
- *
- * @tparam A The type of the auth info.
  */
-trait SocialProfileBuilder[A <: AuthInfo] {
-  self: SocialProvider[A] =>
+trait SocialProfileBuilder {
+  self: SocialProvider =>
 
   /**
    * The type of the profile.
@@ -183,11 +169,9 @@ case class CommonSocialProfile(
 
 /**
  * The profile builder for the common social profile.
- *
- * @tparam A The auth info type.
  */
-trait CommonSocialProfileBuilder[A <: AuthInfo] {
-  self: SocialProfileBuilder[A] =>
+trait CommonSocialProfileBuilder {
+  self: SocialProfileBuilder =>
 
   /**
    * The type of the profile.

--- a/app/com/mohiva/play/silhouette/impl/providers/oauth1/LinkedInProvider.scala
+++ b/app/com/mohiva/play/silhouette/impl/providers/oauth1/LinkedInProvider.scala
@@ -138,6 +138,6 @@ object LinkedInProvider {
     httpLayer: HTTPLayer,
     oAuth1Service: OAuth1Service,
     auth1Settings: OAuth1Settings) = {
-    new LinkedInProvider(cacheLayer, httpLayer, oAuth1Service, auth1Settings) with CommonSocialProfileBuilder[OAuth1Info]
+    new LinkedInProvider(cacheLayer, httpLayer, oAuth1Service, auth1Settings) with CommonSocialProfileBuilder
   }
 }

--- a/app/com/mohiva/play/silhouette/impl/providers/oauth1/TwitterProvider.scala
+++ b/app/com/mohiva/play/silhouette/impl/providers/oauth1/TwitterProvider.scala
@@ -128,6 +128,6 @@ object TwitterProvider {
     httpLayer: HTTPLayer,
     oAuth1Service: OAuth1Service,
     auth1Settings: OAuth1Settings) = {
-    new TwitterProvider(cacheLayer, httpLayer, oAuth1Service, auth1Settings) with CommonSocialProfileBuilder[OAuth1Info]
+    new TwitterProvider(cacheLayer, httpLayer, oAuth1Service, auth1Settings) with CommonSocialProfileBuilder
   }
 }

--- a/app/com/mohiva/play/silhouette/impl/providers/oauth1/XingProvider.scala
+++ b/app/com/mohiva/play/silhouette/impl/providers/oauth1/XingProvider.scala
@@ -135,6 +135,6 @@ object XingProvider {
     httpLayer: HTTPLayer,
     oAuth1Service: OAuth1Service,
     auth1Settings: OAuth1Settings) = {
-    new XingProvider(cacheLayer, httpLayer, oAuth1Service, auth1Settings) with CommonSocialProfileBuilder[OAuth1Info]
+    new XingProvider(cacheLayer, httpLayer, oAuth1Service, auth1Settings) with CommonSocialProfileBuilder
   }
 }

--- a/app/com/mohiva/play/silhouette/impl/providers/oauth2/FacebookProvider.scala
+++ b/app/com/mohiva/play/silhouette/impl/providers/oauth2/FacebookProvider.scala
@@ -149,6 +149,6 @@ object FacebookProvider {
    * @return An instance of this provider.
    */
   def apply(httpLayer: HTTPLayer, stateProvider: OAuth2StateProvider, settings: OAuth2Settings) = {
-    new FacebookProvider(httpLayer, stateProvider, settings) with CommonSocialProfileBuilder[OAuth2Info]
+    new FacebookProvider(httpLayer, stateProvider, settings) with CommonSocialProfileBuilder
   }
 }

--- a/app/com/mohiva/play/silhouette/impl/providers/oauth2/FoursquareProvider.scala
+++ b/app/com/mohiva/play/silhouette/impl/providers/oauth2/FoursquareProvider.scala
@@ -155,6 +155,6 @@ object FoursquareProvider {
    * @return An instance of this provider.
    */
   def apply(httpLayer: HTTPLayer, stateProvider: OAuth2StateProvider, settings: OAuth2Settings) = {
-    new FoursquareProvider(httpLayer, stateProvider, settings) with CommonSocialProfileBuilder[OAuth2Info]
+    new FoursquareProvider(httpLayer, stateProvider, settings) with CommonSocialProfileBuilder
   }
 }

--- a/app/com/mohiva/play/silhouette/impl/providers/oauth2/GitHubProvider.scala
+++ b/app/com/mohiva/play/silhouette/impl/providers/oauth2/GitHubProvider.scala
@@ -132,6 +132,6 @@ object GitHubProvider {
    * @return An instance of this provider.
    */
   def apply(httpLayer: HTTPLayer, stateProvider: OAuth2StateProvider, settings: OAuth2Settings) = {
-    new GitHubProvider(httpLayer, stateProvider, settings) with CommonSocialProfileBuilder[OAuth2Info]
+    new GitHubProvider(httpLayer, stateProvider, settings) with CommonSocialProfileBuilder
   }
 }

--- a/app/com/mohiva/play/silhouette/impl/providers/oauth2/GoogleProvider.scala
+++ b/app/com/mohiva/play/silhouette/impl/providers/oauth2/GoogleProvider.scala
@@ -136,6 +136,6 @@ object GoogleProvider {
    * @return An instance of this provider.
    */
   def apply(httpLayer: HTTPLayer, stateProvider: OAuth2StateProvider, settings: OAuth2Settings) = {
-    new GoogleProvider(httpLayer, stateProvider, settings) with CommonSocialProfileBuilder[OAuth2Info]
+    new GoogleProvider(httpLayer, stateProvider, settings) with CommonSocialProfileBuilder
   }
 }

--- a/app/com/mohiva/play/silhouette/impl/providers/oauth2/InstagramProvider.scala
+++ b/app/com/mohiva/play/silhouette/impl/providers/oauth2/InstagramProvider.scala
@@ -122,6 +122,6 @@ object InstagramProvider {
    * @return An instance of this provider.
    */
   def apply(httpLayer: HTTPLayer, stateProvider: OAuth2StateProvider, settings: OAuth2Settings) = {
-    new InstagramProvider(httpLayer, stateProvider, settings) with CommonSocialProfileBuilder[OAuth2Info]
+    new InstagramProvider(httpLayer, stateProvider, settings) with CommonSocialProfileBuilder
   }
 }

--- a/app/com/mohiva/play/silhouette/impl/providers/oauth2/LinkedInProvider.scala
+++ b/app/com/mohiva/play/silhouette/impl/providers/oauth2/LinkedInProvider.scala
@@ -130,6 +130,6 @@ object LinkedInProvider {
    * @return An instance of this provider.
    */
   def apply(httpLayer: HTTPLayer, stateProvider: OAuth2StateProvider, settings: OAuth2Settings) = {
-    new LinkedInProvider(httpLayer, stateProvider, settings) with CommonSocialProfileBuilder[OAuth2Info]
+    new LinkedInProvider(httpLayer, stateProvider, settings) with CommonSocialProfileBuilder
   }
 }

--- a/app/com/mohiva/play/silhouette/impl/providers/oauth2/VKProvider.scala
+++ b/app/com/mohiva/play/silhouette/impl/providers/oauth2/VKProvider.scala
@@ -125,6 +125,6 @@ object VKProvider {
    * @return An instance of this provider.
    */
   def apply(httpLayer: HTTPLayer, stateProvider: OAuth2StateProvider, settings: OAuth2Settings) = {
-    new VKProvider(httpLayer, stateProvider, settings) with CommonSocialProfileBuilder[OAuth2Info]
+    new VKProvider(httpLayer, stateProvider, settings) with CommonSocialProfileBuilder
   }
 }

--- a/docs/how-it-works/providers.rst
+++ b/docs/how-it-works/providers.rst
@@ -122,18 +122,18 @@ provider to return our previous defined custom profile.
 
 .. code-block:: scala
 
-    trait CustomFacebookProfileBuilder extends SocialProfileBuilder[OAuth2Info] {
+    trait CustomFacebookProfileBuilder extends SocialProfileBuilder {
       self: FacebookProvider =>
 
       /**
        * Defines the profile to return by the provider.
        */
-      override type Profile = CustomSocialProfile
+      type Profile = CustomSocialProfile
 
       /**
        * Parses the profile from the Json response returned by the Facebook API.
        */
-      override protected def parseProfile(parser: JsonParser, json: JsValue): Try[Profile] = Try {
+      protected def parseProfile(parser: JsonParser, json: JsValue): Try[Profile] = Try {
         val commonProfile = parser(json)
         val gender = (json \ "gender").asOpt[String]
 

--- a/test/com/mohiva/play/silhouette/impl/providers/SocialProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/impl/providers/SocialProviderSpec.scala
@@ -36,9 +36,9 @@ abstract class SocialProviderSpec[A <: AuthInfo] extends PlaySpecification with 
    * @param b The matcher block to apply.
    * @return A specs2 match result.
    */
-  def result(providerResult: Future[AuthenticationResult])(b: Future[Result] => MatchResult[_]) = {
-    await(providerResult) must beLike[AuthenticationResult] {
-      case AuthenticationOngoing(result) => b(Future.successful(result))
+  def result(providerResult: Future[Either[Result, A]])(b: Future[Result] => MatchResult[_]) = {
+    await(providerResult) must beLeft[Result].like {
+      case result => b(Future.successful(result))
     }
   }
 
@@ -49,9 +49,9 @@ abstract class SocialProviderSpec[A <: AuthInfo] extends PlaySpecification with 
    * @param b The matcher block to apply.
    * @return A specs2 match result.
    */
-  def authInfo(providerResult: Future[AuthenticationResult])(b: A => MatchResult[_]) = {
-    await(providerResult) must beLike[AuthenticationResult] {
-      case r: AuthenticationCompleted[A] => b(r.authInfo)
+  def authInfo(providerResult: Future[Either[Result, A]])(b: A => MatchResult[_]) = {
+    await(providerResult) must beRight[A].like {
+      case authInfo => b(authInfo)
     }
   }
 

--- a/test/com/mohiva/play/silhouette/impl/providers/custom/FacebookProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/impl/providers/custom/FacebookProviderSpec.scala
@@ -188,11 +188,11 @@ class FacebookProviderSpec extends OAuth2ProviderSpec {
   /**
    * A custom Facebook profile builder for testing purpose.
    */
-  trait CustomFacebookProfileBuilder extends SocialProfileBuilder[OAuth2Info] {
+  trait CustomFacebookProfileBuilder extends SocialProfileBuilder {
     self: FacebookProvider =>
 
-    override type Profile = CustomSocialProfile
-    override protected def parseProfile(parser: Parser, json: JsValue): Try[Profile] = Try {
+    type Profile = CustomSocialProfile
+    protected def parseProfile(parser: Parser, json: JsValue): Try[Profile] = Try {
       val commonProfile = parser(json)
       val gender = (json \ "gender").as[String]
 


### PR DESCRIPTION
- Removes the generic type for the `AuthInfo` on the `SocialProvider` and define it with an abstract type. So it must only be defined on the abstract provider implementation and not on every concrete provider. Furthermore it's now easier to pattern match a SocialProvider.
- Switch back to `Either` as return type for the `authenticate` method. This is because of the fact that only two result types exists for this method. With the, in a previous release, introduced `AuthenticationResult` it must  always be checked for a third case in a pattern match. Otherwise the compiler will show a match error.
