### PR TITLE
make getAccessToken(code: String) accessible

### DIFF
--- a/app/com/mohiva/play/silhouette/impl/providers/OAuth2Provider.scala
+++ b/app/com/mohiva/play/silhouette/impl/providers/OAuth2Provider.scala
@@ -134,7 +134,7 @@ abstract class OAuth2Provider(httpLayer: HTTPLayer, stateProvider: OAuth2StatePr
    * @param code The access code.
    * @return The info containing the access token.
    */
-  protected def getAccessToken(code: String): Future[OAuth2Info] = {
+  def getAccessToken(code: String): Future[OAuth2Info] = {
     httpLayer.url(settings.accessTokenURL).withHeaders(headers: _*).post(Map(
       ClientID -> Seq(settings.clientID),
       ClientSecret -> Seq(settings.clientSecret),


### PR DESCRIPTION
Making the method public allows us to follow the workflow described in [this](https://aaronparecki.com/articles/2012/07/29/1/oauth2-simplified#web-server-apps) link.

This workflow is used in some angular library like [this](https://github.com/sahat/satellizer/wiki/Login-with-OAuth-2.0)
