### PR TITLE
Simplifies the exception and status code handling

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/api/EventBus.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/EventBus.scala
@@ -55,14 +55,6 @@ case class LoginEvent[I <: Identity](identity: I, request: RequestHeader, lang: 
 case class LogoutEvent[I <: Identity](identity: I, request: RequestHeader, lang: Lang) extends SilhouetteEvent
 
 /**
- * An event which will be published after the access was denied to an identity.
- *
- * @param request The request header for the associated request.
- * @param lang The lang associated for the current request.
- */
-case class AccessDeniedEvent(request: RequestHeader, lang: Lang) extends SilhouetteEvent
-
-/**
  * An event which will be published if a request passes authentication.
  *
  * @param identity The logged in identity.

--- a/silhouette/app/com/mohiva/play/silhouette/api/SecuredSettings.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/SecuredSettings.scala
@@ -23,7 +23,7 @@ import scala.concurrent.Future
 
 /**
  * Can be mixed into the GlobalSettings object to define a global behaviour
- * for not-authenticated and not-authorized actions.
+ * for unauthorized and forbidden endpoints.
  */
 trait SecuredSettings {
   this: GlobalSettings =>

--- a/silhouette/app/com/mohiva/play/silhouette/api/exceptions/AuthenticatorCreationException.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/exceptions/AuthenticatorCreationException.scala
@@ -13,15 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.mohiva.play.silhouette.impl.exceptions
-
-import com.mohiva.play.silhouette.api.exceptions.ProviderException
+package com.mohiva.play.silhouette.api.exceptions
 
 /**
- * Indicates that an error occurred during profile retrieval in a social provider.
+ * An exception thrown when there is an error during authenticator creation.
  *
  * @param msg The exception message.
  * @param cause The exception cause.
  */
-class ProfileRetrievalException(msg: String, cause: Throwable = null)
-  extends ProviderException(msg, cause)
+class AuthenticatorCreationException(msg: String, cause: Throwable = null)
+  extends AuthenticatorException(msg, cause)

--- a/silhouette/app/com/mohiva/play/silhouette/api/exceptions/AuthenticatorDiscardingException.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/exceptions/AuthenticatorDiscardingException.scala
@@ -15,25 +15,11 @@
  */
 package com.mohiva.play.silhouette.api.exceptions
 
-import com.mohiva.play.silhouette.api.Logger
-
 /**
- * An exception thrown when there is an error in the authentication flow.
+ * An exception thrown when there is an error during authenticator discarding.
  *
  * @param msg The exception message.
  * @param cause The exception cause.
  */
-class AuthenticationException(msg: String, cause: Throwable)
-  extends Exception(msg, cause)
-  with SilhouetteException
-  with Logger {
-
-  logger.error(msg, cause)
-
-  /**
-   * Constructs an exception with only a message.
-   *
-   * @param msg The exception message.
-   */
-  def this(msg: String) = this(msg, null)
-}
+class AuthenticatorDiscardingException(msg: String, cause: Throwable = null)
+  extends AuthenticatorException(msg, cause)

--- a/silhouette/app/com/mohiva/play/silhouette/api/exceptions/AuthenticatorException.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/exceptions/AuthenticatorException.scala
@@ -13,24 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.mohiva.play.silhouette.impl.providers.oauth1.exceptions
-
-import com.mohiva.play.silhouette.api.exceptions.SilhouetteException
+package com.mohiva.play.silhouette.api.exceptions
 
 /**
- * Indicates that an error occurred during OAuth1 token secret retrieval.
- *
- * @param msg The exception message.
- * @param cause The exception cause.
+ * An exception for all authenticator related errors.
  */
-class TokenSecretException(msg: String, cause: Throwable)
-  extends Exception(msg, cause)
-  with SilhouetteException {
-
-  /**
-   * Constructs an exception with only a message.
-   *
-   * @param msg The exception message.
-   */
-  def this(msg: String) = this(msg, null)
-}
+class AuthenticatorException(msg: String, cause: Throwable = null)
+  extends SilhouetteException(msg, cause)

--- a/silhouette/app/com/mohiva/play/silhouette/api/exceptions/AuthenticatorInitializationException.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/exceptions/AuthenticatorInitializationException.scala
@@ -13,15 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.mohiva.play.silhouette.impl.exceptions
-
-import com.mohiva.play.silhouette.api.exceptions.ProviderException
+package com.mohiva.play.silhouette.api.exceptions
 
 /**
- * Indicates that an error occurred during profile retrieval in a social provider.
+ * An exception thrown when there is an error during authenticator initialization.
  *
  * @param msg The exception message.
  * @param cause The exception cause.
  */
-class ProfileRetrievalException(msg: String, cause: Throwable = null)
-  extends ProviderException(msg, cause)
+class AuthenticatorInitializationException(msg: String, cause: Throwable = null)
+  extends AuthenticatorException(msg, cause)

--- a/silhouette/app/com/mohiva/play/silhouette/api/exceptions/AuthenticatorRenewalException.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/exceptions/AuthenticatorRenewalException.scala
@@ -13,15 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.mohiva.play.silhouette.impl.exceptions
-
-import com.mohiva.play.silhouette.api.exceptions.ProviderException
+package com.mohiva.play.silhouette.api.exceptions
 
 /**
- * Indicates that an error occurred during profile retrieval in a social provider.
+ * An exception thrown when there is an error during authenticator renewal.
  *
  * @param msg The exception message.
  * @param cause The exception cause.
  */
-class ProfileRetrievalException(msg: String, cause: Throwable = null)
-  extends ProviderException(msg, cause)
+class AuthenticatorRenewalException(msg: String, cause: Throwable = null)
+  extends AuthenticatorException(msg, cause)

--- a/silhouette/app/com/mohiva/play/silhouette/api/exceptions/AuthenticatorRetrievalException.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/exceptions/AuthenticatorRetrievalException.scala
@@ -13,15 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.mohiva.play.silhouette.impl.exceptions
-
-import com.mohiva.play.silhouette.api.exceptions.ProviderException
+package com.mohiva.play.silhouette.api.exceptions
 
 /**
- * Indicates that an error occurred during profile retrieval in a social provider.
+ * An exception thrown when there is an error during authenticator retrieval.
  *
  * @param msg The exception message.
  * @param cause The exception cause.
  */
-class ProfileRetrievalException(msg: String, cause: Throwable = null)
-  extends ProviderException(msg, cause)
+class AuthenticatorRetrievalException(msg: String, cause: Throwable = null)
+  extends AuthenticatorException(msg, cause)

--- a/silhouette/app/com/mohiva/play/silhouette/api/exceptions/AuthenticatorUpdateException.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/exceptions/AuthenticatorUpdateException.scala
@@ -13,15 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.mohiva.play.silhouette.impl.exceptions
-
-import com.mohiva.play.silhouette.api.exceptions.ProviderException
+package com.mohiva.play.silhouette.api.exceptions
 
 /**
- * Indicates that an error occurred during profile retrieval in a social provider.
+ * An exception thrown when there is an error during authenticator update.
  *
  * @param msg The exception message.
  * @param cause The exception cause.
  */
-class ProfileRetrievalException(msg: String, cause: Throwable = null)
-  extends ProviderException(msg, cause)
+class AuthenticatorUpdateException(msg: String, cause: Throwable = null)
+  extends AuthenticatorException(msg, cause)

--- a/silhouette/app/com/mohiva/play/silhouette/api/exceptions/ConfigurationException.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/exceptions/ConfigurationException.scala
@@ -15,26 +15,11 @@
  */
 package com.mohiva.play.silhouette.api.exceptions
 
-import com.mohiva.play.silhouette.api.Logger
-
 /**
- * An exception thrown when the user denies access to the application
- * in the login page of the 3rd party service.
+ * Indicates a misconfiguration of a Silhouette component.
  *
  * @param msg The exception message.
  * @param cause The exception cause.
  */
-class AccessDeniedException(msg: String, cause: Throwable)
-  extends Exception(msg, cause)
-  with SilhouetteException
-  with Logger {
-
-  logger.info(msg)
-
-  /**
-   * Constructs an exception with only a message.
-   *
-   * @param msg The exception message.
-   */
-  def this(msg: String) = this(msg, null)
-}
+class ConfigurationException(msg: String, cause: Throwable = null)
+  extends SilhouetteException(msg, cause)

--- a/silhouette/app/com/mohiva/play/silhouette/api/exceptions/NotAuthenticatedException.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/exceptions/NotAuthenticatedException.scala
@@ -13,15 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.mohiva.play.silhouette.impl.exceptions
-
-import com.mohiva.play.silhouette.api.exceptions.ProviderException
+package com.mohiva.play.silhouette.api.exceptions
 
 /**
- * Indicates that an error occurred during profile retrieval in a social provider.
+ * Indicates that a user is not authenticated to access a secured endpoint.
  *
  * @param msg The exception message.
  * @param cause The exception cause.
  */
-class ProfileRetrievalException(msg: String, cause: Throwable = null)
-  extends ProviderException(msg, cause)
+class NotAuthenticatedException(msg: String, cause: Throwable = null)
+  extends SilhouetteException(msg, cause)

--- a/silhouette/app/com/mohiva/play/silhouette/api/exceptions/NotAuthorizedException.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/exceptions/NotAuthorizedException.scala
@@ -13,15 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.mohiva.play.silhouette.impl.exceptions
-
-import com.mohiva.play.silhouette.api.exceptions.ProviderException
+package com.mohiva.play.silhouette.api.exceptions
 
 /**
- * Indicates that an error occurred during profile retrieval in a social provider.
+ * Indicates that the authenticated user is not authorized to access a secured endpoint.
  *
  * @param msg The exception message.
  * @param cause The exception cause.
  */
-class ProfileRetrievalException(msg: String, cause: Throwable = null)
-  extends ProviderException(msg, cause)
+class NotAuthorizedException(msg: String, cause: Throwable = null)
+  extends SilhouetteException(msg, cause)

--- a/silhouette/app/com/mohiva/play/silhouette/api/exceptions/ProviderException.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/exceptions/ProviderException.scala
@@ -13,15 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.mohiva.play.silhouette.impl.exceptions
-
-import com.mohiva.play.silhouette.api.exceptions.ProviderException
+package com.mohiva.play.silhouette.api.exceptions
 
 /**
- * Indicates that an error occurred during profile retrieval in a social provider.
+ * Indicates an error occurred with an authentication provider.
  *
  * @param msg The exception message.
  * @param cause The exception cause.
  */
-class ProfileRetrievalException(msg: String, cause: Throwable = null)
-  extends ProviderException(msg, cause)
+class ProviderException(msg: String, cause: Throwable = null)
+  extends SilhouetteException(msg, cause)

--- a/silhouette/app/com/mohiva/play/silhouette/api/exceptions/SilhouetteException.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/exceptions/SilhouetteException.scala
@@ -18,4 +18,5 @@ package com.mohiva.play.silhouette.api.exceptions
 /**
  * A marker exception for the Silhouette project.
  */
-trait SilhouetteException extends Exception
+class SilhouetteException(msg: String, cause: Throwable = null)
+  extends Exception(msg, cause)

--- a/silhouette/app/com/mohiva/play/silhouette/api/util/DefaultEndpointHandler.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/util/DefaultEndpointHandler.scala
@@ -12,20 +12,7 @@ import scala.concurrent._
 object DefaultEndpointHandler extends Controller {
 
   /**
-   * Handles forbidden requests in a default way.
-   *
-   * The HTTP status code of the response will be 403 Forbidden, complying with
-   * [[https://tools.ietf.org/html/rfc2616#section-10.4.4 RFC 2616]].
-   *
-   * @param request The request header.
-   * @return A response indicating that access is forbidden.
-   */
-  def handleForbidden(implicit request: RequestHeader): Future[Result] = {
-    produceResponse(Forbidden, "silhouette.not.authorized")
-  }
-
-  /**
-   * Handles unauthorized requests in a default way.
+   * Handles not authenticated requests in a default way.
    *
    * The HTTP status code of the response will be 401 Unauthorized, complying with
    * [[https://tools.ietf.org/html/rfc2616#section-10.4.2 RFC 2616]].
@@ -33,8 +20,21 @@ object DefaultEndpointHandler extends Controller {
    * @param request The request header.
    * @return A response indicating that user authentication is required.
    */
-  def handleUnauthorized(implicit request: RequestHeader): Future[Result] = {
+  def handleNotAuthenticated(implicit request: RequestHeader): Future[Result] = {
     produceResponse(Unauthorized, "silhouette.not.authenticated")
+  }
+
+  /**
+   * Handles not authorized requests in a default way.
+   *
+   * The HTTP status code of the response will be 403 Forbidden, complying with
+   * [[https://tools.ietf.org/html/rfc2616#section-10.4.4 RFC 2616]].
+   *
+   * @param request The request header.
+   * @return A response indicating that access is forbidden.
+   */
+  def handleNotAuthorized(implicit request: RequestHeader): Future[Result] = {
+    produceResponse(Forbidden, "silhouette.not.authorized")
   }
 
   /**

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/BearerTokenAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/BearerTokenAuthenticator.scala
@@ -16,7 +16,7 @@
 package com.mohiva.play.silhouette.impl.authenticators
 
 import com.mohiva.play.silhouette._
-import com.mohiva.play.silhouette.api.exceptions.AuthenticationException
+import com.mohiva.play.silhouette.api.exceptions._
 import com.mohiva.play.silhouette.api.services.AuthenticatorService
 import com.mohiva.play.silhouette.api.services.AuthenticatorService._
 import com.mohiva.play.silhouette.api.util.{ Clock, IDGenerator }
@@ -114,7 +114,7 @@ class BearerTokenAuthenticatorService(
         expirationDate = now.plusSeconds(settings.authenticatorExpiry),
         idleTimeout = settings.authenticatorIdleTimeout)
     }.recover {
-      case e => throw new AuthenticationException(CreateError.format(ID, loginInfo), e)
+      case e => throw new AuthenticatorCreationException(CreateError.format(ID, loginInfo), e)
     }
   }
 
@@ -129,7 +129,7 @@ class BearerTokenAuthenticatorService(
       case Some(token) => dao.find(token)
       case None => Future.successful(None)
     }.recover {
-      case e => throw new AuthenticationException(RetrieveError.format(ID), e)
+      case e => throw new AuthenticatorRetrievalException(RetrieveError.format(ID), e)
     }
   }
 
@@ -145,7 +145,7 @@ class BearerTokenAuthenticatorService(
     dao.save(authenticator).map { a =>
       a.id
     }.recover {
-      case e => throw new AuthenticationException(InitError.format(ID, authenticator), e)
+      case e => throw new AuthenticatorInitializationException(InitError.format(ID, authenticator), e)
     }
   }
 
@@ -206,7 +206,7 @@ class BearerTokenAuthenticatorService(
     dao.save(authenticator).flatMap { a =>
       result
     }.recover {
-      case e => throw new AuthenticationException(UpdateError.format(ID, authenticator), e)
+      case e => throw new AuthenticatorUpdateException(UpdateError.format(ID, authenticator), e)
     }
   }
 
@@ -228,7 +228,7 @@ class BearerTokenAuthenticatorService(
         init(a).flatMap(v => embed(v, result))
       }
     }.recover {
-      case e => throw new AuthenticationException(RenewError.format(ID, authenticator), e)
+      case e => throw new AuthenticatorRenewalException(RenewError.format(ID, authenticator), e)
     }
   }
 
@@ -246,7 +246,7 @@ class BearerTokenAuthenticatorService(
     dao.remove(authenticator.id).flatMap { _ =>
       result
     }.recover {
-      case e => throw new AuthenticationException(DiscardError.format(ID, authenticator), e)
+      case e => throw new AuthenticatorDiscardingException(DiscardError.format(ID, authenticator), e)
     }
   }
 }

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticator.scala
@@ -20,7 +20,7 @@
 package com.mohiva.play.silhouette.impl.authenticators
 
 import com.mohiva.play.silhouette._
-import com.mohiva.play.silhouette.api.exceptions.AuthenticationException
+import com.mohiva.play.silhouette.api.exceptions._
 import com.mohiva.play.silhouette.api.services.AuthenticatorService
 import com.mohiva.play.silhouette.api.services.AuthenticatorService._
 import com.mohiva.play.silhouette.api.util.{ Clock, FingerprintGenerator, IDGenerator }
@@ -127,7 +127,7 @@ class CookieAuthenticatorService(
         fingerprint = if (settings.useFingerprinting) Some(fingerprintGenerator.generate) else None
       )
     }.recover {
-      case e => throw new AuthenticationException(CreateError.format(ID, loginInfo), e)
+      case e => throw new AuthenticatorCreationException(CreateError.format(ID, loginInfo), e)
     }
   }
 
@@ -152,7 +152,7 @@ class CookieAuthenticatorService(
         case None => Future.successful(None)
       }
     }.recover {
-      case e => throw new AuthenticationException(RetrieveError.format(ID), e)
+      case e => throw new AuthenticatorRetrievalException(RetrieveError.format(ID), e)
     }
   }
 
@@ -176,7 +176,7 @@ class CookieAuthenticatorService(
         httpOnly = settings.httpOnlyCookie
       )
     }.recover {
-      case e => throw new AuthenticationException(InitError.format(ID, authenticator), e)
+      case e => throw new AuthenticatorInitializationException(InitError.format(ID, authenticator), e)
     }
   }
 
@@ -239,7 +239,7 @@ class CookieAuthenticatorService(
     dao.save(authenticator).flatMap { a =>
       result
     }.recover {
-      case e => throw new AuthenticationException(UpdateError.format(ID, authenticator), e)
+      case e => throw new AuthenticatorUpdateException(UpdateError.format(ID, authenticator), e)
     }
   }
 
@@ -261,7 +261,7 @@ class CookieAuthenticatorService(
         init(a).flatMap(v => embed(v, result))
       }
     }.recover {
-      case e => throw new AuthenticationException(RenewError.format(ID, authenticator), e)
+      case e => throw new AuthenticatorRenewalException(RenewError.format(ID, authenticator), e)
     }
   }
 
@@ -283,7 +283,7 @@ class CookieAuthenticatorService(
         domain = settings.cookieDomain,
         secure = settings.secureCookie)))
     }.recover {
-      case e => throw new AuthenticationException(DiscardError.format(ID, authenticator), e)
+      case e => throw new AuthenticatorDiscardingException(DiscardError.format(ID, authenticator), e)
     }
   }
 }

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticator.scala
@@ -16,7 +16,7 @@
 package com.mohiva.play.silhouette.impl.authenticators
 
 import com.mohiva.play.silhouette._
-import com.mohiva.play.silhouette.api.exceptions.AuthenticationException
+import com.mohiva.play.silhouette.api.exceptions._
 import com.mohiva.play.silhouette.api.services.AuthenticatorService
 import com.mohiva.play.silhouette.api.services.AuthenticatorService._
 import com.mohiva.play.silhouette.api.util.{ Base64, Clock, FingerprintGenerator }
@@ -123,7 +123,7 @@ class SessionAuthenticatorService(
         fingerprint = if (settings.useFingerprinting) Some(fingerprintGenerator.generate) else None
       )
     }).recover {
-      case e => throw new AuthenticationException(CreateError.format(ID, loginInfo), e)
+      case e => throw new AuthenticatorCreationException(CreateError.format(ID, loginInfo), e)
     }
   }
 
@@ -145,7 +145,7 @@ class SessionAuthenticatorService(
         case None => None
       }
     }.recover {
-      case e => throw new AuthenticationException(RetrieveError.format(ID), e)
+      case e => throw new AuthenticatorRetrievalException(RetrieveError.format(ID), e)
     }
   }
 
@@ -217,7 +217,7 @@ class SessionAuthenticatorService(
     result: Future[Result])(implicit request: RequestHeader) = {
 
     result.map(_.addingToSession(settings.sessionKey -> serialize(authenticator))).recover {
-      case e => throw new AuthenticationException(UpdateError.format(ID, authenticator), e)
+      case e => throw new AuthenticatorUpdateException(UpdateError.format(ID, authenticator), e)
     }
   }
 
@@ -237,7 +237,7 @@ class SessionAuthenticatorService(
     create(authenticator.loginInfo).flatMap { a =>
       init(a).flatMap(v => embed(v, result))
     }.recover {
-      case e => throw new AuthenticationException(RenewError.format(ID, authenticator), e)
+      case e => throw new AuthenticatorRenewalException(RenewError.format(ID, authenticator), e)
     }
   }
 
@@ -253,7 +253,7 @@ class SessionAuthenticatorService(
     result: Future[Result])(implicit request: RequestHeader) = {
 
     result.map(_.removingFromSession(settings.sessionKey)).recover {
-      case e => throw new AuthenticationException(DiscardError.format(ID, authenticator), e)
+      case e => throw new AuthenticatorDiscardingException(DiscardError.format(ID, authenticator), e)
     }
   }
 

--- a/silhouette/app/com/mohiva/play/silhouette/impl/exceptions/AccessDeniedException.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/exceptions/AccessDeniedException.scala
@@ -18,10 +18,10 @@ package com.mohiva.play.silhouette.impl.exceptions
 import com.mohiva.play.silhouette.api.exceptions.ProviderException
 
 /**
- * Indicates that an error occurred during profile retrieval in a social provider.
+ * Signals that a social provider denies access during authentication process.
  *
  * @param msg The exception message.
  * @param cause The exception cause.
  */
-class ProfileRetrievalException(msg: String, cause: Throwable = null)
+class AccessDeniedException(msg: String, cause: Throwable = null)
   extends ProviderException(msg, cause)

--- a/silhouette/app/com/mohiva/play/silhouette/impl/exceptions/IdentityNotFoundException.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/exceptions/IdentityNotFoundException.scala
@@ -13,24 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.mohiva.play.silhouette.impl.providers.oauth2.exceptions
+package com.mohiva.play.silhouette.impl.exceptions
 
-import com.mohiva.play.silhouette.api.exceptions.SilhouetteException
+import com.mohiva.play.silhouette.api.exceptions.ProviderException
 
 /**
- * Indicates that an error occurred during OAuth2 state retrieval.
+ * Signals that an identity could not found in a credential based provider.
  *
  * @param msg The exception message.
  * @param cause The exception cause.
  */
-class StateException(msg: String, cause: Throwable)
-  extends Exception(msg, cause)
-  with SilhouetteException {
-
-  /**
-   * Constructs an exception with only a message.
-   *
-   * @param msg The exception message.
-   */
-  def this(msg: String) = this(msg, null)
-}
+class IdentityNotFoundException(msg: String, cause: Throwable = null)
+  extends ProviderException(msg, cause)

--- a/silhouette/app/com/mohiva/play/silhouette/impl/exceptions/InvalidPasswordException.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/exceptions/InvalidPasswordException.scala
@@ -18,10 +18,10 @@ package com.mohiva.play.silhouette.impl.exceptions
 import com.mohiva.play.silhouette.api.exceptions.ProviderException
 
 /**
- * Indicates that an error occurred during profile retrieval in a social provider.
+ * Indicates that an invalid password was entered in a credential based provider.
  *
  * @param msg The exception message.
  * @param cause The exception cause.
  */
-class ProfileRetrievalException(msg: String, cause: Throwable = null)
+class InvalidPasswordException(msg: String, cause: Throwable = null)
   extends ProviderException(msg, cause)

--- a/silhouette/app/com/mohiva/play/silhouette/impl/exceptions/OAuth1TokenSecretException.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/exceptions/OAuth1TokenSecretException.scala
@@ -18,10 +18,10 @@ package com.mohiva.play.silhouette.impl.exceptions
 import com.mohiva.play.silhouette.api.exceptions.ProviderException
 
 /**
- * Indicates that an error occurred during profile retrieval in a social provider.
+ * Indicates that an error occurred during OAuth1 token secret retrieval.
  *
  * @param msg The exception message.
  * @param cause The exception cause.
  */
-class ProfileRetrievalException(msg: String, cause: Throwable = null)
+class OAuth1TokenSecretException(msg: String, cause: Throwable = null)
   extends ProviderException(msg, cause)

--- a/silhouette/app/com/mohiva/play/silhouette/impl/exceptions/OAuth2StateException.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/exceptions/OAuth2StateException.scala
@@ -18,10 +18,10 @@ package com.mohiva.play.silhouette.impl.exceptions
 import com.mohiva.play.silhouette.api.exceptions.ProviderException
 
 /**
- * Indicates that an error occurred during profile retrieval in a social provider.
+ * Indicates that an error occurred during OAuth2 state retrieval.
  *
  * @param msg The exception message.
  * @param cause The exception cause.
  */
-class ProfileRetrievalException(msg: String, cause: Throwable = null)
+class OAuth2StateException(msg: String, cause: Throwable = null)
   extends ProviderException(msg, cause)

--- a/silhouette/app/com/mohiva/play/silhouette/impl/exceptions/UnexpectedResponseException.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/exceptions/UnexpectedResponseException.scala
@@ -18,10 +18,10 @@ package com.mohiva.play.silhouette.impl.exceptions
 import com.mohiva.play.silhouette.api.exceptions.ProviderException
 
 /**
- * Indicates that an error occurred during profile retrieval in a social provider.
+ * Signals that an unexpected response was received from a social provider.
  *
  * @param msg The exception message.
  * @param cause The exception cause.
  */
-class ProfileRetrievalException(msg: String, cause: Throwable = null)
+class UnexpectedResponseException(msg: String, cause: Throwable = null)
   extends ProviderException(msg, cause)

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/BasicAuthProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/BasicAuthProvider.scala
@@ -15,10 +15,11 @@
  */
 package com.mohiva.play.silhouette.impl.providers
 
-import com.mohiva.play.silhouette.api.exceptions.AuthenticationException
+import com.mohiva.play.silhouette.api.exceptions.ConfigurationException
 import com.mohiva.play.silhouette.api.services.AuthInfoService
 import com.mohiva.play.silhouette.api.util._
 import com.mohiva.play.silhouette.api.{ LoginInfo, RequestProvider }
+import com.mohiva.play.silhouette.impl.exceptions.{ IdentityNotFoundException, InvalidPasswordException }
 import com.mohiva.play.silhouette.impl.providers.BasicAuthProvider._
 import play.api.http.HeaderNames
 import play.api.libs.concurrent.Execution.Implicits._
@@ -69,12 +70,12 @@ class BasicAuthProvider(
                 authInfoService.save(loginInfo, passwordHasher.hash(credentials.password))
               }
               Some(loginInfo)
-            case Some(hasher) => throw new AuthenticationException(InvalidPassword.format(id))
-            case None => throw new AuthenticationException(UnsupportedHasher.format(
+            case Some(hasher) => throw new InvalidPasswordException(InvalidPassword.format(id))
+            case None => throw new ConfigurationException(UnsupportedHasher.format(
               id, authInfo.hasher, passwordHasherList.map(_.id).mkString(", ")
             ))
           }
-          case None => throw new AuthenticationException(UnknownCredentials.format(id))
+          case None => throw new IdentityNotFoundException(UnknownCredentials.format(id))
         }
       case None => Future.successful(None)
     }

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/CredentialsProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/CredentialsProvider.scala
@@ -20,9 +20,10 @@
 package com.mohiva.play.silhouette.impl.providers
 
 import com.mohiva.play.silhouette.api._
-import com.mohiva.play.silhouette.api.exceptions.AuthenticationException
+import com.mohiva.play.silhouette.api.exceptions.ConfigurationException
 import com.mohiva.play.silhouette.api.services.AuthInfoService
 import com.mohiva.play.silhouette.api.util.{ Credentials, PasswordHasher, PasswordInfo }
+import com.mohiva.play.silhouette.impl.exceptions.{ IdentityNotFoundException, InvalidPasswordException }
 import com.mohiva.play.silhouette.impl.providers.CredentialsProvider._
 import play.api.libs.concurrent.Execution.Implicits._
 
@@ -68,12 +69,12 @@ class CredentialsProvider(
             authInfoService.save(loginInfo, passwordHasher.hash(credentials.password))
           }
           loginInfo
-        case Some(hasher) => throw new AuthenticationException(InvalidPassword.format(id))
-        case None => throw new AuthenticationException(UnsupportedHasher.format(
+        case Some(hasher) => throw new InvalidPasswordException(InvalidPassword.format(id))
+        case None => throw new ConfigurationException(UnsupportedHasher.format(
           id, authInfo.hasher, passwordHasherList.map(_.id).mkString(", ")
         ))
       }
-      case None => throw new AuthenticationException(UnknownCredentials.format(id))
+      case None => throw new IdentityNotFoundException(UnknownCredentials.format(id))
     }
   }
 }

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/OpenIDProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/OpenIDProvider.scala
@@ -18,9 +18,9 @@ package com.mohiva.play.silhouette.impl.providers
 import java.net.URLEncoder
 
 import com.mohiva.play.silhouette.api._
-import com.mohiva.play.silhouette.api.exceptions.AuthenticationException
 import com.mohiva.play.silhouette.api.services.AuthInfo
 import com.mohiva.play.silhouette.api.util.{ ExtractableRequest, HTTPLayer }
+import com.mohiva.play.silhouette.impl.exceptions.UnexpectedResponseException
 import com.mohiva.play.silhouette.impl.providers.OpenIDProvider._
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.mvc._
@@ -53,7 +53,7 @@ abstract class OpenIDProvider(httpLayer: HTTPLayer, service: OpenIDService, sett
     request.extractString(Mode) match {
       // Tries to verify the user after the provider has redirected back to the application
       case Some(_) => service.verifiedID.map(info => Right(info)).recover {
-        case e => throw new AuthenticationException(ErrorVerification.format(id, e.getMessage), e)
+        case e => throw new UnexpectedResponseException(ErrorVerification.format(id, e.getMessage), e)
       }
       // Starts the OpenID authentication process
       case None =>
@@ -64,7 +64,7 @@ abstract class OpenIDProvider(httpLayer: HTTPLayer, service: OpenIDService, sett
           logger.debug("[Silhouette][%s] Redirecting to: %s".format(id, url))
           Left(redirect)
         }.recover {
-          case e => throw new AuthenticationException(ErrorRedirectURL.format(id, e.getMessage), e)
+          case e => throw new UnexpectedResponseException(ErrorRedirectURL.format(id, e.getMessage), e)
         }
     }
   }

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/FacebookProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/FacebookProvider.scala
@@ -20,9 +20,8 @@
 package com.mohiva.play.silhouette.impl.providers.oauth2
 
 import com.mohiva.play.silhouette.api.LoginInfo
-import com.mohiva.play.silhouette.api.exceptions.AuthenticationException
 import com.mohiva.play.silhouette.api.util.HTTPLayer
-import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
+import com.mohiva.play.silhouette.impl.exceptions.{ UnexpectedResponseException, ProfileRetrievalException }
 import com.mohiva.play.silhouette.impl.providers.OAuth2Provider._
 import com.mohiva.play.silhouette.impl.providers._
 import com.mohiva.play.silhouette.impl.providers.oauth2.FacebookProvider._
@@ -97,7 +96,7 @@ abstract class FacebookProvider(httpLayer: HTTPLayer, stateProvider: OAuth2State
     response.body.split("&|=") match {
       case Array(AccessToken, token, Expires, expiresIn) => Success(OAuth2Info(token, None, Some(expiresIn.toInt)))
       case Array(AccessToken, token) => Success(OAuth2Info(token))
-      case _ => Failure(new AuthenticationException(InvalidInfoFormat.format(id, response.body)))
+      case _ => Failure(new UnexpectedResponseException(InvalidInfoFormat.format(id, response.body)))
     }
   }
 }

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/VKProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/VKProvider.scala
@@ -20,9 +20,8 @@
 package com.mohiva.play.silhouette.impl.providers.oauth2
 
 import com.mohiva.play.silhouette.api.LoginInfo
-import com.mohiva.play.silhouette.api.exceptions.AuthenticationException
 import com.mohiva.play.silhouette.api.util.HTTPLayer
-import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
+import com.mohiva.play.silhouette.impl.exceptions.{ UnexpectedResponseException, ProfileRetrievalException }
 import com.mohiva.play.silhouette.impl.providers.OAuth2Provider._
 import com.mohiva.play.silhouette.impl.providers._
 import com.mohiva.play.silhouette.impl.providers.oauth2.VKProvider._
@@ -95,7 +94,7 @@ abstract class VKProvider(httpLayer: HTTPLayer, stateProvider: OAuth2StateProvid
    */
   override protected def buildInfo(response: WSResponse): Try[OAuth2Info] = {
     response.json.validate[OAuth2Info].asEither.fold(
-      error => Failure(new AuthenticationException(InvalidInfoFormat.format(id, error))),
+      error => Failure(new UnexpectedResponseException(InvalidInfoFormat.format(id, error))),
       info => Success(info)
     )
   }

--- a/silhouette/test/com/mohiva/play/silhouette/api/util/DefaultEndpointHandlerSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/api/util/DefaultEndpointHandlerSpec.scala
@@ -12,127 +12,127 @@ import scala.concurrent._
  */
 class DefaultEndpointHandlerSpec extends PlaySpecification {
 
-  "The `handleForbidden` method" should {
+  "The `handleNotAuthenticated` method" should {
     "return an HTML response for an HTML request" in new WithApplication {
       testResponse(
         acceptedMediaType = Some(HTML),
-        expectedStatus = FORBIDDEN,
+        expectedStatus = UNAUTHORIZED,
         expectedContentType = HTML,
         expectedResponseFragment = "<html>",
-        expectedMessage = "silhouette.not.authorized",
-        f = { r: RequestHeader => DefaultEndpointHandler.handleForbidden(r) })
+        expectedMessage = "silhouette.not.authenticated",
+        f = { r: RequestHeader => DefaultEndpointHandler.handleNotAuthenticated(r) })
     }
 
     "return a JSON response for a JSON request" in new WithApplication {
       testResponse(
         acceptedMediaType = Some(JSON),
-        expectedStatus = FORBIDDEN,
+        expectedStatus = UNAUTHORIZED,
         expectedContentType = JSON,
         expectedResponseFragment = "\"success\":false",
-        expectedMessage = "silhouette.not.authorized",
-        f = { r: RequestHeader => DefaultEndpointHandler.handleForbidden(r) })
+        expectedMessage = "silhouette.not.authenticated",
+        f = { r: RequestHeader => DefaultEndpointHandler.handleNotAuthenticated(r) })
     }
 
     "return a XML response for a XML request" in new WithApplication {
       testResponse(
         acceptedMediaType = Some(XML),
-        expectedStatus = FORBIDDEN,
+        expectedStatus = UNAUTHORIZED,
         expectedContentType = XML,
         expectedResponseFragment = "<success>false</success>",
-        expectedMessage = "silhouette.not.authorized",
-        f = { r: RequestHeader => DefaultEndpointHandler.handleForbidden(r) })
+        expectedMessage = "silhouette.not.authenticated",
+        f = { r: RequestHeader => DefaultEndpointHandler.handleNotAuthenticated(r) })
     }
 
     "return a plain text response for a plain text request" in new WithApplication {
       testResponse(
         acceptedMediaType = Some(TEXT),
-        expectedStatus = FORBIDDEN,
+        expectedStatus = UNAUTHORIZED,
         expectedContentType = TEXT,
-        expectedResponseFragment = Messages("silhouette.not.authorized"),
-        expectedMessage = "silhouette.not.authorized",
-        f = { r: RequestHeader => DefaultEndpointHandler.handleForbidden(r) })
+        expectedResponseFragment = Messages("silhouette.not.authenticated"),
+        expectedMessage = "silhouette.not.authenticated",
+        f = { r: RequestHeader => DefaultEndpointHandler.handleNotAuthenticated(r) })
     }
 
     "return a plain text response for other requests" in new WithApplication {
       testResponse(
         acceptedMediaType = Some(BINARY),
-        expectedStatus = FORBIDDEN,
+        expectedStatus = UNAUTHORIZED,
         expectedContentType = TEXT,
-        expectedResponseFragment = Messages("silhouette.not.authorized"),
-        expectedMessage = "silhouette.not.authorized",
-        f = { r: RequestHeader => DefaultEndpointHandler.handleForbidden(r) })
+        expectedResponseFragment = Messages("silhouette.not.authenticated"),
+        expectedMessage = "silhouette.not.authenticated",
+        f = { r: RequestHeader => DefaultEndpointHandler.handleNotAuthenticated(r) })
     }
 
     "return an HTML response for a request without an Accept header" in new WithApplication {
       testResponse(
         acceptedMediaType = None,
-        expectedStatus = FORBIDDEN,
+        expectedStatus = UNAUTHORIZED,
         expectedContentType = HTML,
-        expectedResponseFragment = Messages("silhouette.not.authorized"),
-        expectedMessage = "silhouette.not.authorized",
-        f = { r: RequestHeader => DefaultEndpointHandler.handleForbidden(r) })
+        expectedResponseFragment = Messages("silhouette.not.authenticated"),
+        expectedMessage = "silhouette.not.authenticated",
+        f = { r: RequestHeader => DefaultEndpointHandler.handleNotAuthenticated(r) })
     }
   }
 
-  "The `handleUnauthorized` method" should {
+  "The `handleNotAuthorized` method" should {
     "return an HTML response for an HTML request" in new WithApplication {
       testResponse(
         acceptedMediaType = Some(HTML),
-        expectedStatus = UNAUTHORIZED,
+        expectedStatus = FORBIDDEN,
         expectedContentType = HTML,
         expectedResponseFragment = "<html>",
-        expectedMessage = "silhouette.not.authenticated",
-        f = { r: RequestHeader => DefaultEndpointHandler.handleUnauthorized(r) })
+        expectedMessage = "silhouette.not.authorized",
+        f = { r: RequestHeader => DefaultEndpointHandler.handleNotAuthorized(r) })
     }
 
     "return a JSON response for a JSON request" in new WithApplication {
       testResponse(
         acceptedMediaType = Some(JSON),
-        expectedStatus = UNAUTHORIZED,
+        expectedStatus = FORBIDDEN,
         expectedContentType = JSON,
         expectedResponseFragment = "\"success\":false",
-        expectedMessage = "silhouette.not.authenticated",
-        f = { r: RequestHeader => DefaultEndpointHandler.handleUnauthorized(r) })
+        expectedMessage = "silhouette.not.authorized",
+        f = { r: RequestHeader => DefaultEndpointHandler.handleNotAuthorized(r) })
     }
 
     "return a XML response for a XML request" in new WithApplication {
       testResponse(
         acceptedMediaType = Some(XML),
-        expectedStatus = UNAUTHORIZED,
+        expectedStatus = FORBIDDEN,
         expectedContentType = XML,
         expectedResponseFragment = "<success>false</success>",
-        expectedMessage = "silhouette.not.authenticated",
-        f = { r: RequestHeader => DefaultEndpointHandler.handleUnauthorized(r) })
+        expectedMessage = "silhouette.not.authorized",
+        f = { r: RequestHeader => DefaultEndpointHandler.handleNotAuthorized(r) })
     }
 
     "return a plain text response for a plain text request" in new WithApplication {
       testResponse(
         acceptedMediaType = Some(TEXT),
-        expectedStatus = UNAUTHORIZED,
+        expectedStatus = FORBIDDEN,
         expectedContentType = TEXT,
-        expectedResponseFragment = Messages("silhouette.not.authenticated"),
-        expectedMessage = "silhouette.not.authenticated",
-        f = { r: RequestHeader => DefaultEndpointHandler.handleUnauthorized(r) })
+        expectedResponseFragment = Messages("silhouette.not.authorized"),
+        expectedMessage = "silhouette.not.authorized",
+        f = { r: RequestHeader => DefaultEndpointHandler.handleNotAuthorized(r) })
     }
 
     "return a plain text response for other requests" in new WithApplication {
       testResponse(
         acceptedMediaType = Some(BINARY),
-        expectedStatus = UNAUTHORIZED,
+        expectedStatus = FORBIDDEN,
         expectedContentType = TEXT,
-        expectedResponseFragment = Messages("silhouette.not.authenticated"),
-        expectedMessage = "silhouette.not.authenticated",
-        f = { r: RequestHeader => DefaultEndpointHandler.handleUnauthorized(r) })
+        expectedResponseFragment = Messages("silhouette.not.authorized"),
+        expectedMessage = "silhouette.not.authorized",
+        f = { r: RequestHeader => DefaultEndpointHandler.handleNotAuthorized(r) })
     }
 
     "return an HTML response for a request without an Accept header" in new WithApplication {
       testResponse(
         acceptedMediaType = None,
-        expectedStatus = UNAUTHORIZED,
+        expectedStatus = FORBIDDEN,
         expectedContentType = HTML,
-        expectedResponseFragment = Messages("silhouette.not.authenticated"),
-        expectedMessage = "silhouette.not.authenticated",
-        f = { r: RequestHeader => DefaultEndpointHandler.handleUnauthorized(r) })
+        expectedResponseFragment = Messages("silhouette.not.authorized"),
+        expectedMessage = "silhouette.not.authorized",
+        f = { r: RequestHeader => DefaultEndpointHandler.handleNotAuthorized(r) })
     }
   }
 

--- a/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticatorSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticatorSpec.scala
@@ -16,7 +16,7 @@
 package com.mohiva.play.silhouette.impl.authenticators
 
 import com.mohiva.play.silhouette.api.LoginInfo
-import com.mohiva.play.silhouette.api.exceptions.AuthenticationException
+import com.mohiva.play.silhouette.api.exceptions._
 import com.mohiva.play.silhouette.api.services.AuthenticatorService._
 import com.mohiva.play.silhouette.api.util.{ Clock, FingerprintGenerator, IDGenerator }
 import com.mohiva.play.silhouette.impl.authenticators.CookieAuthenticatorService._
@@ -118,12 +118,12 @@ class CookieAuthenticatorSpec extends PlaySpecification with Mockito {
       await(service.create(loginInfo)).expirationDate must be equalTo now.plusSeconds(sixHours)
     }
 
-    "throws an Authentication exception if an error occurred during creation" in new Context {
+    "throws an AuthenticatorCreationException exception if an error occurred during creation" in new Context {
       implicit val request = FakeRequest()
 
       idGenerator.generate returns Future.failed(new Exception("Could not generate ID"))
 
-      await(service.create(loginInfo)) must throwA[AuthenticationException].like {
+      await(service.create(loginInfo)) must throwA[AuthenticatorCreationException].like {
         case e =>
           e.getMessage must startWith(CreateError.format(ID, ""))
       }
@@ -176,14 +176,14 @@ class CookieAuthenticatorSpec extends PlaySpecification with Mockito {
       await(service.retrieve) must beSome(authenticator)
     }
 
-    "throws an Authentication exception if an error occurred during retrieval" in new Context {
+    "throws an AuthenticatorRetrievalException exception if an error occurred during retrieval" in new Context {
       implicit val request = FakeRequest().withCookies(Cookie(settings.cookieName, authenticator.id))
 
       fingerprintGenerator.generate throws new RuntimeException("Could not generate ID")
       settings.useFingerprinting returns true
       dao.find(authenticator.id) returns Future.successful(Some(authenticator))
 
-      await(service.retrieve) must throwA[AuthenticationException].like {
+      await(service.retrieve) must throwA[AuthenticatorRetrievalException].like {
         case e =>
           e.getMessage must startWith(RetrieveError.format(ID, ""))
       }
@@ -200,12 +200,12 @@ class CookieAuthenticatorSpec extends PlaySpecification with Mockito {
       there was one(dao).save(any)
     }
 
-    "throws an Authentication exception if an error occurred during initialization" in new Context {
+    "throws an AuthenticatorInitializationException exception if an error occurred during initialization" in new Context {
       dao.save(any) returns Future.failed(new Exception("Cannot store authenticator"))
 
       implicit val request = FakeRequest()
 
-      await(service.init(authenticator)) must throwA[AuthenticationException].like {
+      await(service.init(authenticator)) must throwA[AuthenticatorInitializationException].like {
         case e =>
           e.getMessage must startWith(InitError.format(ID, ""))
       }
@@ -295,12 +295,12 @@ class CookieAuthenticatorSpec extends PlaySpecification with Mockito {
       status(result) must be equalTo OK
     }
 
-    "throws an Authentication exception if an error occurred during update" in new Context {
+    "throws an AuthenticatorUpdateException exception if an error occurred during update" in new Context {
       dao.save(any) returns Future.failed(new Exception("Cannot store authenticator"))
 
       implicit val request = FakeRequest()
 
-      await(service.update(authenticator, Future.successful(Results.Ok))) must throwA[AuthenticationException].like {
+      await(service.update(authenticator, Future.successful(Results.Ok))) must throwA[AuthenticatorUpdateException].like {
         case e =>
           e.getMessage must startWith(UpdateError.format(ID, ""))
       }
@@ -348,7 +348,7 @@ class CookieAuthenticatorSpec extends PlaySpecification with Mockito {
       there was one(dao).save(any)
     }
 
-    "throws an Authentication exception if an error occurred during renewal" in new Context {
+    "throws an AuthenticatorRenewalException exception if an error occurred during renewal" in new Context {
       implicit val request = FakeRequest()
       val now = new DateTime
       val id = "new-test-id"
@@ -358,7 +358,7 @@ class CookieAuthenticatorSpec extends PlaySpecification with Mockito {
       idGenerator.generate returns Future.successful(id)
       clock.now returns now
 
-      await(service.renew(authenticator, Future.successful(Results.Ok))) must throwA[AuthenticationException].like {
+      await(service.renew(authenticator, Future.successful(Results.Ok))) must throwA[AuthenticatorRenewalException].like {
         case e =>
           e.getMessage must startWith(RenewError.format(ID, ""))
       }
@@ -384,13 +384,13 @@ class CookieAuthenticatorSpec extends PlaySpecification with Mockito {
       there was one(dao).remove(authenticator.id)
     }
 
-    "throws an Authentication exception if an error occurred during discarding" in new Context {
+    "throws an AuthenticatorDiscardingException exception if an error occurred during discarding" in new Context {
       implicit val request = FakeRequest()
       val okResult = Future.successful(Results.Status(200))
 
       dao.remove(any) returns Future.failed(new Exception("Cannot store authenticator"))
 
-      await(service.discard(authenticator, okResult)) must throwA[AuthenticationException].like {
+      await(service.discard(authenticator, okResult)) must throwA[AuthenticatorDiscardingException].like {
         case e =>
           e.getMessage must startWith(DiscardError.format(ID, ""))
       }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/CredentialsProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/CredentialsProviderSpec.scala
@@ -19,6 +19,7 @@ import com.mohiva.play.silhouette.api.LoginInfo
 import com.mohiva.play.silhouette.api.exceptions._
 import com.mohiva.play.silhouette.api.services.AuthInfoService
 import com.mohiva.play.silhouette.api.util.{ Credentials, PasswordHasher, PasswordInfo }
+import com.mohiva.play.silhouette.impl.exceptions.{ IdentityNotFoundException, InvalidPasswordException }
 import com.mohiva.play.silhouette.impl.providers.CredentialsProvider._
 import org.specs2.mock.Mockito
 import org.specs2.specification.Scope
@@ -32,35 +33,35 @@ import scala.concurrent.Future
 class CredentialsProviderSpec extends PlaySpecification with Mockito {
 
   "The `authenticate` method" should {
-    "throw AuthenticationException if no auth info could be found for the given credentials" in new WithApplication with Context {
+    "throw IdentityNotFoundException if no auth info could be found for the given credentials" in new WithApplication with Context {
       val loginInfo = new LoginInfo(provider.id, credentials.identifier)
 
       authInfoService.retrieve[PasswordInfo](loginInfo) returns Future.successful(None)
 
-      await(provider.authenticate(credentials)) must throwA[AuthenticationException].like {
+      await(provider.authenticate(credentials)) must throwA[IdentityNotFoundException].like {
         case e => e.getMessage must beEqualTo(UnknownCredentials.format(provider.id))
       }
     }
 
-    "throw AuthenticationException if passwords does not match" in new WithApplication with Context {
+    "throw InvalidPasswordException if passwords does not match" in new WithApplication with Context {
       val passwordInfo = PasswordInfo("foo", "hashed(s3cr3t)")
       val loginInfo = LoginInfo(provider.id, credentials.identifier)
 
       fooHasher.matches(passwordInfo, credentials.password) returns false
       authInfoService.retrieve[PasswordInfo](loginInfo) returns Future.successful(Some(passwordInfo))
 
-      await(provider.authenticate(credentials)) must throwA[AuthenticationException].like {
+      await(provider.authenticate(credentials)) must throwA[InvalidPasswordException].like {
         case e => e.getMessage must beEqualTo(InvalidPassword.format(provider.id))
       }
     }
 
-    "throw AuthenticationException if unsupported hasher is stored" in new WithApplication with Context {
+    "throw ConfigurationException if unsupported hasher is stored" in new WithApplication with Context {
       val passwordInfo = PasswordInfo("unknown", "hashed(s3cr3t)")
       val loginInfo = LoginInfo(provider.id, credentials.identifier)
 
       authInfoService.retrieve[PasswordInfo](loginInfo) returns Future.successful(Some(passwordInfo))
 
-      await(provider.authenticate(credentials)) must throwA[AuthenticationException].like {
+      await(provider.authenticate(credentials)) must throwA[ConfigurationException].like {
         case e => e.getMessage must beEqualTo(UnsupportedHasher.format(provider.id, "unknown", "foo, bar"))
       }
     }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/OpenIDProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/OpenIDProviderSpec.scala
@@ -17,8 +17,8 @@ package com.mohiva.play.silhouette.impl.providers
 
 import java.net.URLEncoder
 
-import com.mohiva.play.silhouette.api.exceptions._
 import com.mohiva.play.silhouette.api.util.HTTPLayer
+import com.mohiva.play.silhouette.impl.exceptions.UnexpectedResponseException
 import com.mohiva.play.silhouette.impl.providers.OpenIDProvider._
 import org.specs2.matcher.ThrownExpectations
 import org.specs2.mock.Mockito
@@ -37,12 +37,12 @@ abstract class OpenIDProviderSpec extends SocialProviderSpec[OpenIDInfo] {
 
   "The authenticate method" should {
     val c = context
-    "fail with an AuthenticationException if redirect URL couldn't be retrieved" in new WithApplication {
+    "fail with an UnexpectedResponseException if redirect URL couldn't be retrieved" in new WithApplication {
       implicit val req = FakeRequest()
 
       c.openIDService.redirectURL(any) returns Future.failed(new Exception(""))
 
-      failed[AuthenticationException](c.provider.authenticate()) {
+      failed[UnexpectedResponseException](c.provider.authenticate()) {
         case e => e.getMessage must startWith(ErrorRedirectURL.format(c.provider.id, ""))
       }
     }
@@ -91,11 +91,11 @@ abstract class OpenIDProviderSpec extends SocialProviderSpec[OpenIDInfo] {
       }
     }
 
-    "fail with an AuthenticationException if auth info cannot be retrieved" in new WithApplication {
+    "fail with an UnexpectedResponseException if auth info cannot be retrieved" in new WithApplication {
       implicit val req = FakeRequest(GET, "?" + Mode + "=id_res")
       c.openIDService.verifiedID(any) returns Future.failed(new Exception(""))
 
-      failed[AuthenticationException](c.provider.authenticate()) {
+      failed[UnexpectedResponseException](c.provider.authenticate()) {
         case e => e.getMessage must startWith(ErrorVerification.format(c.provider.id, ""))
       }
     }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/custom/FacebookProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/custom/FacebookProviderSpec.scala
@@ -16,8 +16,7 @@
 package com.mohiva.play.silhouette.impl.providers.custom
 
 import com.mohiva.play.silhouette.api.LoginInfo
-import com.mohiva.play.silhouette.api.exceptions.AuthenticationException
-import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
+import com.mohiva.play.silhouette.impl.exceptions.{ ProfileRetrievalException, UnexpectedResponseException }
 import com.mohiva.play.silhouette.impl.providers.OAuth2Provider._
 import com.mohiva.play.silhouette.impl.providers.SocialProfileBuilder._
 import com.mohiva.play.silhouette.impl.providers._
@@ -36,7 +35,7 @@ import scala.concurrent.Future
 class FacebookProviderSpec extends OAuth2ProviderSpec {
 
   "The `authenticate` method" should {
-    "fail with AuthenticationException if OAuth2Info can be build because of an unexpected response" in new WithApplication with Context {
+    "fail with UnexpectedResponseException if OAuth2Info can be build because of an unexpected response" in new WithApplication with Context {
       val requestHolder = mock[WSRequestHolder]
       val response = mock[WSResponse]
       implicit val req = FakeRequest(GET, "?" + Code + "=my.code")
@@ -46,7 +45,7 @@ class FacebookProviderSpec extends OAuth2ProviderSpec {
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
       stateProvider.validate(any)(any) returns Future.successful(state)
 
-      failed[AuthenticationException](provider.authenticate()) {
+      failed[UnexpectedResponseException](provider.authenticate()) {
         case e => e.getMessage must equalTo(InvalidInfoFormat.format(provider.id, ""))
       }
     }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/secrets/CookieSecretSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/secrets/CookieSecretSpec.scala
@@ -16,8 +16,8 @@
 package com.mohiva.play.silhouette.impl.providers.oauth1.secrets
 
 import com.mohiva.play.silhouette.api.util.Clock
+import com.mohiva.play.silhouette.impl.exceptions.OAuth1TokenSecretException
 import com.mohiva.play.silhouette.impl.providers.OAuth1Info
-import com.mohiva.play.silhouette.impl.providers.oauth1.exceptions.TokenSecretException
 import com.mohiva.play.silhouette.impl.providers.oauth1.secrets.CookieSecretProvider._
 import org.joda.time.DateTime
 import org.specs2.matcher.JsonMatchers
@@ -72,7 +72,7 @@ class CookieSecretSpec extends PlaySpecification with Mockito with JsonMatchers 
     "throw an TokenSecretException if client secret doesn't exists" in new Context {
       implicit val req = FakeRequest()
 
-      await(provider.retrieve("test")) must throwA[TokenSecretException].like {
+      await(provider.retrieve("test")) must throwA[OAuth1TokenSecretException].like {
         case e => e.getMessage must startWith(ClientSecretDoesNotExists.format("test", ""))
       }
     }
@@ -82,7 +82,7 @@ class CookieSecretSpec extends PlaySpecification with Mockito with JsonMatchers 
 
       implicit val req = FakeRequest().withCookies(Cookie(settings.cookieName, invalidSecret))
 
-      await(provider.retrieve("test")) must throwA[TokenSecretException].like {
+      await(provider.retrieve("test")) must throwA[OAuth1TokenSecretException].like {
         case e => e.getMessage must startWith(InvalidSecretFormat.format("test", ""))
       }
     }
@@ -92,7 +92,7 @@ class CookieSecretSpec extends PlaySpecification with Mockito with JsonMatchers 
 
       implicit val req = FakeRequest().withCookies(Cookie(settings.cookieName, invalidSecret))
 
-      await(provider.retrieve("test")) must throwA[TokenSecretException].like {
+      await(provider.retrieve("test")) must throwA[OAuth1TokenSecretException].like {
         case e => e.getMessage must startWith(InvalidSecretFormat.format("test", ""))
       }
     }
@@ -102,7 +102,7 @@ class CookieSecretSpec extends PlaySpecification with Mockito with JsonMatchers 
 
       implicit val req = FakeRequest().withCookies(Cookie(settings.cookieName, expiredSecret.serialize))
 
-      await(provider.retrieve("test")) must throwA[TokenSecretException].like {
+      await(provider.retrieve("test")) must throwA[OAuth1TokenSecretException].like {
         case e => e.getMessage must startWith(SecretIsExpired.format("test"))
       }
     }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/ClefProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/ClefProviderSpec.scala
@@ -16,8 +16,7 @@
 package com.mohiva.play.silhouette.impl.providers.oauth2
 
 import com.mohiva.play.silhouette.api.LoginInfo
-import com.mohiva.play.silhouette.api.exceptions.AuthenticationException
-import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
+import com.mohiva.play.silhouette.impl.exceptions.{ ProfileRetrievalException, UnexpectedResponseException }
 import com.mohiva.play.silhouette.impl.providers.OAuth2Provider._
 import com.mohiva.play.silhouette.impl.providers.SocialProfileBuilder._
 import com.mohiva.play.silhouette.impl.providers._
@@ -35,7 +34,7 @@ import scala.concurrent.Future
 class ClefProviderSpec extends OAuth2ProviderSpec {
 
   "The `authenticate` method" should {
-    "fail with AuthenticationException if OAuth2Info can be build because of an unexpected response" in new WithApplication with Context {
+    "fail with UnexpectedResponseException if OAuth2Info can be build because of an unexpected response" in new WithApplication with Context {
       val requestHolder = mock[WSRequestHolder]
       val response = mock[WSResponse]
       implicit val req = FakeRequest(GET, "?" + Code + "=my.code")
@@ -45,7 +44,7 @@ class ClefProviderSpec extends OAuth2ProviderSpec {
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
       stateProvider.validate(any)(any) returns Future.successful(state)
 
-      failed[AuthenticationException](provider.authenticate()) {
+      failed[UnexpectedResponseException](provider.authenticate()) {
         case e => e.getMessage must startWith(InvalidInfoFormat.format(provider.id, ""))
       }
     }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/DropboxProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/DropboxProviderSpec.scala
@@ -16,8 +16,7 @@
 package com.mohiva.play.silhouette.impl.providers.oauth2
 
 import com.mohiva.play.silhouette.api.LoginInfo
-import com.mohiva.play.silhouette.api.exceptions.AuthenticationException
-import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
+import com.mohiva.play.silhouette.impl.exceptions.{ UnexpectedResponseException, ProfileRetrievalException }
 import com.mohiva.play.silhouette.impl.providers.OAuth2Provider._
 import com.mohiva.play.silhouette.impl.providers.SocialProfileBuilder._
 import com.mohiva.play.silhouette.impl.providers._
@@ -35,7 +34,7 @@ import scala.concurrent.Future
 class DropboxProviderSpec extends OAuth2ProviderSpec {
 
   "The `authenticate` method" should {
-    "fail with AuthenticationException if OAuth2Info can be build because of an unexpected response" in new WithApplication with Context {
+    "fail with UnexpectedResponseException if OAuth2Info can be build because of an unexpected response" in new WithApplication with Context {
       val requestHolder = mock[WSRequestHolder]
       val response = mock[WSResponse]
       implicit val req = FakeRequest(GET, "?" + Code + "=my.code")
@@ -45,7 +44,7 @@ class DropboxProviderSpec extends OAuth2ProviderSpec {
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
       stateProvider.validate(any)(any) returns Future.successful(state)
 
-      failed[AuthenticationException](provider.authenticate()) {
+      failed[UnexpectedResponseException](provider.authenticate()) {
         case e => e.getMessage must startWith(InvalidInfoFormat.format(provider.id, ""))
       }
     }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/FacebookProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/FacebookProviderSpec.scala
@@ -16,8 +16,7 @@
 package com.mohiva.play.silhouette.impl.providers.oauth2
 
 import com.mohiva.play.silhouette.api.LoginInfo
-import com.mohiva.play.silhouette.api.exceptions.AuthenticationException
-import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
+import com.mohiva.play.silhouette.impl.exceptions.{ ProfileRetrievalException, UnexpectedResponseException }
 import com.mohiva.play.silhouette.impl.providers.OAuth2Provider._
 import com.mohiva.play.silhouette.impl.providers.SocialProfileBuilder._
 import com.mohiva.play.silhouette.impl.providers._
@@ -34,7 +33,7 @@ import scala.concurrent.Future
 class FacebookProviderSpec extends OAuth2ProviderSpec {
 
   "The `authenticate` method" should {
-    "fail with AuthenticationException if OAuth2Info can be build because of an unexpected response" in new WithApplication with Context {
+    "fail with UnexpectedResponseException if OAuth2Info can be build because of an invalid response" in new WithApplication with Context {
       val requestHolder = mock[WSRequestHolder]
       val response = mock[WSResponse]
       implicit val req = FakeRequest(GET, "?" + Code + "=my.code")
@@ -44,7 +43,7 @@ class FacebookProviderSpec extends OAuth2ProviderSpec {
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
       stateProvider.validate(any)(any) returns Future.successful(state)
 
-      failed[AuthenticationException](provider.authenticate()) {
+      failed[UnexpectedResponseException](provider.authenticate()) {
         case e => e.getMessage must equalTo(InvalidInfoFormat.format(provider.id, ""))
       }
     }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/FoursquareProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/FoursquareProviderSpec.scala
@@ -16,8 +16,7 @@
 package com.mohiva.play.silhouette.impl.providers.oauth2
 
 import com.mohiva.play.silhouette.api.LoginInfo
-import com.mohiva.play.silhouette.api.exceptions.AuthenticationException
-import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
+import com.mohiva.play.silhouette.impl.exceptions.{ ProfileRetrievalException, UnexpectedResponseException }
 import com.mohiva.play.silhouette.impl.providers.OAuth2Provider._
 import com.mohiva.play.silhouette.impl.providers.SocialProfileBuilder._
 import com.mohiva.play.silhouette.impl.providers._
@@ -35,7 +34,7 @@ import scala.concurrent.Future
 class FoursquareProviderSpec extends OAuth2ProviderSpec {
 
   "The `authenticate` method" should {
-    "fail with AuthenticationException if OAuth2Info can be build because of an unexpected response" in new WithApplication with Context {
+    "fail with UnexpectedResponseException if OAuth2Info can be build because of an unexpected response" in new WithApplication with Context {
       val requestHolder = mock[WSRequestHolder]
       val response = mock[WSResponse]
       implicit val req = FakeRequest(GET, "?" + Code + "=my.code")
@@ -45,7 +44,7 @@ class FoursquareProviderSpec extends OAuth2ProviderSpec {
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
       stateProvider.validate(any)(any) returns Future.successful(state)
 
-      failed[AuthenticationException](provider.authenticate()) {
+      failed[UnexpectedResponseException](provider.authenticate()) {
         case e => e.getMessage must startWith(InvalidInfoFormat.format(provider.id, ""))
       }
     }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/GitHubProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/GitHubProviderSpec.scala
@@ -16,8 +16,7 @@
 package com.mohiva.play.silhouette.impl.providers.oauth2
 
 import com.mohiva.play.silhouette.api.LoginInfo
-import com.mohiva.play.silhouette.api.exceptions.AuthenticationException
-import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
+import com.mohiva.play.silhouette.impl.exceptions.{ ProfileRetrievalException, UnexpectedResponseException }
 import com.mohiva.play.silhouette.impl.providers.OAuth2Provider._
 import com.mohiva.play.silhouette.impl.providers.SocialProfileBuilder._
 import com.mohiva.play.silhouette.impl.providers._
@@ -36,7 +35,7 @@ import scala.concurrent.Future
 class GitHubProviderSpec extends OAuth2ProviderSpec {
 
   "The `authenticate` method" should {
-    "fail with AuthenticationException if OAuth2Info can be build because of an unexpected response" in new WithApplication with Context {
+    "fail with UnexpectedResponseException if OAuth2Info can be build because of an unexpected response" in new WithApplication with Context {
       val requestHolder = mock[WSRequestHolder]
       val response = mock[WSResponse]
       implicit val req = FakeRequest(GET, "?" + Code + "=my.code")
@@ -46,7 +45,7 @@ class GitHubProviderSpec extends OAuth2ProviderSpec {
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
       stateProvider.validate(any)(any) returns Future.successful(state)
 
-      failed[AuthenticationException](provider.authenticate()) {
+      failed[UnexpectedResponseException](provider.authenticate()) {
         case e => e.getMessage must startWith(InvalidInfoFormat.format(provider.id, ""))
       }
     }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/GoogleProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/GoogleProviderSpec.scala
@@ -16,8 +16,7 @@
 package com.mohiva.play.silhouette.impl.providers.oauth2
 
 import com.mohiva.play.silhouette.api.LoginInfo
-import com.mohiva.play.silhouette.api.exceptions.AuthenticationException
-import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
+import com.mohiva.play.silhouette.impl.exceptions.{ ProfileRetrievalException, UnexpectedResponseException }
 import com.mohiva.play.silhouette.impl.providers.OAuth2Provider._
 import com.mohiva.play.silhouette.impl.providers.SocialProfileBuilder._
 import com.mohiva.play.silhouette.impl.providers._
@@ -35,7 +34,7 @@ import scala.concurrent.Future
 class GoogleProviderSpec extends OAuth2ProviderSpec {
 
   "The `authenticate` method" should {
-    "fail with AuthenticationException if OAuth2Info can be build because of an unexpected response" in new WithApplication with Context {
+    "fail with UnexpectedResponseException if OAuth2Info can be build because of an unexpected response" in new WithApplication with Context {
       val requestHolder = mock[WSRequestHolder]
       val response = mock[WSResponse]
       implicit val req = FakeRequest(GET, "?" + Code + "=my.code")
@@ -45,7 +44,7 @@ class GoogleProviderSpec extends OAuth2ProviderSpec {
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
       stateProvider.validate(any)(any) returns Future.successful(state)
 
-      failed[AuthenticationException](provider.authenticate()) {
+      failed[UnexpectedResponseException](provider.authenticate()) {
         case e => e.getMessage must startWith(InvalidInfoFormat.format(provider.id, ""))
       }
     }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/InstagramProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/InstagramProviderSpec.scala
@@ -16,8 +16,7 @@
 package com.mohiva.play.silhouette.impl.providers.oauth2
 
 import com.mohiva.play.silhouette.api.LoginInfo
-import com.mohiva.play.silhouette.api.exceptions.AuthenticationException
-import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
+import com.mohiva.play.silhouette.impl.exceptions.{ ProfileRetrievalException, UnexpectedResponseException }
 import com.mohiva.play.silhouette.impl.providers.OAuth2Provider._
 import com.mohiva.play.silhouette.impl.providers.SocialProfileBuilder._
 import com.mohiva.play.silhouette.impl.providers._
@@ -35,7 +34,7 @@ import scala.concurrent.Future
 class InstagramProviderSpec extends OAuth2ProviderSpec {
 
   "The `authenticate` method" should {
-    "fail with AuthenticationException if OAuth2Info can be build because of an unexpected response" in new WithApplication with Context {
+    "fail with UnexpectedResponseException if OAuth2Info can be build because of an unexpected response" in new WithApplication with Context {
       val requestHolder = mock[WSRequestHolder]
       val response = mock[WSResponse]
       implicit val req = FakeRequest(GET, "?" + Code + "=my.code")
@@ -45,7 +44,7 @@ class InstagramProviderSpec extends OAuth2ProviderSpec {
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
       stateProvider.validate(any)(any) returns Future.successful(state)
 
-      failed[AuthenticationException](provider.authenticate()) {
+      failed[UnexpectedResponseException](provider.authenticate()) {
         case e => e.getMessage must startWith(InvalidInfoFormat.format(provider.id, ""))
       }
     }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/LinkedInProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/LinkedInProviderSpec.scala
@@ -16,8 +16,7 @@
 package com.mohiva.play.silhouette.impl.providers.oauth2
 
 import com.mohiva.play.silhouette.api.LoginInfo
-import com.mohiva.play.silhouette.api.exceptions.AuthenticationException
-import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
+import com.mohiva.play.silhouette.impl.exceptions.{ ProfileRetrievalException, UnexpectedResponseException }
 import com.mohiva.play.silhouette.impl.providers.OAuth2Provider._
 import com.mohiva.play.silhouette.impl.providers.SocialProfileBuilder._
 import com.mohiva.play.silhouette.impl.providers._
@@ -35,7 +34,7 @@ import scala.concurrent.Future
 class LinkedInProviderSpec extends OAuth2ProviderSpec {
 
   "The `authenticate` method" should {
-    "fail with AuthenticationException if OAuth2Info can be build because of an unexpected response" in new WithApplication with Context {
+    "fail with UnexpectedResponseException if OAuth2Info can be build because of an unexpected response" in new WithApplication with Context {
       val requestHolder = mock[WSRequestHolder]
       val response = mock[WSResponse]
       implicit val req = FakeRequest(GET, "?" + Code + "=my.code")
@@ -45,7 +44,7 @@ class LinkedInProviderSpec extends OAuth2ProviderSpec {
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
       stateProvider.validate(any)(any) returns Future.successful(state)
 
-      failed[AuthenticationException](provider.authenticate()) {
+      failed[UnexpectedResponseException](provider.authenticate()) {
         case e => e.getMessage must startWith(InvalidInfoFormat.format(provider.id, ""))
       }
     }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/VKProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/VKProviderSpec.scala
@@ -16,8 +16,7 @@
 package com.mohiva.play.silhouette.impl.providers.oauth2
 
 import com.mohiva.play.silhouette.api.LoginInfo
-import com.mohiva.play.silhouette.api.exceptions.AuthenticationException
-import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
+import com.mohiva.play.silhouette.impl.exceptions.{ ProfileRetrievalException, UnexpectedResponseException }
 import com.mohiva.play.silhouette.impl.providers.OAuth2Provider._
 import com.mohiva.play.silhouette.impl.providers.SocialProfileBuilder._
 import com.mohiva.play.silhouette.impl.providers._
@@ -35,7 +34,7 @@ import scala.concurrent.Future
 class VKProviderSpec extends OAuth2ProviderSpec {
 
   "The `authenticate` method" should {
-    "fail with AuthenticationException if OAuth2Info can be build because of an unexpected response" in new WithApplication with Context {
+    "fail with UnexpectedResponseException if OAuth2Info can be build because of an unexpected response" in new WithApplication with Context {
       val requestHolder = mock[WSRequestHolder]
       val response = mock[WSResponse]
       implicit val req = FakeRequest(GET, "?" + Code + "=my.code")
@@ -45,7 +44,7 @@ class VKProviderSpec extends OAuth2ProviderSpec {
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
       stateProvider.validate(any)(any) returns Future.successful(state)
 
-      failed[AuthenticationException](provider.authenticate()) {
+      failed[UnexpectedResponseException](provider.authenticate()) {
         case e => e.getMessage must startWith(InvalidInfoFormat.format(provider.id, ""))
       }
     }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/state/CookieStateSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/state/CookieStateSpec.scala
@@ -16,8 +16,8 @@
 package com.mohiva.play.silhouette.impl.providers.oauth2.state
 
 import com.mohiva.play.silhouette.api.util.{ Base64, Clock, IDGenerator }
+import com.mohiva.play.silhouette.impl.exceptions.OAuth2StateException
 import com.mohiva.play.silhouette.impl.providers.OAuth2Provider._
-import com.mohiva.play.silhouette.impl.providers.oauth2.exceptions.StateException
 import com.mohiva.play.silhouette.impl.providers.oauth2.state.CookieStateProvider._
 import org.joda.time.DateTime
 import org.specs2.matcher.JsonMatchers
@@ -73,7 +73,7 @@ class CookieStateSpec extends PlaySpecification with Mockito with JsonMatchers {
     "throw an StateException if client state doesn't exists" in new Context {
       implicit val req = FakeRequest(GET, s"?$State=${state.serialize}")
 
-      await(provider.validate("test")) must throwA[StateException].like {
+      await(provider.validate("test")) must throwA[OAuth2StateException].like {
         case e => e.getMessage must startWith(ClientStateDoesNotExists.format("test", ""))
       }
     }
@@ -81,7 +81,7 @@ class CookieStateSpec extends PlaySpecification with Mockito with JsonMatchers {
     "throw an StateException if provider state doesn't exists" in new WithApplication with Context {
       implicit val req = FakeRequest(GET, "/").withCookies(Cookie(settings.cookieName, state.serialize))
 
-      await(provider.validate("test")) must throwA[StateException].like {
+      await(provider.validate("test")) must throwA[OAuth2StateException].like {
         case e => e.getMessage must startWith(ProviderStateDoesNotExists.format("test", ""))
       }
     }
@@ -91,7 +91,7 @@ class CookieStateSpec extends PlaySpecification with Mockito with JsonMatchers {
 
       implicit val req = FakeRequest(GET, s"?$State=${state.serialize}").withCookies(Cookie(settings.cookieName, invalidState))
 
-      await(provider.validate("test")) must throwA[StateException].like {
+      await(provider.validate("test")) must throwA[OAuth2StateException].like {
         case e => e.getMessage must startWith(InvalidStateFormat.format("test", ""))
       }
     }
@@ -101,7 +101,7 @@ class CookieStateSpec extends PlaySpecification with Mockito with JsonMatchers {
 
       implicit val req = FakeRequest(GET, s"?$State=${state.serialize}").withCookies(Cookie(settings.cookieName, invalidState))
 
-      await(provider.validate("test")) must throwA[StateException].like {
+      await(provider.validate("test")) must throwA[OAuth2StateException].like {
         case e => e.getMessage must startWith(InvalidStateFormat.format("test", ""))
       }
     }
@@ -111,7 +111,7 @@ class CookieStateSpec extends PlaySpecification with Mockito with JsonMatchers {
 
       implicit val req = FakeRequest(GET, s"?$State=$invalidState").withCookies(Cookie(settings.cookieName, state.serialize))
 
-      await(provider.validate("test")) must throwA[StateException].like {
+      await(provider.validate("test")) must throwA[OAuth2StateException].like {
         case e => e.getMessage must startWith(InvalidStateFormat.format("test", ""))
       }
     }
@@ -121,7 +121,7 @@ class CookieStateSpec extends PlaySpecification with Mockito with JsonMatchers {
 
       implicit val req = FakeRequest(GET, s"?$State=$invalidState").withCookies(Cookie(settings.cookieName, state.serialize))
 
-      await(provider.validate("test")) must throwA[StateException].like {
+      await(provider.validate("test")) must throwA[OAuth2StateException].like {
         case e => e.getMessage must startWith(InvalidStateFormat.format("test", ""))
       }
     }
@@ -132,7 +132,7 @@ class CookieStateSpec extends PlaySpecification with Mockito with JsonMatchers {
 
       implicit val req = FakeRequest(GET, s"?$State=${providerState.serialize}").withCookies(Cookie(settings.cookieName, clientState.serialize))
 
-      await(provider.validate("test")) must throwA[StateException].like {
+      await(provider.validate("test")) must throwA[OAuth2StateException].like {
         case e => e.getMessage must startWith(StateIsNotEqual.format("test"))
       }
     }
@@ -142,7 +142,7 @@ class CookieStateSpec extends PlaySpecification with Mockito with JsonMatchers {
 
       implicit val req = FakeRequest(GET, s"?$State=${expiredState.serialize}").withCookies(Cookie(settings.cookieName, expiredState.serialize))
 
-      await(provider.validate("test")) must throwA[StateException].like {
+      await(provider.validate("test")) must throwA[OAuth2StateException].like {
         case e => e.getMessage must startWith(StateIsExpired.format("test"))
       }
     }


### PR DESCRIPTION
This pull request simplifies the handling of the exceptions and the fallback methods to show the appropriate status codes. Previously it was confusing that the `notAuthenticated` method handles the `401 Unauthorized` status code and the `notAuthorized` method handles the `403 Forbidden` result. Now this is completely unified:

There are now three types of exceptions:
`UnauthorizedException` -> handles the `401 Unauthorized` status code
`ForbiddenException` -> handles the `403 Forbidden` status code
`AuthenticationException` -> handles errors in the authentication flow

The `notAuthenticated` fallback handler was renamed to `onUnauthorized` and the `notAuthorized` fallback handler was renamed to `handleForbidden`.

The credential based providers will now throw an `UnauthorizedException` if the password doesn't match or if the user couldn't be found.

The exceptions do not log the errors anymore. Instead the exception handler will log an info for the `UnauthorizedException` and the `ForbiddenException`. The `AuthenticationException` will not be handled by the exception handler. This should be handled by the user or by the global `onError` handler.

Any suggestion would be highly appreciated. Especially from @rfranco or @igorbernstein.