### PR TITLE
Extract EventBus trait

### DIFF
--- a/silhouette-testkit/app/com/mohiva/play/silhouette/test/Fakes.scala
+++ b/silhouette-testkit/app/com/mohiva/play/silhouette/test/Fakes.scala
@@ -194,6 +194,18 @@ object FakeAuthenticator {
 }
 
 /**
+ * A fake event bus that discards all events.
+ */
+case class FakeEventBus() extends EventBus {
+
+  /**
+   * Publishes the event.
+   * @param event The event to publish
+   */
+  override def publish(event: SilhouetteEvent): Unit = ()
+}
+
+/**
  * A fake environment implementation.
  *
  * @param identities A list of (login info -> identity) pairs to return inside a Silhouette action.
@@ -205,7 +217,7 @@ object FakeAuthenticator {
 case class FakeEnvironment[I <: Identity, T <: Authenticator: TypeTag](
   identities: Seq[(LoginInfo, I)],
   providers: Map[String, Provider] = Map(),
-  eventBus: EventBus = EventBus())
+  eventBus: EventBus = FakeEventBus())
   extends Environment[I, T] {
 
   /**

--- a/silhouette/app/com/mohiva/play/silhouette/api/EventBus.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/EventBus.scala
@@ -15,8 +15,6 @@
  */
 package com.mohiva.play.silhouette.api
 
-import akka.event.{ SubchannelClassification, ActorEventBus, LookupClassification }
-import akka.util.Subclassification
 import play.api.i18n.Lang
 import play.api.mvc.RequestHeader
 
@@ -84,51 +82,13 @@ case class NotAuthenticatedEvent(request: RequestHeader, lang: Lang) extends Sil
 case class NotAuthorizedEvent[I <: Identity](identity: I, request: RequestHeader, lang: Lang) extends SilhouetteEvent
 
 /**
- * An event bus implementation which uses a class based lookup classification.
+ * The EventBus api, used to publish authentication related events.
  */
-class EventBus extends ActorEventBus with SubchannelClassification {
-  type Classifier = Class[_ <: SilhouetteEvent]
-  type Event = SilhouetteEvent
+trait EventBus {
 
   /**
-   * The logic to form sub-class hierarchy
+   * Publishes the event.
+   * @param event The event to publish
    */
-  protected implicit val subclassification = new Subclassification[Classifier] {
-    def isEqual(x: Classifier, y: Classifier): Boolean = x == y
-    def isSubclass(x: Classifier, y: Classifier): Boolean = y.isAssignableFrom(x)
-  }
-
-  /**
-   * Publishes the given Event to the given Subscriber.
-   *
-   * @param event The Event to publish.
-   * @param subscriber The Subscriber to which the Event should be published.
-   */
-  protected def publish(event: Event, subscriber: Subscriber): Unit = subscriber ! event
-
-  /**
-   * Returns the Classifier associated with the given Event.
-   *
-   * @param event The event for which the Classifier should be returned.
-   * @return The Classifier for the given Event..
-   */
-  protected def classify(event: Event): Classifier = event.getClass
-}
-
-/**
- * A global event bus instance.
- */
-object EventBus {
-
-  /**
-   * Holds the global event bus instance.
-   */
-  private lazy val instance = new EventBus
-
-  /**
-   * Gets a global event bus instance.
-   *
-   * @return A global event bus instance.
-   */
-  def apply() = instance
+  def publish(event: SilhouetteEvent): Unit
 }

--- a/silhouette/app/com/mohiva/play/silhouette/impl/util/AkkaEventBus.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/util/AkkaEventBus.scala
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mohiva.play.silhouette.impl.util
+
+import akka.event.{ ActorEventBus, SubchannelClassification }
+import akka.util.Subclassification
+import com.mohiva.play.silhouette.api.{ EventBus, SilhouetteEvent }
+
+/**
+ * An event bus implementation using Akka which uses a class based lookup classification.
+ */
+class AkkaEventBus extends ActorEventBus with EventBus with SubchannelClassification {
+  type Classifier = Class[_ <: SilhouetteEvent]
+  type Event = SilhouetteEvent
+
+  /**
+   * The logic to form sub-class hierarchy
+   */
+  protected implicit val subclassification = new Subclassification[Classifier] {
+    def isEqual(x: Classifier, y: Classifier): Boolean = x == y
+    def isSubclass(x: Classifier, y: Classifier): Boolean = y.isAssignableFrom(x)
+  }
+
+  /**
+   * Publishes the given Event to the given Subscriber.
+   *
+   * @param event The Event to publish.
+   * @param subscriber The Subscriber to which the Event should be published.
+   */
+  protected def publish(event: Event, subscriber: Subscriber): Unit = subscriber ! event
+
+  /**
+   * Returns the Classifier associated with the given Event.
+   *
+   * @param event The event for which the Classifier should be returned.
+   * @return The Classifier for the given Event..
+   */
+  protected def classify(event: Event): Classifier = event.getClass
+}
+
+/**
+ * A global event bus instance.
+ */
+object AkkaEventBus {
+
+  /**
+   * Holds the global event bus instance.
+   */
+  private lazy val instance = new AkkaEventBus
+
+  /**
+   * Gets a global event bus instance.
+   *
+   * @return A global event bus instance.
+   */
+  def apply() = instance
+}

--- a/silhouette/test/com/mohiva/play/silhouette/impl/util/EventBusSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/util/EventBusSpec.scala
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.mohiva.play.silhouette.api
+package com.mohiva.play.silhouette.impl.util
 
 import akka.actor.{ Actor, Props }
 import akka.testkit.TestProbe
+import com.mohiva.play.silhouette.api._
 import org.specs2.specification.Scope
 import play.api.i18n.Lang
 import play.api.libs.concurrent.Akka
@@ -25,13 +26,13 @@ import play.api.test.{ FakeRequest, PlaySpecification, WithApplication }
 import scala.concurrent.duration._
 
 /**
- * Test case for the [[com.mohiva.play.silhouette.api.EventBus]] class.
+ * Test case for the [[AkkaEventBus]] class.
  */
 class EventBusSpec extends PlaySpecification {
 
   "The event bus" should {
     "handle an subclass event" in new WithApplication with Context {
-      val eventBus = new EventBus
+      val eventBus = new AkkaEventBus
       val listener = system.actorOf(Props(new Actor {
         def receive = {
           case e => theProbe.ref ! e
@@ -48,7 +49,7 @@ class EventBusSpec extends PlaySpecification {
     }
 
     "handle an event" in new WithApplication with Context {
-      val eventBus = new EventBus
+      val eventBus = new AkkaEventBus
       val listener = system.actorOf(Props(new Actor {
         def receive = {
           case e @ LoginEvent(_, _, _) => theProbe.ref ! e
@@ -62,7 +63,7 @@ class EventBusSpec extends PlaySpecification {
     }
 
     "handle multiple events" in new WithApplication with Context {
-      val eventBus = new EventBus
+      val eventBus = new AkkaEventBus
       val listener = system.actorOf(Props(new Actor {
         def receive = {
           case e @ LoginEvent(_, _, _) => theProbe.ref ! e
@@ -80,7 +81,7 @@ class EventBusSpec extends PlaySpecification {
     }
 
     "differentiate between event classes" in new WithApplication with Context {
-      val eventBus = new EventBus
+      val eventBus = new AkkaEventBus
       val listener = system.actorOf(Props(new Actor {
         def receive = {
           case e @ LoginEvent(_, _, _) => theProbe.ref ! e
@@ -94,7 +95,7 @@ class EventBusSpec extends PlaySpecification {
     }
 
     "not handle not subscribed events" in new WithApplication with Context {
-      val eventBus = new EventBus
+      val eventBus = new AkkaEventBus
       val listener = system.actorOf(Props(new Actor {
         def receive = {
           case e @ LoginEvent(_, _, _) => theProbe.ref ! e
@@ -107,8 +108,8 @@ class EventBusSpec extends PlaySpecification {
     }
 
     "not handle events between different event buses" in new WithApplication with Context {
-      val eventBus1 = new EventBus
-      val eventBus2 = new EventBus
+      val eventBus1 = new AkkaEventBus
+      val eventBus2 = new AkkaEventBus
 
       val listener = system.actorOf(Props(new Actor {
         def receive = {
@@ -123,8 +124,8 @@ class EventBusSpec extends PlaySpecification {
     }
 
     "returns a singleton event bus" in new WithApplication with Context {
-      val eventBus1 = EventBus()
-      val eventBus2 = EventBus()
+      val eventBus1 = AkkaEventBus()
+      val eventBus2 = AkkaEventBus()
 
       eventBus1 ==== eventBus2
     }


### PR DESCRIPTION
This PR addresses #312.  It:
- renames `com.mohiva.play.silhouette.api.EventBus` to `com.mohiva.play.silhouette.impl.util.AkkaEventBus`
- creates a new trait `com.mohiva.play.silhouette.api.EventBus`
- adds a noop `com.mohiva.play.silhouette.test.FakeEventBus`
- simplifies SilhouetteSpec to use Mockito mocks & verifications instead of an Akka TestProbe