### PR TITLE
Force OAuth1 provider to use the safer 1.0a specification and remove cache dependency

### DIFF
--- a/app/com/mohiva/play/silhouette/impl/providers/oauth1/LinkedInProvider.scala
+++ b/app/com/mohiva/play/silhouette/impl/providers/oauth1/LinkedInProvider.scala
@@ -21,7 +21,7 @@ package com.mohiva.play.silhouette.impl.providers.oauth1
 
 import com.mohiva.play.silhouette._
 import com.mohiva.play.silhouette.api.LoginInfo
-import com.mohiva.play.silhouette.api.util.{ CacheLayer, HTTPLayer }
+import com.mohiva.play.silhouette.api.util.HTTPLayer
 import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
 import com.mohiva.play.silhouette.impl.providers._
 import com.mohiva.play.silhouette.impl.providers.oauth1.LinkedInProvider._
@@ -33,7 +33,6 @@ import scala.concurrent.Future
 /**
  * A LinkedIn OAuth1 Provider.
  *
- * @param cacheLayer The cache layer implementation.
  * @param httpLayer The HTTP layer implementation.
  * @param service The OAuth1 service implementation.
  * @param settings The OAuth1 provider settings.
@@ -42,11 +41,8 @@ import scala.concurrent.Future
  * @see https://developer.linkedin.com/documents/authentication
  * @see https://developer.linkedin.com/documents/inapiprofile
  */
-abstract class LinkedInProvider(
-  cacheLayer: CacheLayer,
-  httpLayer: HTTPLayer,
-  service: OAuth1Service,
-  settings: OAuth1Settings) extends OAuth1Provider(cacheLayer, httpLayer, service, settings) {
+abstract class LinkedInProvider(httpLayer: HTTPLayer, service: OAuth1Service, settings: OAuth1Settings)
+  extends OAuth1Provider(httpLayer, service, settings) {
 
   /**
    * The content type returned from the provider.
@@ -129,16 +125,12 @@ object LinkedInProvider {
   /**
    * Creates an instance of the provider.
    *
-   * @param cacheLayer The cache layer implementation.
    * @param httpLayer The HTTP layer implementation.
    * @param oAuth1Service The OAuth1 service implementation.
    * @param auth1Settings The OAuth1 provider settings.
    * @return An instance of this provider.
    */
-  def apply(cacheLayer: CacheLayer,
-    httpLayer: HTTPLayer,
-    oAuth1Service: OAuth1Service,
-    auth1Settings: OAuth1Settings) = {
-    new LinkedInProvider(cacheLayer, httpLayer, oAuth1Service, auth1Settings) with CommonSocialProfileBuilder
+  def apply(httpLayer: HTTPLayer, oAuth1Service: OAuth1Service, auth1Settings: OAuth1Settings) = {
+    new LinkedInProvider(httpLayer, oAuth1Service, auth1Settings) with CommonSocialProfileBuilder
   }
 }

--- a/app/com/mohiva/play/silhouette/impl/providers/oauth1/TwitterProvider.scala
+++ b/app/com/mohiva/play/silhouette/impl/providers/oauth1/TwitterProvider.scala
@@ -21,7 +21,7 @@ package com.mohiva.play.silhouette.impl.providers.oauth1
 
 import com.mohiva.play.silhouette._
 import com.mohiva.play.silhouette.api.LoginInfo
-import com.mohiva.play.silhouette.api.util.{ CacheLayer, HTTPLayer }
+import com.mohiva.play.silhouette.api.util.HTTPLayer
 import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
 import com.mohiva.play.silhouette.impl.providers._
 import com.mohiva.play.silhouette.impl.providers.oauth1.TwitterProvider._
@@ -33,7 +33,6 @@ import scala.concurrent.Future
 /**
  * A Twitter OAuth1 Provider.
  *
- * @param cacheLayer The cache layer implementation.
  * @param httpLayer The HTTP layer implementation.
  * @param oAuth1Service The OAuth1 service implementation.
  * @param oAuth1Settings The OAuth1 provider settings.
@@ -41,11 +40,8 @@ import scala.concurrent.Future
  * @see https://dev.twitter.com/docs/user-profile-images-and-banners
  * @see https://dev.twitter.com/docs/entities#users
  */
-abstract class TwitterProvider(
-  cacheLayer: CacheLayer,
-  httpLayer: HTTPLayer,
-  oAuth1Service: OAuth1Service,
-  oAuth1Settings: OAuth1Settings) extends OAuth1Provider(cacheLayer, httpLayer, oAuth1Service, oAuth1Settings) {
+abstract class TwitterProvider(httpLayer: HTTPLayer, oAuth1Service: OAuth1Service, oAuth1Settings: OAuth1Settings)
+  extends OAuth1Provider(httpLayer, oAuth1Service, oAuth1Settings) {
 
   /**
    * The content type returned from the provider.
@@ -119,16 +115,12 @@ object TwitterProvider {
   /**
    * Creates an instance of the provider.
    *
-   * @param cacheLayer The cache layer implementation.
    * @param httpLayer The HTTP layer implementation.
    * @param oAuth1Service The OAuth1 service implementation.
    * @param auth1Settings The OAuth1 provider settings.
    * @return An instance of this provider.
    */
-  def apply(cacheLayer: CacheLayer,
-    httpLayer: HTTPLayer,
-    oAuth1Service: OAuth1Service,
-    auth1Settings: OAuth1Settings) = {
-    new TwitterProvider(cacheLayer, httpLayer, oAuth1Service, auth1Settings) with CommonSocialProfileBuilder
+  def apply(httpLayer: HTTPLayer, oAuth1Service: OAuth1Service, auth1Settings: OAuth1Settings) = {
+    new TwitterProvider(httpLayer, oAuth1Service, auth1Settings) with CommonSocialProfileBuilder
   }
 }

--- a/app/com/mohiva/play/silhouette/impl/providers/oauth1/XingProvider.scala
+++ b/app/com/mohiva/play/silhouette/impl/providers/oauth1/XingProvider.scala
@@ -21,7 +21,7 @@ package com.mohiva.play.silhouette.impl.providers.oauth1
 
 import com.mohiva.play.silhouette._
 import com.mohiva.play.silhouette.api.LoginInfo
-import com.mohiva.play.silhouette.api.util.{ CacheLayer, HTTPLayer }
+import com.mohiva.play.silhouette.api.util.HTTPLayer
 import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
 import com.mohiva.play.silhouette.impl.providers._
 import com.mohiva.play.silhouette.impl.providers.oauth1.XingProvider._
@@ -33,7 +33,6 @@ import scala.concurrent.Future
 /**
  * A Xing OAuth1 Provider.
  *
- * @param cacheLayer The cache layer implementation.
  * @param httpLayer The HTTP layer implementation.
  * @param oAuth1Service The OAuth1 service implementation.
  * @param oAuth1Settings The OAuth1 provider settings.
@@ -41,11 +40,8 @@ import scala.concurrent.Future
  * @see https://dev.xing.com/docs/get/users/me
  * @see https://dev.xing.com/docs/error_responses
  */
-abstract class XingProvider(
-  cacheLayer: CacheLayer,
-  httpLayer: HTTPLayer,
-  oAuth1Service: OAuth1Service,
-  oAuth1Settings: OAuth1Settings) extends OAuth1Provider(cacheLayer, httpLayer, oAuth1Service, oAuth1Settings) {
+abstract class XingProvider(httpLayer: HTTPLayer, oAuth1Service: OAuth1Service, oAuth1Settings: OAuth1Settings)
+  extends OAuth1Provider(httpLayer, oAuth1Service, oAuth1Settings) {
 
   /**
    * The content type returned from the provider.
@@ -126,16 +122,12 @@ object XingProvider {
   /**
    * Creates an instance of the provider.
    *
-   * @param cacheLayer The cache layer implementation.
    * @param httpLayer The HTTP layer implementation.
    * @param oAuth1Service The OAuth1 service implementation.
    * @param auth1Settings The OAuth1 provider settings.
    * @return An instance of this provider.
    */
-  def apply(cacheLayer: CacheLayer,
-    httpLayer: HTTPLayer,
-    oAuth1Service: OAuth1Service,
-    auth1Settings: OAuth1Settings) = {
-    new XingProvider(cacheLayer, httpLayer, oAuth1Service, auth1Settings) with CommonSocialProfileBuilder
+  def apply(httpLayer: HTTPLayer, oAuth1Service: OAuth1Service, auth1Settings: OAuth1Settings) = {
+    new XingProvider(httpLayer, oAuth1Service, auth1Settings) with CommonSocialProfileBuilder
   }
 }

--- a/app/com/mohiva/play/silhouette/impl/providers/oauth1/services/PlayOAuth1Service.scala
+++ b/app/com/mohiva/play/silhouette/impl/providers/oauth1/services/PlayOAuth1Service.scala
@@ -19,6 +19,7 @@
  */
 package com.mohiva.play.silhouette.impl.providers.oauth1.services
 
+import com.mohiva.play.silhouette.api.Logger
 import com.mohiva.play.silhouette.impl.providers.oauth1.services.PlayOAuth1Service._
 import com.mohiva.play.silhouette.impl.providers.{ OAuth1Info, OAuth1Service, OAuth1Settings }
 import play.api.libs.concurrent.Execution.Implicits._
@@ -33,7 +34,7 @@ import scala.concurrent.Future
  * @param service The Play Framework OAuth implementation.
  * @param settings The service settings.
  */
-class PlayOAuth1Service(service: OAuth, settings: OAuth1Settings) extends OAuth1Service {
+class PlayOAuth1Service(service: OAuth, settings: OAuth1Settings) extends OAuth1Service with Logger {
 
   /**
    * Constructs the default Play Framework OAuth implementation.
@@ -42,6 +43,17 @@ class PlayOAuth1Service(service: OAuth, settings: OAuth1Settings) extends OAuth1
    * @return The OAuth1 service.
    */
   def this(settings: OAuth1Settings) = this(OAuth(serviceInfo(settings), use10a = true), settings)
+
+  /**
+   * Indicates if the service uses the safer 1.0a specification which addresses the session fixation attack
+   * identified in the OAuth Core 1.0 specification.
+   *
+   * @see http://oauth.net/core/1.0a/
+   * @see http://oauth.net/advisories/2009-1/
+   *
+   * @return True if the services uses 1.0a specification, false otherwise.
+   */
+  def use10a = service.use10a
 
   /**
    * Retrieves the request info and secret.

--- a/test/com/mohiva/play/silhouette/impl/providers/oauth1/LinkedInProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/impl/providers/oauth1/LinkedInProviderSpec.scala
@@ -15,16 +15,13 @@
  */
 package com.mohiva.play.silhouette.impl.providers.oauth1
 
-import java.util.UUID
-
 import com.mohiva.play.silhouette.api.LoginInfo
 import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
-import com.mohiva.play.silhouette.impl.providers.OAuth1Provider._
 import com.mohiva.play.silhouette.impl.providers.SocialProfileBuilder._
 import com.mohiva.play.silhouette.impl.providers._
 import com.mohiva.play.silhouette.impl.providers.oauth1.LinkedInProvider._
 import play.api.libs.ws.{ WSRequestHolder, WSResponse }
-import play.api.test.{ FakeRequest, WithApplication }
+import play.api.test.WithApplication
 import test.Helper
 
 import scala.concurrent.Future
@@ -33,21 +30,6 @@ import scala.concurrent.Future
  * Test case for the [[com.mohiva.play.silhouette.impl.providers.oauth1.LinkedInProvider]] class.
  */
 class LinkedInProviderSpec extends OAuth1ProviderSpec {
-
-  "The `authenticate` method" should {
-    "return the auth info" in new WithApplication with Context {
-      val cacheID = UUID.randomUUID().toString
-      implicit val req = FakeRequest(GET, "?" + OAuthVerifier + "=my.verifier").withSession(CacheKey -> cacheID)
-      cacheLayer.find[OAuth1Info](cacheID) returns Future.successful(Some(oAuthInfo))
-      oAuthService.retrieveAccessToken(oAuthInfo, "my.verifier") returns Future.successful(oAuthInfo)
-
-      authInfo(provider.authenticate()) {
-        case authInfo => authInfo must be equalTo oAuthInfo
-      }
-
-      there was one(cacheLayer).remove(cacheID)
-    }
-  }
 
   "The `retrieveProfile` method" should {
     "fail with ProfileRetrievalException if API returns error" in new WithApplication with Context {
@@ -130,6 +112,6 @@ class LinkedInProviderSpec extends OAuth1ProviderSpec {
     /**
      * The provider to test.
      */
-    lazy val provider = LinkedInProvider(cacheLayer, httpLayer, oAuthService, oAuthSettings)
+    lazy val provider = LinkedInProvider(httpLayer, oAuthService, oAuthSettings)
   }
 }

--- a/test/com/mohiva/play/silhouette/impl/providers/oauth1/TwitterProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/impl/providers/oauth1/TwitterProviderSpec.scala
@@ -15,16 +15,13 @@
  */
 package com.mohiva.play.silhouette.impl.providers.oauth1
 
-import java.util.UUID
-
 import com.mohiva.play.silhouette.api.LoginInfo
 import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
-import com.mohiva.play.silhouette.impl.providers.OAuth1Provider._
 import com.mohiva.play.silhouette.impl.providers.SocialProfileBuilder._
 import com.mohiva.play.silhouette.impl.providers._
 import com.mohiva.play.silhouette.impl.providers.oauth1.TwitterProvider._
 import play.api.libs.ws.{ WSRequestHolder, WSResponse }
-import play.api.test.{ FakeRequest, WithApplication }
+import play.api.test.WithApplication
 import test.Helper
 
 import scala.concurrent.Future
@@ -33,21 +30,6 @@ import scala.concurrent.Future
  * Test case for the [[com.mohiva.play.silhouette.impl.providers.oauth1.TwitterProvider]] class.
  */
 class TwitterProviderSpec extends OAuth1ProviderSpec {
-
-  "The `authenticate` method" should {
-    "return the auth info" in new WithApplication with Context {
-      val cacheID = UUID.randomUUID().toString
-      implicit val req = FakeRequest(GET, "?" + OAuthVerifier + "=my.verifier").withSession(CacheKey -> cacheID)
-      cacheLayer.find[OAuth1Info](cacheID) returns Future.successful(Some(oAuthInfo))
-      oAuthService.retrieveAccessToken(oAuthInfo, "my.verifier") returns Future.successful(oAuthInfo)
-
-      authInfo(provider.authenticate()) {
-        case authInfo => authInfo must be equalTo oAuthInfo
-      }
-
-      there was one(cacheLayer).remove(cacheID)
-    }
-  }
 
   "The `retrieveProfile` method" should {
     "fail with ProfileRetrievalException if API returns error" in new WithApplication with Context {
@@ -124,6 +106,6 @@ class TwitterProviderSpec extends OAuth1ProviderSpec {
     /**
      * The provider to test.
      */
-    lazy val provider = TwitterProvider(cacheLayer, httpLayer, oAuthService, oAuthSettings)
+    lazy val provider = TwitterProvider(httpLayer, oAuthService, oAuthSettings)
   }
 }

--- a/test/com/mohiva/play/silhouette/impl/providers/oauth1/XingProviderSpec.scala
+++ b/test/com/mohiva/play/silhouette/impl/providers/oauth1/XingProviderSpec.scala
@@ -15,16 +15,13 @@
  */
 package com.mohiva.play.silhouette.impl.providers.oauth1
 
-import java.util.UUID
-
 import com.mohiva.play.silhouette.api.LoginInfo
 import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
-import com.mohiva.play.silhouette.impl.providers.OAuth1Provider._
 import com.mohiva.play.silhouette.impl.providers.SocialProfileBuilder._
 import com.mohiva.play.silhouette.impl.providers._
 import com.mohiva.play.silhouette.impl.providers.oauth1.XingProvider._
 import play.api.libs.ws.{ WSRequestHolder, WSResponse }
-import play.api.test.{ FakeRequest, WithApplication }
+import play.api.test.WithApplication
 import test.Helper
 
 import scala.concurrent.Future
@@ -33,21 +30,6 @@ import scala.concurrent.Future
  * Test case for the [[com.mohiva.play.silhouette.impl.providers.oauth1.XingProvider]] class.
  */
 class XingProviderSpec extends OAuth1ProviderSpec {
-
-  "The `authenticate` method" should {
-    "return the auth info" in new WithApplication with Context {
-      val cacheID = UUID.randomUUID().toString
-      implicit val req = FakeRequest(GET, "?" + OAuthVerifier + "=my.verifier").withSession(CacheKey -> cacheID)
-      cacheLayer.find[OAuth1Info](cacheID) returns Future.successful(Some(oAuthInfo))
-      oAuthService.retrieveAccessToken(oAuthInfo, "my.verifier") returns Future.successful(oAuthInfo)
-
-      authInfo(provider.authenticate()) {
-        case authInfo => authInfo must be equalTo oAuthInfo
-      }
-
-      there was one(cacheLayer).remove(cacheID)
-    }
-  }
 
   "The `retrieveProfile` method" should {
     "fail with ProfileRetrievalException if API returns error" in new WithApplication with Context {
@@ -127,6 +109,6 @@ class XingProviderSpec extends OAuth1ProviderSpec {
     /**
      * The provider to test.
      */
-    lazy val provider = XingProvider(cacheLayer, httpLayer, oAuthService, oAuthSettings)
+    lazy val provider = XingProvider(httpLayer, oAuthService, oAuthSettings)
   }
 }

--- a/test/com/mohiva/play/silhouette/impl/providers/oauth1/services/PlayOAuth1ServiceSpec.scala
+++ b/test/com/mohiva/play/silhouette/impl/providers/oauth1/services/PlayOAuth1ServiceSpec.scala
@@ -34,6 +34,20 @@ class PlayOAuth1ServiceSpec extends PlaySpecification with Mockito {
     }
   }
 
+  "The `use10a` method" should {
+    "return true if the safer 1.0a specification will be used" in new Context {
+      oauth.use10a returns true
+
+      service.use10a must beTrue
+    }
+
+    "return false if the unsafer 1.0 specification will be used" in new Context {
+      oauth.use10a returns false
+
+      service.use10a must beFalse
+    }
+  }
+
   "The `retrieveRequestToken` method" should {
     "throw exception if the token couldn't be retrieved" in new Context {
       oauth.retrieveRequestToken(settings.callbackURL) returns Left(new OAuthMessageSignerException(""))


### PR DESCRIPTION
The old code has implemented a fix for the [session fixation attack](http://oauth.net/advisories/2009-1/) discovered in 2009. The [fix](http://hueniverse.com/2009/04/23/explaining-the-oauth-session-fixation-attack/) was to check that the user who starts the process is the same as the one who finishes it. In SecureSocial this was implemented with a cache -> session combination, and Silhouette has inherited it from the SecureSocial code base.

This isn't longer needed because the 1.0a specification introduced the additional `oauth_verifier` parameter which was already implemented in the SecureSocial code base. Therefore the current code doesn't work already with the 1.0 specification, because of the `oauth_verifier` parameter which is mandatory for retrieving a access token.

So this pull request removes the cache dependency and forces the user to instantiate the OAuth1 providers with the safer 1.0a specification.

Removing the cache fixes also two other issues.
* A distributed cache was needed in a clustered environment
* The old fix doesn't play well with applications where the request token will be requested client side