### PR TITLE
Make `authorizationURL` for OAuth2 provider optional

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -145,7 +145,7 @@ class. This class has the following form:
 .. code-block:: scala
 
     case class OAuth2Settings(
-      authorizationURL: String,
+      authorizationURL: Option[String],
       accessTokenURL: String,
       redirectURL: String,
       clientID: String,
@@ -158,7 +158,9 @@ class. This class has the following form:
 =========================    ===================================================================
 Property                     Description
 =========================    ===================================================================
-``authorizationURL``         The authorization URL provided by the OAuth provider
+``authorizationURL``         The authorization URL provided by the OAuth provider. This isn't
+                             needed when using Silhouette in conjunction with client side
+                             authentication frameworks
 ``accessTokenURL``           The access token URL provided by the OAuth provider
 ``redirectURL``              The redirect URL to the application after a successful
                              authentication on the OAuth provider
@@ -195,7 +197,6 @@ Your configuration could then have this format:
 .. code-block:: js
 
     clef {
-      authorizationUrl="https://clef.io/api/v1/authorize"
       accessTokenUrl="https://clef.io/api/v1/authorize"
       redirectURL="https://your.domain.tld/authenticate/clef"
       clientId="your.client.id"

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/custom/FacebookProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/custom/FacebookProviderSpec.scala
@@ -158,13 +158,13 @@ class FacebookProviderSpec extends OAuth2ProviderSpec {
     /**
      * The OAuth2 settings.
      */
-    lazy val oAuthSettings = OAuth2Settings(
-      authorizationURL = "https://graph.facebook.com/oauth/authorize",
+    lazy val oAuthSettings = spy(OAuth2Settings(
+      authorizationURL = Some("https://graph.facebook.com/oauth/authorize"),
       accessTokenURL = "https://graph.facebook.com/oauth/access_token",
       redirectURL = "https://www.mohiva.com",
       clientID = "my.client.id",
       clientSecret = "my.client.secret",
-      scope = Some("email"))
+      scope = Some("email")))
 
     /**
      * The provider to test.

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/ClefProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/ClefProviderSpec.scala
@@ -132,7 +132,6 @@ class ClefProviderSpec extends OAuth2ProviderSpec {
      * The OAuth2 settings.
      */
     lazy val oAuthSettings = OAuth2Settings(
-      authorizationURL = "https://clef.io/api/v1/authorize",
       accessTokenURL = "https://clef.io/api/v1/authorize",
       redirectURL = "https://www.mohiva.com",
       clientID = "my.client.id",

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/DropboxProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/DropboxProviderSpec.scala
@@ -136,13 +136,13 @@ class DropboxProviderSpec extends OAuth2ProviderSpec {
     /**
      * The OAuth2 settings.
      */
-    lazy val oAuthSettings = OAuth2Settings(
-      authorizationURL = "https://www.dropbox.com/1/oauth2/authorize",
+    lazy val oAuthSettings = spy(OAuth2Settings(
+      authorizationURL = Some("https://www.dropbox.com/1/oauth2/authorize"),
       accessTokenURL = "https://api.dropbox.com/1/oauth2/token",
       redirectURL = "https://www.mohiva.com",
       clientID = "my.client.id",
       clientSecret = "my.client.secret",
-      scope = None)
+      scope = None))
 
     /**
      * The OAuth2 info returned by Dropbox.

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/FacebookProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/FacebookProviderSpec.scala
@@ -173,13 +173,13 @@ class FacebookProviderSpec extends OAuth2ProviderSpec {
     /**
      * The OAuth2 settings.
      */
-    lazy val oAuthSettings = OAuth2Settings(
-      authorizationURL = "https://graph.facebook.com/oauth/authorize",
+    lazy val oAuthSettings = spy(OAuth2Settings(
+      authorizationURL = Some("https://graph.facebook.com/oauth/authorize"),
       accessTokenURL = "https://graph.facebook.com/oauth/access_token",
       redirectURL = "https://www.mohiva.com",
       clientID = "my.client.id",
       clientSecret = "my.client.secret",
-      scope = Some("email"))
+      scope = Some("email")))
 
     /**
      * The provider to test.

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/FoursquareProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/FoursquareProviderSpec.scala
@@ -201,12 +201,12 @@ class FoursquareProviderSpec extends OAuth2ProviderSpec {
     /**
      * The OAuth2 settings.
      */
-    lazy val oAuthSettings = OAuth2Settings(
-      authorizationURL = "https://foursquare.com/oauth2/authenticate",
+    lazy val oAuthSettings = spy(OAuth2Settings(
+      authorizationURL = Some("https://foursquare.com/oauth2/authenticate"),
       accessTokenURL = "https://foursquare.com/oauth2/access_token",
       redirectURL = "https://www.mohiva.com",
       clientID = "my.client.id",
-      clientSecret = "my.client.secret")
+      clientSecret = "my.client.secret"))
 
     /**
      * The OAuth2 info returned by Foursquare.

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/GitHubProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/GitHubProviderSpec.scala
@@ -129,13 +129,13 @@ class GitHubProviderSpec extends OAuth2ProviderSpec {
     /**
      * The OAuth2 settings.
      */
-    lazy val oAuthSettings = OAuth2Settings(
-      authorizationURL = "https://github.com/login/oauth/authorize",
+    lazy val oAuthSettings = spy(OAuth2Settings(
+      authorizationURL = Some("https://github.com/login/oauth/authorize"),
       accessTokenURL = "https://github.com/login/oauth/access_token",
       redirectURL = "https://www.mohiva.com",
       clientID = "my.client.id",
       clientSecret = "my.client.secret",
-      scope = Some("repo,gist"))
+      scope = Some("repo,gist")))
 
     /**
      * The OAuth2 info returned by GitHub.

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/GoogleProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/GoogleProviderSpec.scala
@@ -150,13 +150,13 @@ class GoogleProviderSpec extends OAuth2ProviderSpec {
     /**
      * The OAuth2 settings.
      */
-    lazy val oAuthSettings = OAuth2Settings(
-      authorizationURL = "https://accounts.google.com/o/oauth2/auth",
+    lazy val oAuthSettings = spy(OAuth2Settings(
+      authorizationURL = Some("https://accounts.google.com/o/oauth2/auth"),
       accessTokenURL = "https://accounts.google.com/o/oauth2/token",
       redirectURL = "https://www.mohiva.com",
       clientID = "my.client.id",
       clientSecret = "my.client.secret",
-      scope = Some("profile,email"))
+      scope = Some("profile,email")))
 
     /**
      * The OAuth2 info returned by Google.

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/InstagramProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/InstagramProviderSpec.scala
@@ -128,13 +128,13 @@ class InstagramProviderSpec extends OAuth2ProviderSpec {
     /**
      * The OAuth2 settings.
      */
-    lazy val oAuthSettings = OAuth2Settings(
-      authorizationURL = "https://api.instagram.com/oauth/authorize",
+    lazy val oAuthSettings = spy(OAuth2Settings(
+      authorizationURL = Some("https://api.instagram.com/oauth/authorize"),
       accessTokenURL = "https://api.instagram.com/oauth/access_token",
       redirectURL = "https://www.mohiva.com",
       clientID = "my.client.id",
       clientSecret = "my.client.secret",
-      scope = Some("basic"))
+      scope = Some("basic")))
 
     /**
      * The OAuth2 info returned by Instagram.

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/LinkedInProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/LinkedInProviderSpec.scala
@@ -133,13 +133,13 @@ class LinkedInProviderSpec extends OAuth2ProviderSpec {
     /**
      * The OAuth2 settings.
      */
-    lazy val oAuthSettings = OAuth2Settings(
-      authorizationURL = "https://www.linkedin.com/uas/oauth2/authorization",
+    lazy val oAuthSettings = spy(OAuth2Settings(
+      authorizationURL = Some("https://www.linkedin.com/uas/oauth2/authorization"),
       accessTokenURL = "https://www.linkedin.com/uas/oauth2/accessToken",
       redirectURL = "https://www.mohiva.com",
       clientID = "my.client.id",
       clientSecret = "my.client.secret",
-      scope = None)
+      scope = None))
 
     /**
      * The OAuth2 info returned by LinkedIn.

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/VKProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/VKProviderSpec.scala
@@ -128,13 +128,13 @@ class VKProviderSpec extends OAuth2ProviderSpec {
     /**
      * The OAuth2 settings.
      */
-    lazy val oAuthSettings = OAuth2Settings(
-      authorizationURL = "http://oauth.vk.com/authorize",
+    lazy val oAuthSettings = spy(OAuth2Settings(
+      authorizationURL = Some("http://oauth.vk.com/authorize"),
       accessTokenURL = "https://oauth.vk.com/access_token",
       redirectURL = "https://www.mohiva.com",
       clientID = "my.client.id",
       clientSecret = "my.client.secret",
-      scope = None)
+      scope = None))
 
     /**
      * The OAuth2 info returned by VK.


### PR DESCRIPTION
For client side authentication frameworks like Satellizer or Clef the step to get the authorization code isn't necessary because this will be handled by this client side frameworks. So the `authorizationURL` should be optional in this case.