### PR TITLE
Documentation edits

### DIFF
--- a/docs/basics/contribute.rst
+++ b/docs/basics/contribute.rst
@@ -71,7 +71,7 @@ Help to improve the documentation
 Every software project is only as good as its documentation. So we do
 our best to cover all the code with a good structured, meaningful and
 up-to-date documentation. But like in the most open source projects,
-time is a precious commodity. So every help is appreciated to improve
+time is a precious commodity. We appreciate all help to improve
 the documentation.
 
 
@@ -81,7 +81,7 @@ Edit on GitHub
 For small typo changes the documentation can be edited directly on
 GitHub. This is very easy by following the "Edit on GitHub" button
 at the top of th page. After you have made your changes you can commit
-it with an meaningful commit message. It will then create automatically
+it with a meaningful commit message. It will then automatically create 
 a new pull request with your proposed changes.
 
 
@@ -89,7 +89,7 @@ Edit it locally
 ^^^^^^^^^^^^^^^
 
 The documentation is written in `RST`_ which can be rendered by `Sphinx`_
-into many output formats like HTML, PDF and `a lot more`_. To render
+into many output formats like HTML, PDF and `many more`_. To render
 the documentation into static HTML which looks the same as this
 documentation on `"Read the docs"`_, you must install Sphinx and the
 `"Read the Docs" theme`_.
@@ -109,12 +109,12 @@ HTML files by executing the following command in the ``docs`` directory.
 
     make html
 
-The documentation can now be found in the ``_build/html`` directory.
+The documentation can then be found in the ``_build/html`` directory.
 Browse the ``index.html`` with your favorite browser to view the changes.
 
 .. _RST: http://docutils.sourceforge.net/docs/user/rst/quickref.html
 .. _Sphinx: http://sphinx-doc.org/
-.. _a lot more: http://sphinx-doc.org/builders.html
+.. _many more: http://sphinx-doc.org/builders.html
 .. _"Read the docs": https://readthedocs.org/
 .. _"Read the Docs" theme: https://github.com/snide/sphinx_rtd_theme
 

--- a/docs/basics/examples.rst
+++ b/docs/basics/examples.rst
@@ -3,13 +3,13 @@
 Examples
 ========
 
-This page lists some examples which shows how Silhouette can be
-implemented.
+This page lists some examples which show how Silhouette can be
+used in various kinds of projects.
 
 **Silhouette Seed Template**
 
 The Silhouette Seed project is an Activator template which shows how
-Silhouette can be implemented in a Play Framework application. It’s a
+Silhouette can be used in a Play Framework application. It’s a
 starting point which can be extended to fit your needs.
 
 `Link <https://github.com/mohiva/play-silhouette-seed>`__
@@ -18,7 +18,7 @@ starting point which can be extended to fit your needs.
 
 **Silhouette Slick Seed Template**
 
-A fork of the Silhouette Seed project which implements Slick as database
+A fork of the Silhouette Seed project which uses Slick as database
 access library.
 
 `Link <https://github.com/sne11ius/play-silhouette-slick-seed>`__
@@ -36,7 +36,7 @@ for dependency injection.
 
 **Silhouette Rest Seed**
 
-Seed project for Play Framework with Silhouette, expose rest api for
+Seed project for Play Framework with Silhouette, exposing a rest api for
 signup and signin.
 
 `Link <https://github.com/merle-/silhouette-rest-seed>`__
@@ -47,7 +47,7 @@ signup and signin.
 
 Project for Play Framework with Silhouette, using a not strict implementation
 of Thin Cake Pattern and showing how to add an authentication and authorizaton
-layer. The project is splitted in two main subprojects: a public web page that
+layer. The project is split in two main subprojects: a public web page that
 uses a complete authentication layer (including sign up with email confirmation
 and reset passwords), and an administration web page that uses also a simple
 authorization layer based on roles.

--- a/docs/basics/features.rst
+++ b/docs/basics/features.rst
@@ -4,22 +4,22 @@ Features
 **Easy to integrate**
 
 Silhouette comes with an `Activator template`_ that gives you a complete
-sample application which is 100% customizable. You must only select the
-template ``play-silhouette-seed`` in your Activator UI. It was never
+sample application which is 100% customizable. Simply select the
+template ``play-silhouette-seed`` in your Activator UI. It has never
 been easier to start a new Silhouette application.
 
 **Authentication support**
 
 Out of the box support for leading social services such as Twitter,
-Facebook, Google, LinkedIn and GitHub. It also provides a credentials
-provider with supports local login functionality.
+Facebook, Google, LinkedIn and GitHub. Silhouette also includes a credentials
+provider that supports local login functionality.
 
 **Asynchronous, non-blocking operations**
 
 We follow the `Reactive Manifesto`_. This means that all requests and
-web service calls are asynchronous, non blocking operations. For the
+web service calls are asynchronous, non-blocking operations. For the
 event handling part of Silhouette we use `Akka’s Event Bus`_
-implementation. And lastly all persistence interfaces are defined to
+implementation. Lastly, all persistence interfaces are defined to
 return Scala Futures.
 
 **Very customizable, extendable and testable**
@@ -31,14 +31,14 @@ coupled design.
 
 **Internationalization support**
 
-Silhouette makes it very easy to internationalize your application by
-passing the Play Framework ``Request`` and ``Lang`` objects around, if
-internationalization comes into play.
+Silhouette makes it very easy to internationalize your application by 
+making the Play Framework's ``Request`` and ``Lang`` available where 
+they are needed.
 
 **Well tested** |Coverage Status|
 
 Silhouette is a security component which protects your users from being
-compromised by attackers. Therefore we try to cover the complete code
+compromised by attackers. Therefore we aim for complete code coverage
 with unit and integration tests.
 
 **Follows the OWASP Authentication Cheat Sheet**

--- a/docs/basics/help.rst
+++ b/docs/basics/help.rst
@@ -1,8 +1,8 @@
 Help
 ====
 
-If you need help with the integration of Silhouette into your project,
-don’t hesitate and ask questions in our `mailing list`_ or on `Stack
+If you need help with integrating Silhouette into your project,
+don’t hesitate to ask questions using our `mailing list`_ or on `Stack
 Overflow`_.
 
 .. _mailing list: https://groups.google.com/forum/#!forum/play-silhouette

--- a/docs/how-it-works/actions.rst
+++ b/docs/how-it-works/actions.rst
@@ -26,7 +26,7 @@ your code is invoked.
       }
     }
 
-There is also a ``UserAwareAction`` that can be used in actions that
+There is also a ``UserAwareAction`` that can be used for actions that
 need to know if there is a current user but can be executed even if
 there isn’t one.
 
@@ -49,13 +49,13 @@ there isn’t one.
       }
     }
 
-For not authenticated users you can implement a global or local fallback
+For unauthenticated users you can implement a global or local fallback
 action.
 
 Global Fallback
 ^^^^^^^^^^^^^^^
 
-You can implement the ``SecuredSettings`` trait into your ``Global``
+You can mix the ``SecuredSettings`` trait into your ``Global``
 object. This trait provides a method called ``onNotAuthenticated``. If
 you implement this method, then every time a user calls a restricted
 action, the result specified in the global fallback method will be
@@ -80,10 +80,10 @@ returned.
 Local Fallback
 ^^^^^^^^^^^^^^
 
-Every controller which is derived from ``Silhouette`` base controller
+Every controller which is derived from the ``Silhouette`` base controller
 has a method called ``notAuthenticated``. If you override these method,
 then you can return a not-authenticated result similar to the global
-fallback but only for these specific controller. The local fallback has
+fallback but only for this specific controller. The local fallback has
 precedence over the global fallback.
 
 .. code-block:: scala
@@ -112,7 +112,7 @@ precedence over the global fallback.
     }
 
 .. Note::
-   If you don’t implement one of the both fallback methods, a 401 response with a simple
+   If you don’t implement one or both of the fallback methods, a 401 response with a simple
    message will be displayed to the user.
 
 Adding Authorization
@@ -120,10 +120,10 @@ Adding Authorization
 
 Silhouette provides a way to add authorization logic to your controller
 actions. This is done by implementing an ``Authorization`` object that
-is passed to the ``SecuredAction`` as a parameter.
+is passed to ``SecuredAction`` as a parameter.
 
 After checking if a user is authenticated the ``Authorization`` instance
-is used to verify if the execution should be allowed or not.
+is used to verify whether the execution should be allowed or not.
 
 .. code-block:: scala
 
@@ -165,13 +165,13 @@ Here’s how you would use it:
         // do something here
     }
 
-For not authorized users you can implement a global or local fallback
-action similar to the fallback for not-authenticated users.
+For unauthorized users you can implement a global or local fallback
+action similar to the fallback for unauthenticated users.
 
 Global Fallback
 ^^^^^^^^^^^^^^^
 
-You can implement the ``SecuredSettings`` trait into your ``Global``
+You can mix the ``SecuredSettings`` trait into your ``Global``
 object. This trait provides a method called ``onNotAuthorized``. If you
 implement this method, then every time a user calls an action on which
 he isn’t authorized, the result specified in the global fallback method
@@ -199,7 +199,7 @@ Local Fallback
 Every controller which is derived from ``Silhouette`` base controller
 has a method called ``notAuthorized``. If you override these method,
 then you can return a not-authorized result similar to the global
-fallback but only for these specific controller. The local fallback has
+fallback but only for this specific controller. The local fallback has
 precedence over the global fallback.
 
 .. code-block:: scala
@@ -234,11 +234,10 @@ precedence over the global fallback.
 Handle Ajax requests
 --------------------
 
-If you send Ajax and normal requests to your Play app, then you should
-tell your app that it should handle Ajax requests differently, so that
-it can respond with a JSON result, for example. There are two different
-methods to achieve this. The first method uses a non-standard HTTP
-request header. Then on the Play side you can check for this header and
+Applications that accept both Ajax and normal requests should likely provide
+a JSON result to the first and a different result to others. There are two different
+approaches to achieve this. The first approach uses a non-standard HTTP
+request header. The Play application can check for this header and
 respond with a suitable result. The second approach uses `Content
 negotiation`_ to serve different versions of a document based on the
 ``ACCEPT`` request header.
@@ -247,7 +246,7 @@ Non-standard header
 ^^^^^^^^^^^^^^^^^^^
 
 The example below uses a non-standard HTTP request header inside a
-secured action and inside a fallback method for non-authenticated users.
+secured action and inside a fallback method for unauthenticated users.
 
 **The JavaScript part with JQuery**
 
@@ -258,7 +257,7 @@ secured action and inside a fallback method for non-authenticated users.
         ...
     });
 
-**The Play part with a local fallback method for not-authenticated users**
+**The Play part with a local fallback method for unauthenticated users**
 
 .. code-block:: scala
 
@@ -305,7 +304,7 @@ implemented, Silhouette responds with the appropriate response based on
 the ``ACCEPT`` header defined by the user agent. The response format
 will default to plain text in case the request does not match one of the
 known media types. The example below uses content negotiation inside a
-secured action and inside a fallback method for not-authenticated users.
+secured action and inside a fallback method for unauthenticated users.
 
 **The JavaScript part with JQuery**
 
@@ -319,7 +318,7 @@ secured action and inside a fallback method for not-authenticated users.
         ...
     })
 
-**The Play part with a local fallback method for not-authenticated users**
+**The Play part with a local fallback method for unauthenticated users**
 
 .. code-block:: scala
 

--- a/docs/how-it-works/authenticator.rst
+++ b/docs/how-it-works/authenticator.rst
@@ -12,10 +12,10 @@ for an identity.
 
 .. _authenticator_service_impl:
 
-Authenticator service
+Authenticator Service
 ---------------------
 
-To every Authenticator pertains an associated service which handles this authenticator.
+Every Authenticator has an associated Authenticator Service which handles that kind of authenticator.
 This service is responsible for the following actions:
 
 Create an authenticator
@@ -28,9 +28,9 @@ used to track the user on every subsequent request.
 Retrieve an authenticator
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Based on the authenticator a service is responsible for, it checks the incoming request
-for an existing authenticator artifact. This artifact can be embedded in every part(user
-session, cookie, user defined header field, request param) of an incoming HTTP request. Some
+An authenticator service is used to check an incoming request for an existing instance of
+its authenticator. An authenticator can be embedded in any part of the incoming HTTP request 
+(user session, cookie, user defined header field, request param). Some
 services can validate a retrieved authenticator, based on its ID, against a backing store.
 Silhouette automatically tries to retrieve an authenticator on every request to a
 :ref:`Silhouette action <silhouette_actions>`.
@@ -38,43 +38,42 @@ Silhouette automatically tries to retrieve an authenticator on every request to 
 Init an authenticator
 ^^^^^^^^^^^^^^^^^^^^^
 
-The initialization of an authenticator means, that all authenticator artifacts will be
+Authentictors need to be initialized, usually when they are created during a successful
+authentication. Initializing an authenticator causes it to be
 embedded into a Play framework request or result. This can by done by creating a cookie,
-storing data into the user session or sending the artifacts in a user defined header. If
+storing data into the user session or including the authenticator in a user defined header. If
 the service uses a backing store, then the authenticator instance will be stored in it.
-The initialization should be done after a successful authentication with a new created
-authenticator.
 
-Embedding the authenticator related data into the result means that the data will be send
+Embedding the authenticator related data into the result means that the data will be sent
 to the client. It may also be useful to embed the authenticator related data into an incoming
 request to lead the ``SecuredAction`` to believe that the request is a new request which
-contains a valid authenticator. This can be useful in Play filters.
+contains a valid authenticator. This typically done in a Play filter.
 
 .. Attention::
    The following actions are only used for internal purposes inside a :ref:`Silhouette
-   action <silhouette_actions>`. But it might be useful to know how an authenticator
-   will be handled.
+   action <silhouette_actions>`. It's provided here as background information and for
+   advanced users.
 
 Touch an authenticator
 ^^^^^^^^^^^^^^^^^^^^^^
 
-If an authenticator uses sliding window expiration then this method updates the last used
-time on the authenticator. So to mark an authenticator as used it will be touched on every
-request to a :ref:`Silhouette action <silhouette_actions>`. If sliding window expiration
-is disabled then the authenticator will not be updated.
+For authenticators that use a sliding window expiration, calling ``touch`` causes
+the last used time to be updated upon each request to a :ref:`Silhouette action 
+<silhouette_actions>`. Such updates are not needed for authenticators that do not use
+a sliding window expiration.
 
 Update an authenticator
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 Automatically updates the state of an authenticator on every request to a :ref:`Silhouette
-action <silhouette_actions>`. Updated authenticator artifacts will be embed into the Play
-framework result, before sending it to the client. If the service uses a backing store, then
-the authenticator instance will be updated in the store too.
+action <silhouette_actions>`. Updated authenticators will be embedded into the Play
+framework result before sending it to the client. If the service uses a backing store, then
+the authenticator instance will be updated in the store, too.
 
 Renew an authenticator
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Authenticators have a fix expiration date. So with this method it's possible to renew the
+Authenticators have a fix expiration date. With this method it's possible to renew the
 expiration of an authenticator by discarding the old one and creating a new one. Based on
 the implementation, the renew method revokes the given authenticator first, before creating
 a new one. If the authenticator was updated, then the updated artifacts will be embedded
@@ -89,11 +88,13 @@ into the response.
 Discard an authenticator
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-If an authenticator is invalid then Silhouette automatically discards an authenticator on
-every request to a :ref:`Silhouette action <silhouette_actions>`. Discarding means that all
+Every request to a :ref:`Silhouette action <silhouette_actions>` causes invalid authenticators 
+to be automatically discarded.
+Discarding means that all
 client side stored artifacts will be removed. If the service uses a backing store, then the
-authenticator will also be removed from it. To logout a user from a Silhouette application,
-the authenticator must also be discarded manually.
+authenticator will also be removed from it. 
+
+Logging a user out of a Silhouette application requires explicitly discarding the authenticator.
 
 .. Note::
    To discard an authenticator you must call the `discard` method of the authenticator
@@ -104,12 +105,12 @@ the authenticator must also be discarded manually.
 List of authenticators
 ----------------------
 
-We have put a great effort to build a whole set of stateless as well as stateful `authenticator
-implementations`_, which cover the most use cases. Now it's up to you to decide which
+Silhouette comes with a set of stateless as well as stateful `authenticator
+implementations`_ that cover most use cases. It's up to you to decide which
 authenticator fits best into your application architecture.
 
 .. Hint::
-   A good decision aid can give you the blog posts `Cookies vs Tokens. Getting auth right with
+   Good decision aids can be found in the blog posts `Cookies vs Tokens. Getting auth right with
    Angular.JS`_ and `10 Things You Should Know about Tokens`_ from Auth0.
 
 .. _Cookies vs Tokens. Getting auth right with Angular.JS: https://auth0.com/blog/2014/01/07/angularjs-authentication-with-cookies-vs-token/
@@ -119,15 +120,15 @@ authenticator fits best into your application architecture.
 CookieAuthenticator
 ^^^^^^^^^^^^^^^^^^^
 
-An authenticator that uses a stateful, cookie based approach. It works by storing the unique
+An authenticator that uses a stateful, cookie-based approach. It works by storing the unique
 ID of the authenticator in a cookie. This ID gets then mapped to an authenticator instance
-in the server side backing store. This approach can also be named "server side session".
+in the server side backing store. This approach could also be named "server side session".
 
-The authenticator can use sliding window expiration. This means that the authenticator times
-out after a certain time if it wasn't used. This can be controlled with the :ref:`authenticatorIdleTimeout
+The authenticator can use a sliding window expiration. This means that the authenticator times
+out after a certain time if it hasn't been used. This can be controlled with the :ref:`authenticatorIdleTimeout
 <cookie_authenticator_settings>` property of the settings class.
 
-**Pro**
+**Pros**
 
 * Small network throughput on client side
 * Ideal for traditional browser based websites
@@ -139,7 +140,7 @@ out after a certain time if it wasn't used. This can be controlled with the :ref
 * Not stateless (needs a synchronized backing store)
 * Less than ideal for mobile or single page apps
 * Can be vulnerable for `CSRF`_ attacks
-* Plays not well with `CORS`_
+* Does not play well with `CORS`_
 
 .. Tip::
    Please take a look on the :ref:`configuration settings <cookie_authenticator_settings>`, on
@@ -148,14 +149,14 @@ out after a certain time if it wasn't used. This can be controlled with the :ref
 SessionAuthenticator
 ^^^^^^^^^^^^^^^^^^^^
 
-An authenticator that uses a stateless, session based approach. It works by storing a serialized
+An authenticator that uses a stateless, session-based approach. It works by storing a serialized
 authenticator instance in the Play Framework session cookie.
 
-The authenticator can use sliding window expiration. This means that the authenticator times
-out after a certain time if it wasn't used. This can be controlled with the :ref:`authenticatorIdleTimeout
-<session_authenticator_settings>` property of the settings class.
+The authenticator can use a sliding window expiration. This means that the authenticator times
+out after a certain time if it hasn't been used. This can be controlled with the :ref:`authenticatorIdleTimeout
+<sessoion_authenticator_settings>` property of the settings class.
 
-**Pro**
+**Pros**
 
 * No network throughput on the server side
 * Ideal for traditional browser based websites
@@ -167,7 +168,7 @@ out after a certain time if it wasn't used. This can be controlled with the :ref
 * Larger network throughput on client side
 * Less than ideal for mobile or single page apps
 * Can be vulnerable for `CSRF`_ attacks
-* Plays not well with `CORS`_
+* Does not play well with `CORS`_
 
 .. Tip::
    Please take a look on the :ref:`configuration settings <session_authenticator_settings>`, on
@@ -176,15 +177,15 @@ out after a certain time if it wasn't used. This can be controlled with the :ref
 BearerTokenAuthenticator
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-An authenticator that uses a header based approach with the help of a bearer token. It works by
+An authenticator that uses a header-based approach with the help of a bearer token. It works by
 transporting a token in a user defined header to track the authenticated user and a server side
 backing store that maps the token to an authenticator instance.
 
-The authenticator can use sliding window expiration. This means that the authenticator times out
-after a certain time if it wasn't used. This can be controlled with the :ref:`authenticatorIdleTimeout
+The authenticator can use a sliding window expiration. This means that the authenticator times
+out after a certain time if it hasn't been used. This can be controlled with the :ref:`authenticatorIdleTimeout
 <bearer_token_authenticator_settings>` property of the settings class.
 
-**Pro**
+**Pros**
 
 * Small network throughput on client side
 * Ideal for mobile or single page apps
@@ -205,16 +206,16 @@ after a certain time if it wasn't used. This can be controlled with the :ref:`au
 JWTAuthenticator
 ^^^^^^^^^^^^^^^^
 
-An authenticator that uses a header based approach with the help of a `JWT`_. It works by using a
+An authenticator that uses a header-based approach with the help of a `JWT`_ (JSON Web Token). It works by using a
 JWT to transport the authenticator data inside a user defined header. It can be stateless with the
 disadvantages that the JWT can't be invalidated.
 
-The authenticator can use sliding window expiration. This means that the authenticator times out
-after a certain time if it wasn't used. This can be controlled with the :ref:`authenticatorIdleTimeout
+The authenticator can use a sliding window expiration. This means that the authenticator times
+out after a certain time if it hasn't been used. This can be controlled with the :ref:`authenticatorIdleTimeout
 <jwt_authenticator_settings>` property of the settings class. If this feature is activated then a
 new token will be generated on every update. Make sure your application can handle this case.
 
-**Pro**
+**Pros**
 
 * Ideal for mobile or single page apps
 * Can be stateless (with the disadvantages it can't be invalidated)

--- a/docs/how-it-works/caching.rst
+++ b/docs/how-it-works/caching.rst
@@ -1,31 +1,30 @@
 Caching
 =======
 
-Silhouette caches some authentication artifacts. So here you can find
-some information on how you can configure or implement caching in a way
-that fits into your application architecture.
+Silhouette caches some authentication artifacts. Here are some suggestions
+on configuring or implementing caching in your application architecture
+so that Silhouette can also use it.
 
 
 Implement caching
 -----------------
 
-By default, Play gets shipped with `EHCache`_, which is configured as a
-lightweight, in-memory cache. Is this not enough for your application
-architecture, then there exists two possibilities to use another cache
-with Silhouette.
+By default, Play is shipped with `EHCache`_, a
+lightweight, in-memory cache. If this is not enough for your application
+architecture, there are at least two other caching options to use with Silhouette.
 
 
 Use another Play cache plugin
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Play has its own cache plugin architecture. So the easiest way is to use
+Play has its own cache plugin architecture. So the easiest approach is to use
 another cache plugin for Play. You can then use the `PlayCacheLayer`_
-implementation and plug in a new cache into your application.
+implementation and plug a new cache into your application.
 
 .. _PlayCacheLayer: https://github.com/mohiva/play-silhouette/blob/master/app/com/mohiva/play/silhouette/impl/util/PlayCacheLayer.scala
 
 
-Implement own cache layer
+Implement your own cache layer
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Silhouette provides a `CacheLayer`_ trait which can be used to create a
@@ -45,13 +44,14 @@ artifacts must be synchronized between instances.
 Development mode
 ----------------
 
-When using the default Play cache in development mode, then the cache gets
-cleaned after every app reload. This is because, by default, the `EHCache`_
-(the cache used by Play) is configured to store the data only im memory.
+When using the default Play cache in development mode, the cache will be
+cleaned after every app reload. This is because Play's cache (`EHCache`_)
+is configured to store the data only im memory by default.
 This can be changed by overriding the shipped ``ehcache.xml`` from the
-jars, to persist the cache on the disk.
+jars to persist the cache on the disk.
 
-To change this default behaviour you must copy the ``ehcache.xml`` to your
+To change the default behaviour you must copy the ``ehcache.xml`` from the
+distribution jars to your
 configuration directory. Then add ``<diskStore path="java.io.tmpdir"/>`` and
 change ``diskPersistent`` to ``true``. The following example shows a possible
 configuration. Adapt it to fit your needs.

--- a/docs/how-it-works/environment.rst
+++ b/docs/how-it-works/environment.rst
@@ -1,8 +1,8 @@
 Environment
 ===========
 
-The environment defines the key components which are needed by a Silhouette application.
-This components consists of
+The environment defines the key components needed by a Silhouette application.
+It consists of
 the :ref:`identity implementation <identity_impl>`,
 the :ref:`authenticator implementation <authenticator_impl>`,
 the :ref:`identity service implementation <identity_service_impl>`,
@@ -11,9 +11,8 @@ the :ref:`provider implementation <provider_impl>` and
 the :ref:`event bus implementation <event_bus_impl>`.
 
 A configured environment is needed in every derived `Silhouette controller`_ implementation
-and it should be provided through dependency injection. Regardless of whether compile time
-or runtime dependency injection is preferred, Silhouette plays well with both of them. You
-can find an example of both, runtime or compile time dependency injection on the
-:ref:`example page <examples>`.
+and should be provided through dependency injection. Silhouette plays well with both compile time
+and runtime dependency injection. You can find examples of both approaches
+on the :ref:`example page <examples>`.
 
 .. _Silhouette controller: https://github.com/mohiva/play-silhouette/blob/master/app/com/mohiva/play/silhouette/api/Silhouette.scala

--- a/docs/how-it-works/error-handling.rst
+++ b/docs/how-it-works/error-handling.rst
@@ -7,23 +7,23 @@ Every provider implementation in Silhouette throws either an
 credentials or a social provider denies an authentication attempt. In
 any other case the ``AuthenticationException`` will be thrown.
 
-Due the asynchronous nature of Silhouette, all exceptions will be throw
+Due to the asynchronous nature of Silhouette, all exceptions will be thrown
 in Futures. This means that exceptions may not be caught in a
 ``try catch`` block because Futures may be executed in separate Threads.
-To solve this problem, Futures have its own error handling mechanism.
+To solve this problem, Futures have their own error handling mechanism.
 They can be recovered from an error state into desirable state with the
-help of the ``recover`` and ``recoverWith`` methods. These both methods
-accepts an partial function which transforms the ``Exception`` into any
-other type. For more information please visit the `documentation`_ of
-the ``Future`` trait.
+help of the ``recover`` and ``recoverWith`` methods. Both methods
+accept a partial function which transforms the ``Exception`` into any
+other type. For more information please visit the ``Future`` trait's 
+`documentation`_.
 
 All controller implementations which are derived from the ``Silhouette``
-base controller, can make the usage of the ``exceptionHandler`` method.
+base controller can use the ``exceptionHandler`` method.
 This is a default recover implementation which transforms an
 ``AccessDeniedException`` into a 403 Forbidden result and an
 ``AuthenticationException`` into a 401 Unauthorized result. The
 following code snippet shows how an error can be recovered from a failed
-authentication try.
+authentication.
 
 .. code-block:: scala
 

--- a/docs/how-it-works/events.rst
+++ b/docs/how-it-works/events.rst
@@ -5,7 +5,7 @@ Events
 
 Silhouette provides event handling based on `Akka’s Event Bus`_. The
 following events are provided by Silhouette, although only the three
-marked of them are fired from core.
+marked events are fired from core.
 
 * SignUpEvent
 * LoginEvent
@@ -15,7 +15,7 @@ marked of them are fired from core.
 * NotAuthenticatedEvent \*
 * NotAuthorizedEvent \*
 
-It is very easy to propagate own events over the event bus by
+It is very easy to propagate your own events over the event bus by
 implementing the ``SilhouetteEvent`` trait.
 
 .. code-block:: scala
@@ -25,11 +25,11 @@ implementing the ``SilhouetteEvent`` trait.
 Use the event bus
 -----------------
 
-The event bus is available in every Silhouette controller over the
+The event bus is available in every Silhouette controller using the
 environment variable ``env.eventBus``. You can also inject the event bus
-into other classes like services or DAOs. You must only take care that
-you use the same event bus. There exists a singleton event bus by
-calling ``EventBus()``.
+into other classes like services or DAOs. 
+``EventBus()`` is a singleton you can call to ensure that you always use
+the same event bus.
 
 Listen for events
 -----------------

--- a/docs/how-it-works/identity.rst
+++ b/docs/how-it-works/identity.rst
@@ -4,9 +4,10 @@ Identity
 ========
 
 Silhouette defines a user through its ``Identity`` trait. This trait
-doesn’t define any defaults expect the :ref:`login-info`
+doesn’t define any defaults except the :ref:`login-info`
 which contains the data about the provider that authenticated that
 identity. This login information must be stored with the identity.
+
 If the application supports the concept of “merged identities”, i.e.,
 the same user being able to authenticate through different providers,
 then make sure that the login information gets stored separately. Later
@@ -15,10 +16,9 @@ you can see how this can be implemented.
 Implement an identity
 ---------------------
 
-As pointed out in the introduction of this chapter a user is an
-representation of an ``Identity``. So to define a user you must create a
-class that extends the ``Identity`` trait. Your user can contain any
-information. There are no restrictions how a user must be constructed.
+To define a user for your application, create a class that extends the
+``Identity`` trait. Your user class may contain any information, without
+restriction.
 
 Below we define a simple user with a unique ID, the login information for
 the provider which authenticates that user and some basic information like
@@ -38,11 +38,10 @@ name and email.
 Login information
 ^^^^^^^^^^^^^^^^^
 
-Contains the data about the provider that authenticated an identity.
-This information is mostly public available and it simply consists of a
-unique provider ID and a unique key which identifies a user on this
-provider (userID, email, …). This information will be represented by the
-`LoginInfo`_ trait.
+The `LoginInfo`_ trait contains the data about the provider that authenticated an identity.
+This information is mostly publicly available and it simply consists of a
+unique provider ID and a unique key which identifies a user to this
+provider (userID, email, …). 
 
 .. _LoginInfo: https://github.com/mohiva/play-silhouette/blob/master/app/com/mohiva/play/silhouette/api/Identity.scala#L45
 
@@ -53,15 +52,15 @@ The identity service
 
 Silhouette relies on an implementation of ``IdentityService`` to handle
 all the operations related to retrieving identities. Using this
-delegation model you are not forced to use a particular model object or
-a persistence mechanism but rather provide a service that translates
+delegation model means you are not forced to use a particular model object or
+persistence mechanism. Instead, you provide a service that translates
 back and forth between your models and what Silhouette understands.
 
 The ``IdentityService`` defines a raw type which must be derived from
 ``Identity``. This has the advantage that your service implementation
-returns always your implemented ``Identity``.
+returns always your implemention of ``Identity``.
 
-Let’s illustrate how a user defined implementation can look like:
+Here's a sample implementation:
 
 .. code-block:: scala
 
@@ -83,7 +82,7 @@ Link an identity to multiple login information
 ----------------------------------------------
 
 Silhouette doesn’t provide built-in functionality to link multiple
-login information to a single user, but it makes this task very easy
+identities to a single user, but it makes this task very easy
 by providing the basics. In the abstract this task can be done by
 linking the different login information returned by each provider,
 with a single user identified by an unique ID. The unique user will

--- a/docs/how-it-works/logging.rst
+++ b/docs/how-it-works/logging.rst
@@ -1,9 +1,8 @@
 Logging
 =======
 
-Silhouette uses named loggers for logging. So in your application you
-have a more fine-grained control over the log entries logged by
-Silhouette.
+Silhouette uses named loggers for logging. This gives your application 
+fine-grained control over the log entries logged by Silhouette.
 
 Configure logging
 -----------------
@@ -32,7 +31,7 @@ detailed level for some components.
 Use the logger
 --------------
 
-To use the named logger you must only implement the ``Logger`` trait into your
+To use the named logger you only need to mix the ``Logger`` trait into your
 class or trait. Then you can use the ``logger`` property to access the `Play
 logging API`_.
 

--- a/docs/how-it-works/providers.rst
+++ b/docs/how-it-works/providers.rst
@@ -11,15 +11,16 @@ information about an identity.
 Credentials provider
 --------------------
 
-Silhouette supports local form authentication with the credentials provider.
+Silhouette supports local authentication, typically via an HTML form, 
+with the credentials provider.
 This provider accepts credentials and returns the login information for an
-identity after a successful authentication. Typically credentials consists
-of an identifier(a username or email address) and a password.
+identity after a successful authentication. Typically credentials consist
+of an identifier (a username or email address) and a password.
 
-The provider supports the change of password hashing algorithms on the
+The credentials provider supports changing the password hashing algorithm on the
 fly. Sometimes it may be possible to change the hashing algorithm used
 by the application. But the hashes stored in the backing store can’t be
-converted back into plain text passwords, to hash them again with the
+converted back into plain text passwords to hash them again with the
 new algorithm. So if a user successfully authenticates after the
 application has changed the hashing algorithm, the provider hashes the
 entered password again with the new algorithm and stores the
@@ -29,7 +30,7 @@ authentication info in the backing store.
 Social providers
 ----------------
 
-A social provider allows an identity to authenticate it on your website
+A social provider allows a user to authenticate an identity on your website
 with an existing account from an external social website like Facebook,
 Google or Twitter. Following you can find a list of all supported
 providers grouped by authentication protocol.
@@ -58,51 +59,45 @@ Social profile
 
 The social profile contains the profile data returned from the social providers.
 Silhouette provides a default social profile called `CommonSocialProfile`_,
-which contains the most common profile data a provider can return. But it is also
-possible to define an own social profile which can be consists of more
-data.
+which contains the most common profile data providers return. 
 
 .. _CommonSocialProfile: https://github.com/mohiva/play-silhouette/blob/master/app/com/mohiva/play/silhouette/impl/providers/SocialProvider.scala#L168
 
 Social profile builders
 -----------------------
 
-It can be the case that more than the common profile information
-supported by Silhouette should be returned from a social provider.
-Additional profile information could be, as example, the location or the
-gender of a user. To solve this issue Silhouette has a very neat
-solution called “profile builders”. The advantage of this solution is
-that it prevents a developer to duplicate existing code by overriding
-the providers to return the additional profile information. Instead the
-developer can mixin a profile builder which adds only the programming
-logic for the additional fields.
+Some providers return a superset of the information in `CommonSocialProfile`_,
+for example the location or gender of the user. Silouette's “profile builders”
+allow you to construct custom profiles without duplicating existing code. Instead
+of overriding the provider to return the additional profile information, developers
+can mix in a profile builder which adds only the programming logic for the additional
+fields.
 
 The default social profile builder
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Silhouette ships with a built-in profile builder called
-``CommonSocialProfileBuilder`` which returns the ``CommonSocialProfile``
-object after successful authentication. This profile builder is mixed
-into all provider implementations by instantiating it with their
-companion objects. So instead of instantiating the provider with the new
-keyword, you must call the apply method on its companion object.
+All provider implementations are abstract because a profile builder must be
+specified before an object can be instantiated. Silhouette ships with a 
+default profile builder, ``CommonSocialProfileBuilder``, which returns a 
+``CommonSocialProfile`` after successful authentication. However, it can't
+be mixed into the provider by default because Scala doesn't allow us to override
+a concrete type with a different concrete type. That is, mixing in a default builder
+would prevent customization.
+
+Silhouette handles this problem by leaving the provider class abstract but making the 
+companion object's ``apply`` method handle the most common case -- 
+instantiating a provider with a ``CommonSocialProfileBuilder``. So in most
+cases you should simply call the apply method and instead of using the ``new`` keyword:
 
 .. code-block:: scala
 
     FacebookProvider(httpLayer, stateProvider, settings)
 
-.. Hint::
-   All provider implementations are abstract, so they cannot be
-   instantiated without a profile builder. This is because of the fact that
-   a concrete type in Scala cannot be overridden by a different concrete
-   type. And therefore we cannot mixin the common profile builder by
-   default, because it couldn’t be overridden by a custom profile builder.
-
 Write a custom social profile builder
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 As noted above it is very easy to write your own profile builder
-implementations. Lets take a look on the following code examples. The
+implementations. Let's take a look on the following code examples. The
 first one defines a custom social profile that differs from the common
 social profile by the additional gender field.
 
@@ -118,7 +113,7 @@ social profile by the additional gender field.
       gender: Option[String] = None) extends SocialProfile
 
 Now we create a profile builder which can be mixed into the Facebook
-provider to return our previous defined custom profile.
+provider to return our previously defined custom profile.
 
 .. code-block:: scala
 
@@ -163,8 +158,8 @@ provider with the profile builder.
 OAuth2 state
 ------------
 
-The OAuth2 protocol supports the `state parameter`_, that a client can be include in the request
-and the server returns as a parameter unmodified in the response. This parameter `should be used mainly`_
+The OAuth2 protocol supports the `state parameter`_, a value the client can include in the request
+and that the server returns as a parameter unmodified in the response. This parameter `should be used mainly`_
 to protect an application against `CSRF attacks`_. But it can also be used to remember some
 state about the user.
 
@@ -179,8 +174,8 @@ provider. All state provider implementations can be found in the `impl package`_
 List of OAuth2 states
 ^^^^^^^^^^^^^^^^^^^^^
 
-We provide some built in states, but as noted above an own state can be implemented to remember
-some state about a user.
+We provide some built in state providers, but as noted above a customized 
+state can be implemented to remember some state about a user.
 
 CookieState
 '''''''''''
@@ -197,11 +192,14 @@ from the `OAuth2 RFC`_ and it provides a stateless/scalable approach.
 Authentication information
 --------------------------
 
-The authentication information contains secure data like access tokens, hashed passwords and so on, which
-should never be exposed to the public. To retrieve other than by Silhouette supported information from a
-provider, try to connect again with this information and fetch the missing data.
+The `AuthInfo`_ implementation contains authentication information such 
+as access tokens, hashed passwords, and so on -- which
+should never be exposed to the public. Each provider defines its own 
+`AuthInfo`_ implementation.
 
-Due its nature, the information will be represented by different implementations. Mostly every provider
-implementation defines its own `AuthInfo`_ implementation.
+As with other Silhouette structures that vary in their implementation,
+`AuthInfo`_ is managed by a `AuthInfoService`_ that saves and retrieves
+the information as needed.  
 
-.. _AuthInfo: https://github.com/mohiva/play-silhouette/blob/master/app/com/mohiva/play/silhouette/api/services/AuthInfoService.scala#L60
+.. _AuthInfoService: https://github.com/mohiva/play-silhouette/blob/master/app/com/mohiva/play/silhouette/api/services/AuthInfoService.scala#L31
+.. _AuthInfo: https://github.com/mohiva/play-silhouette/blob/master/app/com/mohiva/play/silhouette/api/services/AuthInfoService.scala#L61

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,8 +8,8 @@ Welcome to Silhouette's documentation!
        development. Were you looking for version |last_stable| documentation?
 
 **Silhouette** is an authentication library for Play Framework
-applications that supports several authentication methods, including
-OAuth1, OAuth2, OpenID, Credentials or custom authentication schemes.
+applications. It supports several authentication methods, including
+OAuth1, OAuth2, OpenID, Credentials, and custom authentication schemes.
 
 It can be integrated as is, or used as a building block and customized
 to meet specific application requirements, thanks to its loosely coupled

--- a/site/index.md
+++ b/site/index.md
@@ -16,15 +16,17 @@ The project is named after the fictional crime fighter character [Silhouette](ht
 
 #### Easy to integrate
 
-Silhouette comes with an [Activator template](https://github.com/mohiva/play-silhouette-seed) that gives you a complete sample application which is 100% customizable. You must only select the template `play-silhouette-seed` in your Activator UI. It was never been easier to start a new Silhouette application.
+Silhouette comes with an [Activator template](https://github.com/mohiva/play-silhouette-seed) that gives you a complete sample application which is 100% customizable. Simply select the
+template `play-silhouette-seed` in your Activator UI. It has never been easier to start a new Silhouette application.
 
 #### Authentication support
 
-Out of the box support for leading social services such as Twitter, Facebook, Google, LinkedIn and GitHub. It also provides a credentials provider with supports local login functionality.
+Out of the box support for leading social services such as Twitter, Facebook, Google, LinkedIn and GitHub. Silhouette also includes a credentials provider that supports local login functionality.
 
 #### Asynchronous, non-blocking operations
 
-We follow the [Reactive Manifesto](http://www.reactivemanifesto.org/). This means that all requests and web service calls are asynchronous, non blocking operations. For the event handling part of Silhouette we use [Akka's Event Bus](http://doc.akka.io/docs/akka/2.2.4/scala/event-bus.html) implementation. And lastly all persistence interfaces are defined to return Scala Futures.
+We follow the [Reactive Manifesto](http://www.reactivemanifesto.org/). This means that all requests and web service calls are asynchronous, non-blocking operations. For the event handling part of Silhouette we use [Akka's Event Bus](http://doc.akka.io/docs/akka/2.2.4/scala/event-bus.html) implementation. Lastly, all persistence interfaces are defined to return Scala Futures.
+
 
 #### Very customizable, extendable and testable
 
@@ -32,11 +34,11 @@ From the ground up Silhouette was designed to be as customizable, extendable and
 
 #### Internationalization support
 
-Silhouette makes it very easy to internationalize your application by passing the Play Framework `Request` and `Lang` objects around, if internationalization comes into play.
+Silhouette makes it very easy to internationalize your application by making the Play Framework's ``Request`` and ``Lang`` available where they are needed.
 
 #### Well tested
 
-Silhouette is a security component which protects your users from being compromised by attackers. Therefore we try to cover the complete code with unit and integration tests.
+Silhouette is a security component which protects your users from being compromised by attackers. Therefore we aim for complete code coverage with unit and integration tests.
 
 #### Follows the OWASP Authentication Cheat Sheet
 
@@ -44,7 +46,7 @@ Silhouette implements and promotes best practices such as described by the [OWAS
 
 ## Documentation
 
-See [the project documentation](http://docs.silhouette.mohiva.com/en/latest/) for more information. If you need help with the integration of Silhouette into your project, don't hesitate and ask questions in our [mailing list](https://groups.google.com/forum/#!forum/play-silhouette) or on [Stack Overflow](http://stackoverflow.com/questions/tagged/playframework).
+See [the project documentation](http://docs.silhouette.mohiva.com/en/latest/) for more information. If you need help with the integration of Silhouette into your project, don't hesitate to ask questions in our [mailing list](https://groups.google.com/forum/#!forum/play-silhouette) or on [Stack Overflow](http://stackoverflow.com/questions/tagged/playframework).
 
 ## License
 


### PR DESCRIPTION
Edit the documentation for minor grammar, idiomatic usage, and sentence construction issues.  Overall the documentation is great;  this is just cleaning up some places that sound a little odd.

There are some notes left in the documentation delimited by [bwb: ...] where I made a larger-than-usual change or I thought needed attention from someone more familiar with the codebase than I am.
