### PR TITLE
Relative callback urls?

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth1Provider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth1Provider.scala
@@ -87,7 +87,7 @@ abstract class OAuth1Provider(
         }
         // The oauth_verifier field is not in the request.
         // This is the first step in the OAuth flow. We need to get the request tokens.
-        case _ => service.retrieveRequestToken(settings.callbackURL).flatMap { info =>
+        case _ => service.retrieveRequestToken(resolveCallbackURL(settings.callbackURL)).flatMap { info =>
           tokenSecretProvider.build(info).map { tokenSecret =>
             val url = service.redirectUrl(info.token)
             val redirect = Results.Redirect(url)
@@ -253,6 +253,7 @@ trait OAuth1TokenSecretProvider {
  * @param accessTokenURL The access token URL provided by the OAuth provider.
  * @param authorizationURL The authorization URL provided by the OAuth provider.
  * @param callbackURL The callback URL to the application after a successful authentication on the OAuth provider.
+ *                    The URL can be a relative path which will be resolved against the current request's host.
  * @param consumerKey The consumer ID provided by the OAuth provider.
  * @param consumerSecret The consumer secret provided by the OAuth provider.
  */

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/openid/services/PlayOpenIDService.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/openid/services/PlayOpenIDService.scala
@@ -38,10 +38,11 @@ class PlayOpenIDService(settings: OpenIDSettings) extends OpenIDService {
    * Retrieve the URL where the user should be redirected to start the OpenID authentication process.
    *
    * @param openID The OpenID to use for authentication.
+   * @param resolvedCallbackURL The full callback URL to the application after a successful authentication.
    * @return The redirect URL where the user should be redirected to start the OpenID authentication process.
    */
-  def redirectURL(openID: String): Future[String] = Try {
-    OpenID.redirectURL(openID, settings.callbackURL, settings.axRequired, settings.axOptional, settings.realm)
+  def redirectURL(openID: String, resolvedCallbackURL: String): Future[String] = Try {
+    OpenID.redirectURL(openID, resolvedCallbackURL, settings.axRequired, settings.axOptional, settings.realm)
   } match {
     case Success(f) => f
     case Failure(e) => Future.failed(e)

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/LinkedInProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/LinkedInProviderSpec.scala
@@ -101,13 +101,13 @@ class LinkedInProviderSpec extends OAuth1ProviderSpec {
     /**
      * The OAuth1 settings.
      */
-    lazy val oAuthSettings = OAuth1Settings(
+    lazy val oAuthSettings = spy(OAuth1Settings(
       requestTokenURL = "https://api.linkedin.com/uas/oauth/requestToken",
       accessTokenURL = "https://api.linkedin.com/uas/oauth/accessToken",
       authorizationURL = "https://api.linkedin.com/uas/oauth/authenticate",
       callbackURL = "https://www.mohiva.com",
       consumerKey = "my.consumer.key",
-      consumerSecret = "my.consumer.secret")
+      consumerSecret = "my.consumer.secret"))
 
     /**
      * The provider to test.

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/TwitterProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/TwitterProviderSpec.scala
@@ -95,13 +95,13 @@ class TwitterProviderSpec extends OAuth1ProviderSpec {
     /**
      * The OAuth1 settings.
      */
-    lazy val oAuthSettings = OAuth1Settings(
+    lazy val oAuthSettings = spy(OAuth1Settings(
       requestTokenURL = "https://twitter.com/oauth/request_token",
       accessTokenURL = "https://twitter.com/oauth/access_token",
       authorizationURL = "https://twitter.com/oauth/authenticate",
       callbackURL = "https://www.mohiva.com",
       consumerKey = "my.consumer.key",
-      consumerSecret = "my.consumer.secret")
+      consumerSecret = "my.consumer.secret"))
 
     /**
      * The provider to test.

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/XingProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/XingProviderSpec.scala
@@ -98,13 +98,13 @@ class XingProviderSpec extends OAuth1ProviderSpec {
     /**
      * The OAuth1 settings.
      */
-    lazy val oAuthSettings = OAuth1Settings(
+    lazy val oAuthSettings = spy(OAuth1Settings(
       requestTokenURL = "https://api.xing.com/v1/request_token",
       accessTokenURL = "https://api.xing.com/v1/access_token",
       authorizationURL = "https://api.xing.com/v1/authorize",
       callbackURL = "https://www.mohiva.com",
       consumerKey = "my.consumer.key",
-      consumerSecret = "my.consumer.secret")
+      consumerSecret = "my.consumer.secret"))
 
     /**
      * The provider to test.

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/openid/SteamProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/openid/SteamProviderSpec.scala
@@ -54,11 +54,11 @@ class SteamProviderSpec extends OpenIDProviderSpec {
     /**
      * The OpenID settings.
      */
-    lazy val openIDSettings = OpenIDSettings(
+    lazy val openIDSettings = spy(OpenIDSettings(
       providerURL = "https://steamcommunity.com/openid/",
       callbackURL = "http://localhost:9000/authenticate/steam",
       realm = Some("http://localhost:9000")
-    )
+    ))
 
     /**
      * The provider to test.

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/openid/YahooProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/openid/YahooProviderSpec.scala
@@ -62,7 +62,7 @@ class YahooProviderSpec extends OpenIDProviderSpec {
     /**
      * The OpenID settings.
      */
-    lazy val openIDSettings = OpenIDSettings(
+    lazy val openIDSettings = spy(OpenIDSettings(
       providerURL = "https://me.yahoo.com/",
       callbackURL = "http://localhost:9000/authenticate/yahoo",
       axRequired = Seq(
@@ -71,7 +71,7 @@ class YahooProviderSpec extends OpenIDProviderSpec {
         "image" -> "http://axschema.org/media/image/default"
       ),
       realm = Some("http://localhost:9000")
-    )
+    ))
 
     /**
      * The provider to test.


### PR DESCRIPTION
Please excuse this incomplete PR, its only meant to start a discussion.  I was wondering if you would be open to the idea of allowing relative callback urls in OAuth1, OAuth2 & OpenID settings?  I figure that
- the urls should be configured using play's reverse routes
- the only thing that changes between environments is the domain
- in almost all cases, the domain that starts the oauth flow is the one that will get the redirect from the 3rd party provider
- having less duplication in the conf files is a good thing

Expected usage:
```scala
def provideFacebookProvider(httpLayer: HTTPLayer, stateProvider: OAuth2StateProvider): FacebookProvider = {
    FacebookProvider(httpLayer, stateProvider, OAuth2Settings(
      //...
      redirectURL = routes.SocialAuthController.authenticate("facebook").toString
     //...
  }
```

My current approach should be backwards compatible with absolute urls.

If you are interested in this & are ok with the approach, I'll add tests & doc

Best,
Igor