### PR TITLE
add logic operator to Authorization

### DIFF
--- a/app/com/mohiva/play/silhouette/api/Authorization.scala
+++ b/app/com/mohiva/play/silhouette/api/Authorization.scala
@@ -40,3 +40,51 @@ trait Authorization[I <: Identity] {
    */
   def isAuthorized(identity: I)(implicit request: RequestHeader, lang: Lang): Boolean
 }
+
+/**
+ * The companion object.
+ */
+object Authorization {
+
+  /**
+   * An rich authorization which will be able to do logic operator.
+   *
+   * @param self The authorization.
+   */
+  implicit final class RichAuthorization[I <: Identity](self: Authorization[I]) {
+
+    /**
+     * Negation (not) operator
+     * @return The authorization
+     */
+    def unary_! : Authorization[I] = new Authorization[I] {
+      def isAuthorized(identity: I)(implicit request: RequestHeader, lang: Lang): Boolean = {
+        !self.isAuthorized(identity)
+      }
+    }
+
+    /**
+     * Conjuction (and) operator.
+     *
+     * @param authorization The authorization to be conjunction.
+     * @return The authorization
+     */
+    def &&(authorization: Authorization[I]): Authorization[I] = new Authorization[I] {
+      def isAuthorized(identity: I)(implicit request: RequestHeader, lang: Lang): Boolean = {
+        self.isAuthorized(identity) && authorization.isAuthorized(identity)
+      }
+    }
+
+    /**
+     * Disjunction (or) operator.
+     *
+     * @param authorization The authorization to be disjunction.
+     * @return The authorization
+     */
+    def ||(authorization: Authorization[I]): Authorization[I] = new Authorization[I] {
+      def isAuthorized(identity: I)(implicit request: RequestHeader, lang: Lang): Boolean = {
+        self.isAuthorized(identity) || authorization.isAuthorized(identity)
+      }
+    }
+  }
+}

--- a/docs/how-it-works/actions.rst
+++ b/docs/how-it-works/actions.rst
@@ -213,6 +213,29 @@ Here’s how you would use it:
 For unauthorized users you can implement a global or local fallback
 action similar to the fallback for unauthenticated users.
 
+Logic Operator
+^^^^^^^^^^^^^^^
+
+You can use logic operator (``NOT`` ``AND`` ``OR``) into your ``Authorization``
+
+.. code-block:: scala
+
+  def myAction = SecuredAction(!WithProvider("twitter")) { implicit request =>
+    // do something here
+  }
+
+.. code-block:: scala
+
+  def myAction = SecuredAction(WithProvider("twitter") || WithProvider("facebook")) { implicit request =>
+    // do something here
+  }
+
+.. code-block:: scala
+
+  def myAction = SecuredAction(WithProvider("twitter") && WithProvider("facebook")) { implicit request =>
+    // do something here
+  }
+
 Global Fallback
 ^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
add logic operator to be easly to reuse authorization.

``` scala
case class WithProvider(provider: String) extends Authorization[User] {
  def isAuthorized(user: User)(implicit request: RequestHeader, lang: Lang) = {
    user.identityId.providerId == provider
  }
}
```

``` scala
def myAction = SecuredAction(WithProvider("twitter") || WithProvider("facebook")) { implicit request =>
  // do something here
}

def myAction = SecuredAction(!WithProvider("twitter")) { implicit request =>
  // do something here
}

def myAction = SecuredAction(WithProvider("twitter") && WithProvider("facebook")) { implicit request =>
  // do something here
}
```
