### PR TITLE
Replace `Accept` header with `Accept-Language`, `Accept-Charset` and `Accept-Encoding` headers in default fingerprint generator

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/impl/util/DefaultFingerprintGenerator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/util/DefaultFingerprintGenerator.scala
@@ -25,8 +25,11 @@ import play.api.http.HeaderNames._
 import play.api.mvc.RequestHeader
 
 /**
- * A generator which creates a SHA1 fingerprint from `User-Agent` and `Accept` headers and if defined the
- * remote address of the user.
+ * A generator which creates a SHA1 fingerprint from `User-Agent`, `Accept-Language`, `Accept-Charset`
+ * and `Accept-Encoding` headers and if defined the remote address of the user.
+ *
+ * The `ACCEPT` header would also be a good candidate, but this header makes problems in applications
+ * which uses content negotiation. So the default fingerprint generator doesn't include it.
  *
  * @param includeRemoteAddress Indicates if the remote address should be included into the fingerprint.
  */
@@ -41,7 +44,9 @@ class DefaultFingerprintGenerator(includeRemoteAddress: Boolean = false) extends
   def generate(implicit request: RequestHeader) = {
     Crypt.sha1(new StringBuilder()
       .append(request.headers.get(USER_AGENT).getOrElse("")).append(":")
-      .append(request.headers.get(ACCEPT).getOrElse("")).append(":")
+      .append(request.headers.get(ACCEPT_LANGUAGE).getOrElse("")).append(":")
+      .append(request.headers.get(ACCEPT_CHARSET).getOrElse("")).append(":")
+      .append(request.headers.get(ACCEPT_ENCODING).getOrElse("")).append(":")
       .append(if (includeRemoteAddress) request.remoteAddress else "")
       .toString()
     )

--- a/silhouette/test/com/mohiva/play/silhouette/impl/util/DefaultFingerprintGeneratorSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/util/DefaultFingerprintGeneratorSpec.scala
@@ -29,31 +29,56 @@ class DefaultFingerprintGeneratorSpec extends PlaySpecification {
       val generator = new DefaultFingerprintGenerator()
       implicit val request = FakeRequest().withHeaders(USER_AGENT -> userAgent)
 
-      generator.generate must be equalTo Crypt.sha1(userAgent + "::")
+      generator.generate must be equalTo Crypt.sha1(userAgent + "::::")
     }
 
-    "return fingerprint including the `Accept` header" in {
-      val accept = "test-accept"
+    "return fingerprint including the `Accept-Language` header" in {
+      val acceptLanguage = "test-accept-language"
       val generator = new DefaultFingerprintGenerator()
-      implicit val request = FakeRequest().withHeaders(ACCEPT -> accept)
+      implicit val request = FakeRequest().withHeaders(ACCEPT_LANGUAGE -> acceptLanguage)
 
-      generator.generate must be equalTo Crypt.sha1(":" + accept + ":")
+      generator.generate must be equalTo Crypt.sha1(":" + acceptLanguage + ":::")
+    }
+
+    "return fingerprint including the `Accept-Charset` header" in {
+      val acceptCharset = "test-accept-charset"
+      val generator = new DefaultFingerprintGenerator()
+      implicit val request = FakeRequest().withHeaders(ACCEPT_CHARSET -> acceptCharset)
+
+      generator.generate must be equalTo Crypt.sha1("::" + acceptCharset + "::")
+    }
+
+    "return fingerprint including the `Accept-Encoding` header" in {
+      val acceptEncoding = "test-accept-encoding"
+      val generator = new DefaultFingerprintGenerator()
+      implicit val request = FakeRequest().withHeaders(ACCEPT_ENCODING -> acceptEncoding)
+
+      generator.generate must be equalTo Crypt.sha1(":::" + acceptEncoding + ":")
     }
 
     "return fingerprint including the remote address" in {
       val generator = new DefaultFingerprintGenerator(true)
       implicit val request = FakeRequest()
 
-      generator.generate must be equalTo Crypt.sha1("::127.0.0.1")
+      generator.generate must be equalTo Crypt.sha1("::::127.0.0.1")
     }
 
     "return fingerprint including all values" in {
       val userAgent = "test-user-agent"
-      val accept = "test-accept"
+      val acceptLanguage = "test-accept-language"
+      val acceptCharset = "test-accept-charset"
+      val acceptEncoding = "test-accept-encoding"
       val generator = new DefaultFingerprintGenerator(true)
-      implicit val request = FakeRequest().withHeaders(USER_AGENT -> userAgent, ACCEPT -> accept)
+      implicit val request = FakeRequest().withHeaders(
+        USER_AGENT -> userAgent,
+        ACCEPT_LANGUAGE -> acceptLanguage,
+        ACCEPT_CHARSET -> acceptCharset,
+        ACCEPT_ENCODING -> acceptEncoding
+      )
 
-      generator.generate must be equalTo Crypt.sha1(userAgent + ":" + accept + ":127.0.0.1")
+      generator.generate must be equalTo Crypt.sha1(
+        userAgent + ":" + acceptLanguage + ":" + acceptCharset + ":" + acceptEncoding + ":127.0.0.1"
+      )
     }
   }
 }


### PR DESCRIPTION
A better fix for #271 