### PR TITLE
Fix typo in a code sample

### DIFF
--- a/docs/how-it-works/identity.rst
+++ b/docs/how-it-works/identity.rst
@@ -38,7 +38,7 @@ name and email.
 
 .. code-block:: scala
 
-    case class User(,
+    case class User(
       userID: Long,
       loginInfo: LoginInfo,
       name: String,


### PR DESCRIPTION
I found a small typo in a code sample from documentation: there is an extra comma at the end of line no 41