### PR TITLE
Change header in default Fingerprint generator

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/impl/util/DefaultFingerprintGenerator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/util/DefaultFingerprintGenerator.scala
@@ -41,7 +41,7 @@ class DefaultFingerprintGenerator(includeRemoteAddress: Boolean = false) extends
   def generate(implicit request: RequestHeader) = {
     Crypt.sha1(new StringBuilder()
       .append(request.headers.get(USER_AGENT).getOrElse("")).append(":")
-      .append(request.headers.get(ACCEPT).getOrElse("")).append(":")
+      .append(request.headers.get(ACCEPT_LANGUAGE).getOrElse("")).append(":")
       .append(if (includeRemoteAddress) request.remoteAddress else "")
       .toString()
     )


### PR DESCRIPTION
Instead of using ACCEPT header for the default Fingerprint generator, use the ACCEPT-LANGUAGE header:
Using the ACCEPT header field for the default Fingerprint generator will cause problems for applications that use different media types depending on the request. For example, you may have a controller that accepts "application/json, text/javascript, */*; q=0.01" for GET /fooJSON, and "text/html,application/xhtml+xml,application/xml;q=0.9" for GET /fooHTML. Although the user can implement his/her own generator in this case, it will be good to avoid the "ACCEPT" header for the default generator (so as to remove a potential complication for new users who, for example, use a mixture of REST and HTML for their API). ACCEPT-LANGUAGE, on the other hand, will be least likely to be different across requests.