### PR TITLE
Update testing.rst to notify 1.0 users that this feature is only available for 2.0

### DIFF
--- a/docs/how-it-works/testing.rst
+++ b/docs/how-it-works/testing.rst
@@ -11,6 +11,8 @@ scenarios.
 .. code-block:: scala
 
   import com.mohiva.play.silhouette.test._
+  
+This package is only available for play-silhouette 2.0-SNAPSHOT that is currently under development. 
 
 All helpers are test framework agnostic. You can use it with `Specs2`_, `ScalaTest`_ or every
 other testing framework. In our examples we use `Specs2`_ to demonstrate how to test Silhouette


### PR DESCRIPTION
I was looking for a way to test controllers that are using silhouette and this page was the first thing that was suggested by google. It took me some time to find out that this was for silhouette 2.0 and all this thanks to this seed https://github.com/mohiva/play-silhouette-seed
