### PR TITLE
Change header in default Fingerprint generator

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/impl/util/DefaultFingerprintGenerator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/util/DefaultFingerprintGenerator.scala
@@ -41,7 +41,7 @@ class DefaultFingerprintGenerator(includeRemoteAddress: Boolean = false) extends
   def generate(implicit request: RequestHeader) = {
     Crypt.sha1(new StringBuilder()
       .append(request.headers.get(USER_AGENT).getOrElse("")).append(":")
-      .append(request.headers.get(ACCEPT).getOrElse("")).append(":")
+      .append(request.headers.get(ACCEPT_LANGUAGE).getOrElse("")).append(":")
       .append(if (includeRemoteAddress) request.remoteAddress else "")
       .toString()
     )

--- a/silhouette/test/com/mohiva/play/silhouette/impl/util/DefaultFingerprintGeneratorSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/util/DefaultFingerprintGeneratorSpec.scala
@@ -32,12 +32,12 @@ class DefaultFingerprintGeneratorSpec extends PlaySpecification {
       generator.generate must be equalTo Crypt.sha1(userAgent + "::")
     }
 
-    "return fingerprint including the `Accept` header" in {
-      val accept = "test-accept"
+    "return fingerprint including the `Accept-Language` header" in {
+      val acceptLanguage = "test-accept-language"
       val generator = new DefaultFingerprintGenerator()
-      implicit val request = FakeRequest().withHeaders(ACCEPT -> accept)
+      implicit val request = FakeRequest().withHeaders(ACCEPT_LANGUAGE -> acceptLanguage)
 
-      generator.generate must be equalTo Crypt.sha1(":" + accept + ":")
+      generator.generate must be equalTo Crypt.sha1(":" + acceptLanguage + ":")
     }
 
     "return fingerprint including the remote address" in {
@@ -49,11 +49,11 @@ class DefaultFingerprintGeneratorSpec extends PlaySpecification {
 
     "return fingerprint including all values" in {
       val userAgent = "test-user-agent"
-      val accept = "test-accept"
+      val acceptLanguage = "test-accept-language"
       val generator = new DefaultFingerprintGenerator(true)
-      implicit val request = FakeRequest().withHeaders(USER_AGENT -> userAgent, ACCEPT -> accept)
+      implicit val request = FakeRequest().withHeaders(USER_AGENT -> userAgent, ACCEPT_LANGUAGE -> acceptLanguage)
 
-      generator.generate must be equalTo Crypt.sha1(userAgent + ":" + accept + ":127.0.0.1")
+      generator.generate must be equalTo Crypt.sha1(userAgent + ":" + acceptLanguage + ":127.0.0.1")
     }
   }
 }


### PR DESCRIPTION
In default FingerprintGenerator, replace ACCEPT header with ACCEPT-LANGUAGE header (when generating Fingerprint):

Using the ACCEPT header field for the default Fingerprint generator will cause problems for applications that use different media types depending on requests. For example, you may have a controller that processes user sign-in POST request RESTfully (accepting "application/json, text/javascript, /; q=0.01"); therefore the authenticator and its corresponding fingerprint is created using this JSON etc ACCEPT header. On the other hand, the post-sign-in process may include a Redirect action whose GET request uses the usual HTTP request type i.e. "text/html,application/xhtml+xml,application/xml;q=0.9". In this case, silhouette will fail during authenticator retrieval when processing the GET request (because the fingerprints are different). 

Although the user can implement his/her own generator in this case, it will be good to avoid the "ACCEPT" header for the default generator (so as to remove a potential complication for new users who, for example, use such a mixture of REST and HTML in their API). 

ACCEPT-LANGUAGE, on the other hand, will be least likely to be different across request types.