### PR TITLE
Better social profile builder implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add request providers in combination with HTTP basic auth provider
 - Add Dropbox provider
 - Add request extractors
+- Better social profile builder implementation
 
 ## 1.0 (2014-06-12)
 

--- a/app/com/mohiva/play/silhouette/impl/providers/oauth2/GitHubProvider.scala
+++ b/app/com/mohiva/play/silhouette/impl/providers/oauth2/GitHubProvider.scala
@@ -19,7 +19,6 @@
  */
 package com.mohiva.play.silhouette.impl.providers.oauth2
 
-import com.mohiva.play.silhouette._
 import com.mohiva.play.silhouette.api.LoginInfo
 import com.mohiva.play.silhouette.api.util.HTTPLayer
 import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
@@ -44,7 +43,7 @@ abstract class GitHubProvider(httpLayer: HTTPLayer, stateProvider: OAuth2StatePr
   extends OAuth2Provider(httpLayer, stateProvider, settings) {
 
   /**
-   * The content type returned from the provider.
+   * The content type to parse a profile from.
    */
   type Content = JsValue
 
@@ -84,28 +83,47 @@ abstract class GitHubProvider(httpLayer: HTTPLayer, stateProvider: OAuth2StatePr
           val docURL = (json \ "documentation_url").asOpt[String]
 
           throw new ProfileRetrievalException(SpecifiedProfileError.format(id, msg, docURL))
-        case _ => Future.from(parseProfile(parser, json))
+        case _ => profileParser.parse(json)
       }
     }
   }
+}
+
+/**
+ * The profile parser for the common social profile.
+ */
+class GitHubProfileParser extends SocialProfileParser[JsValue, CommonSocialProfile] {
 
   /**
-   * Defines the parser which parses the most common profile supported by Silhouette.
+   * Parses the social profile.
    *
-   * @return The parser which parses the most common profile supported by Silhouette.
+   * @param json The content returned from the provider.
+   * @return The social profile from given result.
    */
-  protected def parser: Parser = (json: JsValue) => {
+  def parse(json: JsValue) = Future.successful {
     val userID = (json \ "id").as[Long]
     val fullName = (json \ "name").asOpt[String]
     val avatarUrl = (json \ "avatar_url").asOpt[String]
     val email = (json \ "email").asOpt[String].filter(!_.isEmpty)
 
     CommonSocialProfile(
-      loginInfo = LoginInfo(id, userID.toString),
+      loginInfo = LoginInfo(ID, userID.toString),
       fullName = fullName,
       avatarURL = avatarUrl,
       email = email)
   }
+}
+
+/**
+ * The profile builder for the common social profile.
+ */
+trait GitHubProfileBuilder extends CommonSocialProfileBuilder {
+  self: GitHubProvider =>
+
+  /**
+   * The profile parser implementation.
+   */
+  val profileParser = new GitHubProfileParser
 }
 
 /**
@@ -133,6 +151,6 @@ object GitHubProvider {
    * @return An instance of this provider.
    */
   def apply(httpLayer: HTTPLayer, stateProvider: OAuth2StateProvider, settings: OAuth2Settings) = {
-    new GitHubProvider(httpLayer, stateProvider, settings) with CommonSocialProfileBuilder
+    new GitHubProvider(httpLayer, stateProvider, settings) with GitHubProfileBuilder
   }
 }

--- a/app/com/mohiva/play/silhouette/impl/providers/oauth2/LinkedInProvider.scala
+++ b/app/com/mohiva/play/silhouette/impl/providers/oauth2/LinkedInProvider.scala
@@ -19,7 +19,6 @@
  */
 package com.mohiva.play.silhouette.impl.providers.oauth2
 
-import com.mohiva.play.silhouette._
 import com.mohiva.play.silhouette.api.LoginInfo
 import com.mohiva.play.silhouette.api.util.HTTPLayer
 import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
@@ -45,7 +44,7 @@ abstract class LinkedInProvider(httpLayer: HTTPLayer, stateProvider: OAuth2State
   extends OAuth2Provider(httpLayer, stateProvider, settings) {
 
   /**
-   * The content type returned from the provider.
+   * The content type to parse a profile from.
    */
   type Content = JsValue
 
@@ -78,17 +77,24 @@ abstract class LinkedInProvider(httpLayer: HTTPLayer, stateProvider: OAuth2State
           val timestamp = (json \ "timestamp").asOpt[Long]
 
           Future.failed(new ProfileRetrievalException(SpecifiedProfileError.format(id, error, message, requestId, status, timestamp)))
-        case _ => Future.from(parseProfile(parser, json))
+        case _ => profileParser.parse(json)
       }
     }
   }
+}
+
+/**
+ * The profile parser for the common social profile.
+ */
+class LinkedInProfileParser extends SocialProfileParser[JsValue, CommonSocialProfile] {
 
   /**
-   * Defines the parser which parses the most common profile supported by Silhouette.
+   * Parses the social profile.
    *
-   * @return The parser which parses the most common profile supported by Silhouette.
+   * @param json The content returned from the provider.
+   * @return The social profile from given result.
    */
-  protected def parser: Parser = (json: JsValue) => {
+  def parse(json: JsValue) = Future.successful {
     val userID = (json \ "id").as[String]
     val firstName = (json \ "firstName").asOpt[String]
     val lastName = (json \ "lastName").asOpt[String]
@@ -97,13 +103,25 @@ abstract class LinkedInProvider(httpLayer: HTTPLayer, stateProvider: OAuth2State
     val email = (json \ "emailAddress").asOpt[String]
 
     CommonSocialProfile(
-      loginInfo = LoginInfo(id, userID),
+      loginInfo = LoginInfo(ID, userID),
       firstName = firstName,
       lastName = lastName,
       fullName = fullName,
       avatarURL = avatarURL,
       email = email)
   }
+}
+
+/**
+ * The profile builder for the common social profile.
+ */
+trait LinkedInProfileBuilder extends CommonSocialProfileBuilder {
+  self: LinkedInProvider =>
+
+  /**
+   * The profile parser implementation.
+   */
+  val profileParser = new LinkedInProfileParser
 }
 
 /**
@@ -131,6 +149,6 @@ object LinkedInProvider {
    * @return An instance of this provider.
    */
   def apply(httpLayer: HTTPLayer, stateProvider: OAuth2StateProvider, settings: OAuth2Settings) = {
-    new LinkedInProvider(httpLayer, stateProvider, settings) with CommonSocialProfileBuilder
+    new LinkedInProvider(httpLayer, stateProvider, settings) with LinkedInProfileBuilder
   }
 }


### PR DESCRIPTION
The social profile builder in the old implementation has defined the default parser to return a `CommonSocialProfile` instance instead of the `Profile` type defined as `type Profile <: SocialProfile`. So it wasn't possible to write a parser which returns a custom social profile.

The new implementation can now handle this. It provides now a profile parser which can handle custom social profiles and which can be reused by other profile parsers to avoid code duplication.