### PR TITLE
Fix hyperlinks to source trees

### DIFF
--- a/docs/how-it-works/authenticator.rst
+++ b/docs/how-it-works/authenticator.rst
@@ -123,7 +123,7 @@ authenticator fits best into your application architecture.
 
 .. _Cookies vs Tokens. Getting auth right with Angular.JS: https://auth0.com/blog/2014/01/07/angularjs-authentication-with-cookies-vs-token/
 .. _10 Things You Should Know about Tokens: https://auth0.com/blog/2014/01/27/ten-things-you-should-know-about-tokens-and-cookies/
-.. _authenticator implementations: https://github.com/mohiva/play-silhouette/tree/master/app/com/mohiva/play/silhouette/impl/authenticators
+.. _authenticator implementations: https://github.com/mohiva/play-silhouette/tree/master/silhouette/app/com/mohiva/play/silhouette/impl/authenticators
 
 CookieAuthenticator
 ^^^^^^^^^^^^^^^^^^^

--- a/docs/how-it-works/providers.rst
+++ b/docs/how-it-works/providers.rst
@@ -230,7 +230,7 @@ provider. All state provider implementations can be found in the `impl package`_
 .. _state parameter: http://tools.ietf.org/html/rfc6749#section-4.1.1
 .. _CSRF attacks: http://www.oauthsecurity.com/#authorization-code-flow
 .. _should be used mainly: http://www.thread-safe.com/2014/05/the-correct-use-of-state-parameter-in.html
-.. _impl package: https://github.com/mohiva/play-silhouette/tree/master/app/com/mohiva/play/silhouette/impl/providers/oauth2/state
+.. _impl package: https://github.com/mohiva/play-silhouette/tree/master/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/state
 
 List of OAuth2 states
 ^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
These are missing links which refer to source tree instead of a blob.