### PR TITLE
Sessionauthenticator removes added Values from Play Session

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticator.scala
@@ -168,7 +168,7 @@ class SessionAuthenticatorService(
    * @return The manipulated result.
    */
   def embed(session: Session, result: Future[Result])(implicit request: RequestHeader) = {
-    result.map(_.withSession(session))
+    result.map(_.addingToSession(session.data.toSeq: _*))
   }
 
   /**
@@ -216,7 +216,7 @@ class SessionAuthenticatorService(
     authenticator: SessionAuthenticator,
     result: Future[Result])(implicit request: RequestHeader) = {
 
-    result.map(_.withSession(request.session + (settings.sessionKey -> serialize(authenticator)))).recover {
+    result.map(_.addingToSession(settings.sessionKey -> serialize(authenticator))).recover {
       case e => throw new AuthenticationException(UpdateError.format(ID, authenticator), e)
     }
   }
@@ -252,7 +252,7 @@ class SessionAuthenticatorService(
     authenticator: SessionAuthenticator,
     result: Future[Result])(implicit request: RequestHeader) = {
 
-    result.map(_.withSession(request.session - settings.sessionKey)).recover {
+    result.map(_.removingFromSession(settings.sessionKey)).recover {
       case e => throw new AuthenticationException(DiscardError.format(ID, authenticator), e)
     }
   }


### PR DESCRIPTION
Hi,
We currently have the problem that if we use the SessionAuthenticator as authenticator we cannot add additional values in the Session anymore. These values will be removed during the update/touch process of the sessionauthenticator.

```java
package com.springer.nemo.identity.controllers

import com.mohiva.play.silhouette.api
import com.mohiva.play.silhouette.api.{ LoginInfo, Silhouette }
import com.mohiva.play.silhouette.impl.authenticators.SessionAuthenticator
import com.mohiva.play.silhouette.test.{ FakeEnvironment, FakeRequestWithAuthenticator }
import org.scalatest.{ Matchers, FlatSpec }
import org.scalatest.concurrent.{ AsyncAssertions, ScalaFutures }
import play.api.Play
import play.api.test.{ FakeApplication, FakeRequest }
import play.api.test.Helpers._

case class User(loginInfo: LoginInfo) extends api.Identity

class SilhouetteController extends Silhouette[User, SessionAuthenticator] {
  val loginInfo = new LoginInfo("foo", "bar")
  val identity = new User(loginInfo)

  val env = FakeEnvironment[User, SessionAuthenticator](Seq(loginInfo -> identity))

  val request = FakeRequest().withAuthenticator(loginInfo)(env)

  def testAttachToSession = UserAwareAction { implicit request =>
    Ok.withSession(("key" -> "valueX"))
  }
}

class SilhouetteSpec extends FlatSpec with AsyncAssertions with ScalaFutures with Matchers {

  "UserAwareAction" should "allow custom attributes in session" in {
    Play.start(FakeApplication())
    val controller = new SilhouetteController
    val request = controller.request
    whenReady(controller.testAttachToSession(request)) { result =>
      result.header.status should be(OK)
      result.session(request).get("key") should be(defined)
      result.session(request).get("key").get should be("valueX")

    }
    Play.stop()
  }
}
```

This feature would be really nice. 

P.s.
Really nice project. Helped us a lot. Thanks for all your work.