### PR TITLE
Some authenticators cannot be discarded inside a Silhouette action

### DIFF
--- a/app/com/mohiva/play/silhouette/api/Authenticator.scala
+++ b/app/com/mohiva/play/silhouette/api/Authenticator.scala
@@ -19,6 +19,13 @@
  */
 package com.mohiva.play.silhouette.api
 
+import com.mohiva.play.silhouette.api.Authenticator.Discard
+import com.mohiva.play.silhouette.api.Authenticator.Renew
+import play.api.libs.concurrent.Execution.Implicits._
+import play.api.mvc.Result
+
+import scala.concurrent.Future
+
 /**
  * An authenticator tracks an authenticated user.
  */
@@ -37,6 +44,58 @@ trait Authenticator {
    * @return True if the authenticator isn't expired and isn't timed out.
    */
   def isValid: Boolean
+
+  /**
+   * Discards an authenticator.
+   *
+   * @param result The result to wrap into the [[com.mohiva.play.silhouette.api.Authenticator.Discard]] result.
+   * @return A [[com.mohiva.play.silhouette.api.Authenticator.Discard]] result.
+   */
+  def discard(result: Result): Result = new Discard(result)
+
+  /**
+   * Discards an authenticator.
+   *
+   * @param result The result to wrap into the [[com.mohiva.play.silhouette.api.Authenticator.Discard]] result.
+   * @return A [[com.mohiva.play.silhouette.api.Authenticator.Discard]] result.
+   */
+  def discard(result: Future[Result]): Future[Result] = result.map(r => discard(r))
+
+  /**
+   * Renews an authenticator.
+   *
+   * @param result The result to wrap into the [[com.mohiva.play.silhouette.api.Authenticator.Renew]] result.
+   * @return A [[com.mohiva.play.silhouette.api.Authenticator.Renew]] result.
+   */
+  def renew(result: Result): Result = new Renew(result)
+
+  /**
+   * Renews an authenticator.
+   *
+   * @param result The result to wrap into the [[com.mohiva.play.silhouette.api.Authenticator.Renew]] result.
+   * @return A [[com.mohiva.play.silhouette.api.Authenticator.Renew]] result.
+   */
+  def renew(result: Future[Result]): Future[Result] = result.map(r => renew(r))
+}
+
+/**
+ * The companion object.
+ */
+object Authenticator {
+
+  /**
+   * A marker result which indicates that an authenticator should be discarded.
+   *
+   * @param result The wrapped result.
+   */
+  class Discard(result: Result) extends Result(result.header, result.body, result.connection)
+
+  /**
+   * A marker result which indicates that an authenticator should be renewed.
+   *
+   * @param result The wrapped result.
+   */
+  class Renew(result: Result) extends Result(result.header, result.body, result.connection)
 }
 
 /**

--- a/app/com/mohiva/play/silhouette/api/services/AuthenticatorService.scala
+++ b/app/com/mohiva/play/silhouette/api/services/AuthenticatorService.scala
@@ -25,7 +25,7 @@ import play.api.mvc.{ Headers, RequestHeader, Result }
 import scala.concurrent.Future
 
 /**
- * The authenticator store is in charge of persisting authenticators for the Silhouette module.
+ * Handles authenticators for the Silhouette module.
  *
  * @tparam T The type of the authenticator this service is responsible for.
  */
@@ -86,19 +86,55 @@ trait AuthenticatorService[T <: Authenticator] {
    */
   def init(authenticator: T, request: RequestHeader): Future[RequestHeader]
 
+  ///////////////////////////////////////////////////////////////////////////////////////////////
+  //
+  // Internal API
+  //
+  // Due the fact that the update method gets called on every subsequent request to update the
+  // authenticator related data in the backing store and in the result, it isn't possible to
+  // discard or renew the authenticator simultaneously. This is because the "update" method would
+  // override the result created by the "renew" or "discard" method, because it will be executed
+  // as last in the chain.
+  //
+  // As example:
+  // If we discard the session in a Silhouette action then it will be removed from session. But
+  // at the end the update method will embed the session again, because it gets called with the
+  // result of the action.
+  //
+  // So we restrict the access to this methods and force the developer to use the "renew" and
+  // "discard" methods on the Authenticator instance. These methods wrap the result into a marker
+  // result, for which we can execute the appropriate method on this service.
+  //
+  ///////////////////////////////////////////////////////////////////////////////////////////////
+
   /**
-   * Updates authenticator specific data.
+   * Touches an authenticator.
+   *
+   * An authenticator can use sliding window expiration. This means that the authenticator times
+   * out after a certain time if it wasn't used. So to mark an authenticator as used it will be
+   * touched on every request to a Silhouette action. If an authenticator should not be touched
+   * because of the fact that sliding window expiration is disabled, then it should be returned
+   * on the right, otherwise it should be returned on the left. An untouched authenticator needn't
+   * be updated later by the [[update]] method.
+   *
+   * @param authenticator The authenticator to touch.
+   * @return The touched authenticator on the left or the untouched authenticator on the right.
+   */
+  protected[silhouette] def touch(authenticator: T): Either[T, T]
+
+  /**
+   * Updates a touched authenticator.
    *
    * If the authenticator was updated, then the updated artifacts should be embedded into the response.
-   * This method gets called on every subsequent request if an identity access a `SecuredAction` or
-   * a `UserAwareAction`.
+   * This method gets called on every subsequent request if an identity accesses a Silhouette action,
+   * expect the authenticator was not touched.
    *
    * @param authenticator The authenticator to update.
-   * @param result A function which gets the updated authenticator and returns the original or a manipulated result.
+   * @param result The result to manipulate.
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  def update(authenticator: T, result: T => Future[Result])(implicit request: RequestHeader): Future[Result]
+  protected[silhouette] def update(authenticator: T, result: Future[Result])(implicit request: RequestHeader): Future[Result]
 
   /**
    * Renews the expiration of an authenticator.
@@ -108,11 +144,11 @@ trait AuthenticatorService[T <: Authenticator] {
    * into the response.
    *
    * @param authenticator The authenticator to renew.
-   * @param result A function which gets the updated authenticator and returns the original or a manipulated result.
+   * @param result The result to manipulate.
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  def renew(authenticator: T, result: T => Future[Result])(implicit request: RequestHeader): Future[Result]
+  protected[silhouette] def renew(authenticator: T, result: Future[Result])(implicit request: RequestHeader): Future[Result]
 
   /**
    * Manipulates the response and removes authenticator specific artifacts before sending it to the client.
@@ -122,7 +158,7 @@ trait AuthenticatorService[T <: Authenticator] {
    * @param request The request header.
    * @return The manipulated result.
    */
-  def discard(authenticator: T, result: Future[Result])(implicit request: RequestHeader): Future[Result]
+  protected[silhouette] def discard(authenticator: T, result: Future[Result])(implicit request: RequestHeader): Future[Result]
 }
 
 /**

--- a/app/com/mohiva/play/silhouette/impl/authenticators/BearerTokenAuthenticator.scala
+++ b/app/com/mohiva/play/silhouette/impl/authenticators/BearerTokenAuthenticator.scala
@@ -89,8 +89,7 @@ class BearerTokenAuthenticatorService(
   settings: BearerTokenAuthenticatorSettings,
   dao: AuthenticatorDAO[BearerTokenAuthenticator],
   idGenerator: IDGenerator,
-  clock: Clock)
-  extends AuthenticatorService[BearerTokenAuthenticator] with Logger {
+  clock: Clock) extends AuthenticatorService[BearerTokenAuthenticator] with Logger {
 
   /**
    * Creates a new authenticator for the specified login info.
@@ -161,19 +160,38 @@ class BearerTokenAuthenticatorService(
   }
 
   /**
+   * @inheritdoc
+   *
+   * @param authenticator The authenticator to touch.
+   * @return The touched authenticator on the left or the untouched authenticator on the right.
+   */
+  protected[silhouette] def touch(
+    authenticator: BearerTokenAuthenticator): Either[BearerTokenAuthenticator, BearerTokenAuthenticator] = {
+
+    if (authenticator.idleTimeout.isDefined) {
+      Left(authenticator.copy(lastUsedDate = clock.now))
+    } else {
+      Right(authenticator)
+    }
+  }
+
+  /**
    * Updates the authenticator with the new last used date in the backing store.
    *
    * We needn't embed the token in the response here because the token itself will not be changed.
    * Only the authenticator in the backing store will be changed.
    *
    * @param authenticator The authenticator to update.
-   * @param result A function which gets the updated authenticator and returns the original result.
+   * @param result The result to manipulate.
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  def update(authenticator: BearerTokenAuthenticator, result: BearerTokenAuthenticator => Future[Result])(implicit request: RequestHeader) = {
-    dao.save(authenticator.copy(lastUsedDate = clock.now)).flatMap { a =>
-      result(a)
+  protected[silhouette] def update(
+    authenticator: BearerTokenAuthenticator,
+    result: Future[Result])(implicit request: RequestHeader) = {
+
+    dao.save(authenticator).flatMap { a =>
+      result
     }.recover {
       case e => throw new AuthenticationException(UpdateError.format(ID, authenticator), e)
     }
@@ -184,14 +202,17 @@ class BearerTokenAuthenticatorService(
    * that it isn't possible to use a bearer token which was bound to this authenticator.
    *
    * @param authenticator The authenticator to update.
-   * @param result A function which gets the updated authenticator and returns the original result.
+   * @param result The result to manipulate.
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  def renew(authenticator: BearerTokenAuthenticator, result: BearerTokenAuthenticator => Future[Result])(implicit request: RequestHeader) = {
+  protected[silhouette] def renew(
+    authenticator: BearerTokenAuthenticator,
+    result: Future[Result])(implicit request: RequestHeader) = {
+
     dao.remove(authenticator.id).flatMap { _ =>
       create(authenticator.loginInfo).flatMap { a =>
-        init(a, result(a))
+        init(a, result)
       }
     }.recover {
       case e => throw new AuthenticationException(RenewError.format(ID, authenticator), e)
@@ -205,7 +226,10 @@ class BearerTokenAuthenticatorService(
    * @param request The request header.
    * @return The manipulated result.
    */
-  def discard(authenticator: BearerTokenAuthenticator, result: Future[Result])(implicit request: RequestHeader) = {
+  protected[silhouette] def discard(
+    authenticator: BearerTokenAuthenticator,
+    result: Future[Result])(implicit request: RequestHeader) = {
+
     dao.remove(authenticator.id).flatMap { _ =>
       result
     }.recover {

--- a/docs/how-it-works/authenticator.rst
+++ b/docs/how-it-works/authenticator.rst
@@ -50,6 +50,19 @@ to the client. It may also be useful to embed the authenticator related data int
 request to lead the ``SecuredAction`` to believe that the request is a new request which
 contains a valid authenticator. This can be useful in Play filters.
 
+.. Attention::
+   The following actions are only used for internal purposes inside a :ref:`Silhouette
+   action <silhouette_actions>`. But it might be useful to know how an authenticator
+   will be handled.
+
+Touch an authenticator
+^^^^^^^^^^^^^^^^^^^^^^
+
+If an authenticator uses sliding window expiration then this method updates the last used
+time on the authenticator. So to mark an authenticator as used it will be touched on every
+request to a :ref:`Silhouette action <silhouette_actions>`. If sliding window expiration
+is disabled then the authenticator will not be updated.
+
 Update an authenticator
 ^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -67,6 +80,12 @@ the implementation, the renew method revokes the given authenticator first, befo
 a new one. If the authenticator was updated, then the updated artifacts will be embedded
 into the response.
 
+.. Note::
+   To renew an authenticator you must call the `renew` method of the authenticator instance
+   inside a :ref:`Silhouette action <silhouette_actions>`. This method accepts a `Result`
+   and returns a wrapped `Renew` result, which notifies the action to renew the
+   authenticator instead of updating it.
+
 Discard an authenticator
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -76,6 +95,11 @@ client side stored artifacts will be removed. If the service uses a backing stor
 authenticator will also be removed from it. To logout a user from a Silhouette application,
 the authenticator must also be discarded manually.
 
+.. Note::
+   To discard an authenticator you must call the `discard` method of the authenticator
+   instance inside a :ref:`Silhouette action <silhouette_actions>`. This method accepts a
+   `Result` and returns a wrapped `Discard` result, which notifies the action to discard
+   the authenticator instead of updating it.
 
 List of authenticators
 ----------------------

--- a/test/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticatorSpec.scala
+++ b/test/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticatorSpec.scala
@@ -15,17 +15,17 @@
  */
 package com.mohiva.play.silhouette.impl.authenticators
 
+import com.mohiva.play.silhouette.api.LoginInfo
 import com.mohiva.play.silhouette.api.exceptions.AuthenticationException
 import com.mohiva.play.silhouette.api.services.AuthenticatorService._
 import com.mohiva.play.silhouette.api.util.{ Clock, FingerprintGenerator, IDGenerator }
-import com.mohiva.play.silhouette.api.{ Authenticator, LoginInfo }
 import com.mohiva.play.silhouette.impl.authenticators.CookieAuthenticatorService._
 import com.mohiva.play.silhouette.impl.daos.AuthenticatorDAO
 import org.joda.time.DateTime
 import org.specs2.mock.Mockito
 import org.specs2.specification.Scope
 import play.api.mvc.{ Cookie, Results }
-import play.api.test.{ FakeRequest, PlaySpecification }
+import play.api.test.{ FakeRequest, PlaySpecification, WithApplication }
 
 import scala.concurrent.Future
 
@@ -283,39 +283,54 @@ class CookieAuthenticatorSpec extends PlaySpecification with Mockito {
     }
   }
 
+  "The `touch` method of the service" should {
+    "update the last used date if idle timeout is defined" in new WithApplication with Context {
+      settings.authenticatorIdleTimeout returns Some(1)
+      clock.now returns DateTime.now
+
+      service.touch(authenticator) must beLeft[CookieAuthenticator].like {
+        case a =>
+          a.lastUsedDate must be equalTo clock.now
+      }
+    }
+
+    "do not update the last used date if idle timeout is not defined" in new WithApplication with Context {
+      settings.authenticatorIdleTimeout returns None
+      clock.now returns DateTime.now
+
+      service.touch(authenticator) must beRight[CookieAuthenticator].like {
+        case a =>
+          a.lastUsedDate must be equalTo authenticator.lastUsedDate
+      }
+    }
+  }
+
   "The `update` method of the service" should {
     "update the authenticator in backing store" in new Context {
       dao.save(any) returns Future.successful(authenticator)
-      clock.now returns DateTime.now().plusHours(1)
 
       implicit val request = FakeRequest()
 
-      await(service.update(authenticator, _ => Future.successful(Results.Status(200))))
+      await(service.update(authenticator, Future.successful(Results.Ok)))
 
-      there was one(dao).save(authenticator.copy(lastUsedDate = clock.now))
+      there was one(dao).save(authenticator)
     }
 
     "return the result if the authenticator could be stored in backing store" in new Context {
       dao.save(any) answers { p => Future.successful(p.asInstanceOf[CookieAuthenticator]) }
-      clock.now returns DateTime.now().plusHours(1)
 
-      // In this case the result must be 0 because the backing store returns the updated
-      // authenticator and this returned authenticator doesn't equal the passed authenticator
-      // because the lastUsedDate was updated
       implicit val request = FakeRequest()
-      val updatedResult = (a: Authenticator) => Future.successful(Results.Status(if (a == authenticator) 1 else 0))
-      val result = service.update(authenticator, updatedResult)
+      val result = service.update(authenticator, Future.successful(Results.Ok))
 
-      status(result) must be equalTo 0
+      status(result) must be equalTo OK
     }
 
     "throws an Authentication exception if an error occurred during update" in new Context {
       dao.save(any) returns Future.failed(new Exception("Cannot store authenticator"))
 
       implicit val request = FakeRequest()
-      val okResult = (a: Authenticator) => Future.successful(Results.Status(200))
 
-      await(service.update(authenticator, okResult)) must throwA[AuthenticationException].like {
+      await(service.update(authenticator, Future.successful(Results.Ok))) must throwA[AuthenticationException].like {
         case e =>
           e.getMessage must startWith(UpdateError.format(ID, ""))
       }
@@ -333,7 +348,7 @@ class CookieAuthenticatorSpec extends PlaySpecification with Mockito {
       idGenerator.generate returns Future.successful(id)
       clock.now returns now
 
-      await(service.renew(authenticator, _ => Future.successful(Results.Status(200))))
+      await(service.renew(authenticator, Future.successful(Results.Ok)))
 
       there was one(dao).remove(authenticator.id)
     }
@@ -348,7 +363,7 @@ class CookieAuthenticatorSpec extends PlaySpecification with Mockito {
       idGenerator.generate returns Future.successful(id)
       clock.now returns now
 
-      val result = service.renew(authenticator, _ => Future.successful(Results.Status(200)))
+      val result = service.renew(authenticator, Future.successful(Results.Ok))
 
       cookies(result).get(settings.cookieName) should beSome[Cookie].which { c =>
         c.name must be equalTo settings.cookieName
@@ -364,7 +379,6 @@ class CookieAuthenticatorSpec extends PlaySpecification with Mockito {
 
     "throws an Authentication exception if an error occurred during renewal" in new Context {
       implicit val request = FakeRequest()
-      val okResult = (a: Authenticator) => Future.successful(Results.Status(200))
       val now = new DateTime
       val id = "new-test-id"
 
@@ -373,7 +387,7 @@ class CookieAuthenticatorSpec extends PlaySpecification with Mockito {
       idGenerator.generate returns Future.successful(id)
       clock.now returns now
 
-      await(service.renew(authenticator, okResult)) must throwA[AuthenticationException].like {
+      await(service.renew(authenticator, Future.successful(Results.Ok))) must throwA[AuthenticationException].like {
         case e =>
           e.getMessage must startWith(RenewError.format(ID, ""))
       }


### PR DESCRIPTION
Due the fact that the update method gets called on every subsequent request to update the authenticator related data in the backing store and in the result, it isn't possible to discard or renew the authenticator simultaneously. This is because the "update" method would override the result created by the "renew" or "discard" method, because it will be executed as last in the chain.

As example:
If we discard the session in a Silhouette action then it will be removed from session. But at the end the update method will embed the session again, because it gets called with the result of the action.

So we restrict the access to this methods and force the developer to use the "renew" and "discard" methods on the Authenticator instance. These methods wrap the result into a marker result, for which we can execute the appropriate method on this service.
