### PR TITLE
CredentialsProvider & BasicAuthProvider should throw AccessDeniedExceptions

### DIFF
--- a/docs/how-it-works/error-handling.rst
+++ b/docs/how-it-works/error-handling.rst
@@ -3,9 +3,9 @@ Error handling
 
 Every provider implementation in Silhouette throws either an
 ``AccessDeniedException`` or an ``AuthenticationException``. The
-``AccessDeniedException`` will be thrown if a user provides incorrect
-credentials or a social provider denies an authentication attempt. In
-any other case the ``AuthenticationException`` will be thrown.
+``AccessDeniedException`` will be thrown if a social provider
+denies an authentication attempt. In any other case the ``AuthenticationException``
+will be thrown.
 
 Due to the asynchronous nature of Silhouette, all exceptions will be thrown
 in Futures. This means that exceptions may not be caught in a
@@ -14,7 +14,7 @@ To solve this problem, Futures have their own error handling mechanism.
 They can be recovered from an error state into desirable state with the
 help of the ``recover`` and ``recoverWith`` methods. Both methods
 accept a partial function which transforms the ``Exception`` into any
-other type. For more information please visit the ``Future`` trait's 
+other type. For more information please visit the ``Future`` trait's
 `documentation`_.
 
 All controller implementations which are derived from the ``Silhouette``
@@ -34,5 +34,9 @@ authentication.
 .. Note::
    The ``exceptionHandler`` method calls the local or global
    fallback methods under the hood to return the appropriate result.
+
+It is also possible to override the exception handler to handle user
+defined exceptions and to delegate the errors to the expected status
+codes.
 
 .. _documentation: http://www.scala-lang.org/api/current/#scala.concurrent.Future


### PR DESCRIPTION
Unless I'm misunderstanding https://github.com/mohiva/play-silhouette/blob/ce877f/docs/how-it-works/error-handling.rst
> The AccessDeniedException will be thrown if a user provides incorrect credentials

The following lines should throw AccessDeniedExceptions instead of AuthenticationExceptions:

[CredentialsProvider.scala#L76](https://github.com/mohiva/play-silhouette/blob/ce877f/silhouette/app/com/mohiva/play/silhouette/impl/providers/CredentialsProvider.scala#L76)

[BasicAuthProvider.scala#L77](https://github.com/mohiva/play-silhouette/blob/ce877f/silhouette/app/com/mohiva/play/silhouette/impl/providers/BasicAuthProvider.scala#L77)
