### PR TITLE
Make FakeJWTAuthenticatorService working without started app

### DIFF
--- a/silhouette-testkit/app/com/mohiva/play/silhouette/test/Fakes.scala
+++ b/silhouette-testkit/app/com/mohiva/play/silhouette/test/Fakes.scala
@@ -132,7 +132,7 @@ case class FakeBearerTokenAuthenticatorService() extends BearerTokenAuthenticato
  * A fake JWT authenticator service.
  */
 case class FakeJWTAuthenticatorService() extends JWTAuthenticatorService(
-  new JWTAuthenticatorSettings(sharedSecret = UUID.randomUUID().toString),
+  new JWTAuthenticatorSettings(sharedSecret = UUID.randomUUID().toString, encryptSubject = false),
   None,
   new SecureRandomIDGenerator(),
   Clock())


### PR DESCRIPTION
When the `encryptSubject` configuration is activated, the encryption rely on `Crypto.encryptAES` which require a started application (https://github.com/playframework/playframework/blob/2.3.x/framework/src/play/src/main/scala/play/api/libs/Crypto.scala#L59).

By just setting encryptSubject to false in test, it should allows to initiate the JWSAuthenticator before the WithApplication block.