### PR TITLE
Update REST seed with Silhouette 2.0

### DIFF
--- a/docs/basics/examples.rst
+++ b/docs/basics/examples.rst
@@ -49,7 +49,7 @@ for dependency injection.
 Seed project for Play Framework with Silhouette, exposing a rest api for
 signup and signin.
 
-`Link <https://github.com/merle-/silhouette-rest-seed>`__
+`Link <https://github.com/studiodev/silhouette-rest-seed>`__
 
 --------------
 


### PR DESCRIPTION
Hello,

I've updated the Silhouette-rest-seed to works with Silhouette 2.0.
I've tried to follow the way you develop the official seed.

The main difference is that I've removed the social things. I don't see in a REST API why we would like to connect with a social provider.
But If someone think it's important, I will accept PR gladly.

If you have any comment about the seed, just tell me, I can update it :)