### PR TITLE
Add new init method which returns the generated value instead of embedding it 

### DIFF
--- a/app/com/mohiva/play/silhouette/api/Authenticator.scala
+++ b/app/com/mohiva/play/silhouette/api/Authenticator.scala
@@ -32,6 +32,11 @@ import scala.concurrent.Future
 trait Authenticator {
 
   /**
+   * The Type of the generated value an authenticator will be serialized to.
+   */
+  type Value
+
+  /**
    * Gets the linked login info for an identity.
    *
    * @return The linked login info for an identity.

--- a/app/com/mohiva/play/silhouette/api/Silhouette.scala
+++ b/app/com/mohiva/play/silhouette/api/Silhouette.scala
@@ -293,7 +293,9 @@ trait Silhouette[I <: Identity, A <: Authenticator] extends Controller with Logg
         case hr @ HandlerResult(pr: Authenticator.Renew, _) =>
           env.authenticatorService.renew(authenticator, Future.successful(pr)).map(pr => hr.copy(pr))
         case hr @ HandlerResult(pr, _) =>
-          env.authenticatorService.init(authenticator, Future.successful(pr)).map(pr => hr.copy(pr))
+          env.authenticatorService.init(authenticator).flatMap { value =>
+            env.authenticatorService.embed(value, Future.successful(pr))
+          }.map(pr => hr.copy(pr))
       }
     }
 

--- a/app/com/mohiva/play/silhouette/api/services/AuthenticatorService.scala
+++ b/app/com/mohiva/play/silhouette/api/services/AuthenticatorService.scala
@@ -68,7 +68,28 @@ trait AuthenticatorService[T <: Authenticator] {
    * @param request The request header.
    * @return The manipulated result.
    */
+  @deprecated("Use `init` and `embed` instead; Will be removed in 2.0 final", "2.0-MASTER")
   def init(authenticator: T, result: Future[Result])(implicit request: RequestHeader): Future[Result]
+
+  /**
+   * Initializes an authenticator and instead of embedding into the the request or result, it returns
+   * the serialized value.
+   *
+   * @param authenticator The authenticator instance.
+   * @param request The request header.
+   * @return The serialized authenticator value.
+   */
+  def init(authenticator: T)(implicit request: RequestHeader): Future[T#Value]
+
+  /**
+   * Embeds authenticator specific artifacts into the response.
+   *
+   * @param value The authenticator value to embed.
+   * @param result The result to manipulate.
+   * @param request The request header.
+   * @return The manipulated result.
+   */
+  def embed(value: T#Value, result: Future[Result])(implicit request: RequestHeader): Future[Result]
 
   /**
    * Embeds authenticator specific artifacts into the request.
@@ -80,11 +101,11 @@ trait AuthenticatorService[T <: Authenticator] {
    *
    * If an existing authenticator exists, then it will be overridden.
    *
-   * @param authenticator The authenticator instance.
+   * @param value The authenticator value to embed.
    * @param request The request header.
    * @return The manipulated request header.
    */
-  def init(authenticator: T, request: RequestHeader): Future[RequestHeader]
+  def embed(value: T#Value, request: RequestHeader): RequestHeader
 
   ///////////////////////////////////////////////////////////////////////////////////////////////
   //

--- a/app/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticator.scala
+++ b/app/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticator.scala
@@ -17,6 +17,7 @@ package com.mohiva.play.silhouette.impl.authenticators
 
 import com.mohiva.play.silhouette.api.services.AuthenticatorService
 import com.mohiva.play.silhouette.api.{ Authenticator, LoginInfo }
+import play.api.libs.concurrent.Execution.Implicits._
 import play.api.mvc.{ RequestHeader, Result }
 
 import scala.concurrent.Future
@@ -29,6 +30,11 @@ import scala.concurrent.Future
  * @param loginInfo The linked login info for an identity.
  */
 case class DummyAuthenticator(loginInfo: LoginInfo) extends Authenticator {
+
+  /**
+   * The Type of the generated value an authenticator will be serialized to.
+   */
+  type Value = Unit
 
   /**
    * Authenticator is always valid.
@@ -73,18 +79,40 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @param request The request header.
    * @return The manipulated result.
    */
+  @deprecated("Use `init` and `embed` instead; Will be removed in 2.0 final", "2.0-MASTER")
   def init(authenticator: DummyAuthenticator, result: Future[Result])(implicit request: RequestHeader) = {
+    init(authenticator).flatMap(s => embed(s, result))
+  }
+
+  /**
+   * Returns noting because this authenticator doesn't have a serialized representation.
+   *
+   * @param authenticator The authenticator instance.
+   * @param request The request header.
+   * @return The serialized authenticator value.
+   */
+  def init(authenticator: DummyAuthenticator)(implicit request: RequestHeader) = Future.successful(())
+
+  /**
+   * Returns the original result, because we needn't add the authenticator to the result.
+   *
+   * @param value The authenticator value to embed.
+   * @param result The result to manipulate.
+   * @param request The request header.
+   * @return The manipulated result.
+   */
+  def embed(value: Unit, result: Future[Result])(implicit request: RequestHeader) = {
     result
   }
 
   /**
    * Returns the original request, because we needn't add the authenticator to the request.
    *
-   * @param authenticator The authenticator instance.
+   * @param value The authenticator value to embed.
    * @param request The request header.
    * @return The manipulated request header.
    */
-  def init(authenticator: DummyAuthenticator, request: RequestHeader) = Future.successful(request)
+  def embed(value: Unit, request: RequestHeader) = request
 
   /**
    * @inheritdoc

--- a/app/com/mohiva/play/silhouette/test/package.scala
+++ b/app/com/mohiva/play/silhouette/test/package.scala
@@ -1,6 +1,7 @@
 package com.mohiva.play.silhouette
 
 import com.mohiva.play.silhouette.api._
+import play.api.libs.concurrent.Execution.Implicits._
 import play.api.test.{ FakeHeaders, FakeRequest }
 
 import scala.concurrent.duration._
@@ -38,7 +39,7 @@ package object test {
      * @return A fake request.
      */
     def withAuthenticator[T <: Authenticator](authenticator: T)(implicit env: Environment[_, T]): FakeRequest[A] = {
-      val rh = env.authenticatorService.init(authenticator, f)
+      val rh = env.authenticatorService.init(authenticator)(f).map(v => env.authenticatorService.embed(v, f))
       new FakeRequest(
         id = rh.id,
         tags = rh.tags,

--- a/docs/how-it-works/authenticator.rst
+++ b/docs/how-it-works/authenticator.rst
@@ -38,10 +38,16 @@ Init an authenticator
 ^^^^^^^^^^^^^^^^^^^^^
 
 Authenticators need to be initialized, usually when they are created during a successful
-authentication. Initializing an authenticator causes it to be embedded into a Play framework
-request or result. This can by done by creating a cookie, storing data into the user session
-or including the authenticator in a user defined header. If the service uses a backing store,
-then the authenticator instance will be stored in it.
+authentication. If the service uses a backing store, then the authenticator instance will
+be stored in it, to check the validity of an authenticator on every subsequent request to
+the application.
+
+Embed an authenticator
+^^^^^^^^^^^^^^^^^^^^^^
+
+After initialization an authenticator must be embedded into a Play framework request or result.
+This can by done by creating a cookie, storing data into the user session or including the
+authenticator in a user defined header.
 
 Embedding the authenticator related data into the result means that the data will be sent
 to the client. It may also be useful to embed the authenticator related data into an incoming

--- a/test/com/mohiva/play/silhouette/api/SilhouetteSpec.scala
+++ b/test/com/mohiva/play/silhouette/api/SilhouetteSpec.scala
@@ -288,7 +288,8 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       basicAuthRequestProvider.authenticate(any) returns Future.successful(Some(identity.loginInfo))
       env.authenticatorService.retrieve(any) returns Future.successful(None)
       env.authenticatorService.create(any)(any) returns Future.successful(authenticator)
-      env.authenticatorService.init(any[FakeAuthenticator], any[Future[Result]])(any) answers { (a, m) =>
+      env.authenticatorService.init(any)(any) answers { p => Future.successful(p.asInstanceOf[FakeAuthenticator#Value]) }
+      env.authenticatorService.embed(any, any[Future[Result]])(any) answers { (a, m) =>
         a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
@@ -300,7 +301,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
         status(result) must equalTo(OK)
         contentAsString(result) must contain("full.access")
         there was one(env.authenticatorService).create(any)(any)
-        there was one(env.authenticatorService).init(any[FakeAuthenticator], any[Future[Result]])(any)
+        there was one(env.authenticatorService).init(any)(any)
         theProbe.expectMsg(500 millis, AuthenticatedEvent(identity, request, lang))
       }
     }
@@ -346,7 +347,8 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       tokenRequestProvider.authenticate(any) returns Future.successful(Some(identity.loginInfo))
       env.authenticatorService.retrieve(any) returns Future.successful(None)
       env.authenticatorService.create(any)(any) returns Future.successful(authenticator)
-      env.authenticatorService.init(any[FakeAuthenticator], any[Future[Result]])(any) answers { (a, m) =>
+      env.authenticatorService.init(any)(any) answers { p => Future.successful(p.asInstanceOf[FakeAuthenticator#Value]) }
+      env.authenticatorService.embed(any, any[Future[Result]])(any) answers { (a, m) =>
         a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
@@ -358,7 +360,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
         status(result) must equalTo(OK)
         contentAsString(result) must contain("full.access")
         there was one(env.authenticatorService).create(any)(any)
-        there was one(env.authenticatorService).init(any[FakeAuthenticator], any[Future[Result]])(any)
+        there was one(env.authenticatorService).init(any)(any)
         theProbe.expectMsg(500 millis, AuthenticatedEvent(identity, request, lang))
       }
     }
@@ -564,7 +566,8 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       basicAuthRequestProvider.authenticate(any) returns Future.successful(Some(identity.loginInfo))
       env.authenticatorService.retrieve(any) returns Future.successful(None)
       env.authenticatorService.create(any)(any) returns Future.successful(authenticator)
-      env.authenticatorService.init(any[FakeAuthenticator], any[Future[Result]])(any) answers { (a, m) =>
+      env.authenticatorService.init(any)(any) answers { p => Future.successful(p.asInstanceOf[FakeAuthenticator#Value]) }
+      env.authenticatorService.embed(any, any[Future[Result]])(any) answers { (a, m) =>
         a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
@@ -575,7 +578,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       status(result) must equalTo(OK)
       contentAsString(result) must contain("with.identity.and.authenticator")
       there was one(env.authenticatorService).create(any)(any)
-      there was one(env.authenticatorService).init(any[FakeAuthenticator], any[Future[Result]])(any)
+      there was one(env.authenticatorService).init(any)(any)
     }
 
     "update an initialized authenticator if it was touched" in new WithSecuredGlobal {
@@ -613,7 +616,8 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       tokenRequestProvider.authenticate(any) returns Future.successful(Some(identity.loginInfo))
       env.authenticatorService.retrieve(any) returns Future.successful(None)
       env.authenticatorService.create(any)(any) returns Future.successful(authenticator)
-      env.authenticatorService.init(any[FakeAuthenticator], any[Future[Result]])(any) answers { (a, m) =>
+      env.authenticatorService.init(any)(any) answers { p => Future.successful(p.asInstanceOf[FakeAuthenticator#Value]) }
+      env.authenticatorService.embed(any, any[Future[Result]])(any) answers { (a, m) =>
         a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
@@ -624,7 +628,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       status(result) must equalTo(OK)
       contentAsString(result) must contain("with.identity.and.authenticator")
       there was one(env.authenticatorService).create(any)(any)
-      there was one(env.authenticatorService).init(any[FakeAuthenticator], any[Future[Result]])(any)
+      there was one(env.authenticatorService).init(any)(any)
     }
 
     "renew an initialized authenticator" in new WithDefaultGlobal {

--- a/test/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticatorSpec.scala
+++ b/test/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticatorSpec.scala
@@ -50,20 +50,28 @@ class DummyAuthenticatorSpec extends PlaySpecification with Mockito {
     }
   }
 
-  "The result `init` method of the service" should {
+  "The `init` method of the service" should {
+    "return unit" in new Context {
+      implicit val request = FakeRequest()
+
+      await(service.init(authenticator)) must be equalTo (())
+    }
+  }
+
+  "The result `embed` method of the service" should {
     "return the original response" in new Context {
       implicit val request = FakeRequest()
       val result = Future.successful(Results.Status(200))
 
-      service.init(authenticator, result) must be equalTo result
+      service.embed((), result) must be equalTo result
     }
   }
 
-  "The request `init` method of the service" should {
+  "The request `embed` method of the service" should {
     "return the original request" in new Context {
       val request = FakeRequest()
 
-      await(service.init(authenticator, request)) must be equalTo request
+      service.embed((), request) must be equalTo request
     }
   }
 

--- a/test/com/mohiva/play/silhouette/impl/authenticators/JWTAuthenticatorSpec.scala
+++ b/test/com/mohiva/play/silhouette/impl/authenticators/JWTAuthenticatorSpec.scala
@@ -257,92 +257,77 @@ class JWTAuthenticatorSpec extends PlaySpecification with Mockito with JsonMatch
   }
 
   "The `init` method of the service" should {
-    "return the response with a header if DAO is enabled and authenticator could be saved in backing store" in new WithApplication with Context {
+    "return the token if DAO is enabled and authenticator could be saved in backing store" in new WithApplication with Context {
       dao.save(any) answers { p => Future.successful(p.asInstanceOf[JWTAuthenticator]) }
       implicit val request = FakeRequest()
 
-      val result = service(Some(dao)).init(authenticator, Future.successful(Results.Status(200)))
+      val token = await(service(Some(dao)).init(authenticator))
 
-      header(settings.headerName, result) should beSome(service(None).serialize(authenticator))
+      token must be equalTo service(None).serialize(authenticator)
+      there was one(dao).save(any)
     }
 
-    "return the response with a header if DAO is disabled" in new WithApplication with Context {
+    "return the token if DAO is disabled" in new WithApplication with Context {
       implicit val request = FakeRequest()
 
-      val result = service(None).init(authenticator, Future.successful(Results.Status(200)))
+      val token = await(service(None).init(authenticator))
 
-      header(settings.headerName, result) should beSome(service(None).serialize(authenticator))
+      token must be equalTo service(None).serialize(authenticator)
       there was no(dao).save(any)
     }
 
-    "throws an Authentication exception if error an occurred during initialization" in new Context {
+    "throws an Authentication exception if an error occurred during initialization" in new Context {
       dao.save(any) returns Future.failed(new Exception("Cannot store authenticator"))
 
       implicit val request = FakeRequest()
       val okResult = Future.successful(Results.Status(200))
 
-      await(service(Some(dao)).init(authenticator, okResult)) must throwA[AuthenticationException].like {
+      await(service(Some(dao)).init(authenticator)) must throwA[AuthenticationException].like {
         case e =>
           e.getMessage must startWith(InitError.format(ID, ""))
       }
     }
   }
 
-  "The request `init` method of the service" should {
-    "return the request with a header if DAO is enabled and authenticator could be saved in backing store" in new WithApplication with Context {
+  "The result `embed` method of the service" should {
+    "return the response with a header" in new WithApplication with Context {
+      dao.save(any) answers { p => Future.successful(p.asInstanceOf[JWTAuthenticator]) }
+      implicit val request = FakeRequest()
+      val token = service(None).serialize(authenticator)
+
+      val result = service(Some(dao)).embed(token, Future.successful(Results.Status(200)))
+
+      header(settings.headerName, result) should beSome(token)
+    }
+  }
+
+  "The request `embed` method of the service" should {
+    "return the request with a header " in new WithApplication with Context {
       dao.save(any) answers { p => Future.successful(p.asInstanceOf[JWTAuthenticator]) }
 
-      val request = await(service(Some(dao)).init(authenticator, FakeRequest()))
+      val token = service(None).serialize(authenticator)
+      val request = service(Some(dao)).embed(token, FakeRequest())
 
       request.headers.get(settings.headerName) should beSome(service(None).serialize(authenticator))
     }
 
-    "return the request with a header if DAO is disabled" in new WithApplication with Context {
-      val request = await(service(None).init(authenticator, FakeRequest()))
-
-      request.headers.get(settings.headerName) should beSome(service(None).serialize(authenticator))
-      there was no(dao).save(any)
-    }
-
-    "override an existing token if DAO is enabled" in new WithApplication with Context {
+    "override an existing token" in new WithApplication with Context {
       dao.save(any) answers { p => Future.successful(p.asInstanceOf[JWTAuthenticator]) }
 
-      val request = await(service(Some(dao)).init(authenticator, FakeRequest().withHeaders(settings.headerName -> "test")))
+      val token = service(None).serialize(authenticator)
+      val request = service(Some(dao)).embed(token, FakeRequest().withHeaders(settings.headerName -> "test"))
 
       request.headers.get(settings.headerName) should beSome(service(None).serialize(authenticator))
     }
 
-    "override an existing token if DAO is disabled" in new WithApplication with Context {
-      val request = await(service(None).init(authenticator, FakeRequest().withHeaders(settings.headerName -> "test")))
-
-      request.headers.get(settings.headerName) should beSome(service(None).serialize(authenticator))
-      there was no(dao).save(any)
-    }
-
-    "keep non authenticator related headers if DAO is enabled" in new WithApplication with Context {
+    "keep non authenticator related headers" in new WithApplication with Context {
       dao.save(any) answers { p => Future.successful(p.asInstanceOf[JWTAuthenticator]) }
 
-      val request = await(service(Some(dao)).init(authenticator, FakeRequest().withHeaders("test" -> "test")))
+      val token = service(None).serialize(authenticator)
+      val request = service(Some(dao)).embed(token, FakeRequest().withHeaders("test" -> "test"))
 
       request.headers.get(settings.headerName) should beSome(service(None).serialize(authenticator))
       request.headers.get("test") should beSome("test")
-    }
-
-    "keep non authenticator related headers if DAO is disabled" in new WithApplication with Context {
-      val request = await(service(None).init(authenticator, FakeRequest().withHeaders("test" -> "test")))
-
-      request.headers.get(settings.headerName) should beSome(service(None).serialize(authenticator))
-      request.headers.get("test") should beSome("test")
-      there was no(dao).save(any)
-    }
-
-    "throws an Authentication exception if error an occurred during initialization" in new Context {
-      dao.save(any) returns Future.failed(new Exception("Cannot store authenticator"))
-
-      await(service(Some(dao)).init(authenticator, FakeRequest())) must throwA[AuthenticationException].like {
-        case e =>
-          e.getMessage must startWith(InitError.format(ID, ""))
-      }
     }
   }
 


### PR DESCRIPTION
Based on this [SO question](http://stackoverflow.com/questions/27417061/reaching-jwt-token-in-play2-silhouette-jwtauthenticator) it would be nice if the authenticator could return the generated value instead of embedding it into the the response or request.

The JWT authenticator should then return a string representing the generated JWT, the cookie authenticator should return a `Cookie` instance, the session authenticator a `Session` instance and so on. 