### PR TITLE
Allow custom authenticator service from outside of silhouette package

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/api/services/AuthenticatorService.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/services/AuthenticatorService.scala
@@ -128,7 +128,7 @@ trait AuthenticatorService[T <: Authenticator] {
    * @param authenticator The authenticator to touch.
    * @return The touched authenticator on the left or the untouched authenticator on the right.
    */
-  protected[silhouette] def touch(authenticator: T): Either[T, T]
+  def touch(authenticator: T): Either[T, T]
 
   /**
    * Updates a touched authenticator.
@@ -142,7 +142,7 @@ trait AuthenticatorService[T <: Authenticator] {
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  protected[silhouette] def update(authenticator: T, result: Future[Result])(implicit request: RequestHeader): Future[Result]
+  def update(authenticator: T, result: Future[Result])(implicit request: RequestHeader): Future[Result]
 
   /**
    * Renews the expiration of an authenticator.
@@ -156,7 +156,7 @@ trait AuthenticatorService[T <: Authenticator] {
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  protected[silhouette] def renew(authenticator: T, result: Future[Result])(implicit request: RequestHeader): Future[Result]
+  def renew(authenticator: T, result: Future[Result])(implicit request: RequestHeader): Future[Result]
 
   /**
    * Manipulates the response and removes authenticator specific artifacts before sending it to the client.
@@ -166,7 +166,7 @@ trait AuthenticatorService[T <: Authenticator] {
    * @param request The request header.
    * @return The manipulated result.
    */
-  protected[silhouette] def discard(authenticator: T, result: Future[Result])(implicit request: RequestHeader): Future[Result]
+  def discard(authenticator: T, result: Future[Result])(implicit request: RequestHeader): Future[Result]
 }
 
 /**

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/BearerTokenAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/BearerTokenAuthenticator.scala
@@ -178,7 +178,7 @@ class BearerTokenAuthenticatorService(
    * @param authenticator The authenticator to touch.
    * @return The touched authenticator on the left or the untouched authenticator on the right.
    */
-  protected[silhouette] def touch(
+  def touch(
     authenticator: BearerTokenAuthenticator): Either[BearerTokenAuthenticator, BearerTokenAuthenticator] = {
 
     if (authenticator.idleTimeout.isDefined) {
@@ -199,7 +199,7 @@ class BearerTokenAuthenticatorService(
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  protected[silhouette] def update(
+  def update(
     authenticator: BearerTokenAuthenticator,
     result: Future[Result])(implicit request: RequestHeader) = {
 
@@ -219,7 +219,7 @@ class BearerTokenAuthenticatorService(
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  protected[silhouette] def renew(
+  def renew(
     authenticator: BearerTokenAuthenticator,
     result: Future[Result])(implicit request: RequestHeader) = {
 
@@ -239,7 +239,7 @@ class BearerTokenAuthenticatorService(
    * @param request The request header.
    * @return The manipulated result.
    */
-  protected[silhouette] def discard(
+  def discard(
     authenticator: BearerTokenAuthenticator,
     result: Future[Result])(implicit request: RequestHeader) = {
 

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticator.scala
@@ -211,7 +211,7 @@ class CookieAuthenticatorService(
    * @param authenticator The authenticator to touch.
    * @return The touched authenticator on the left or the untouched authenticator on the right.
    */
-  protected[silhouette] def touch(
+  def touch(
     authenticator: CookieAuthenticator): Either[CookieAuthenticator, CookieAuthenticator] = {
 
     if (authenticator.idleTimeout.isDefined) {
@@ -232,7 +232,7 @@ class CookieAuthenticatorService(
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  protected[silhouette] def update(
+  def update(
     authenticator: CookieAuthenticator,
     result: Future[Result])(implicit request: RequestHeader) = {
 
@@ -252,7 +252,7 @@ class CookieAuthenticatorService(
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  protected[silhouette] def renew(
+  def renew(
     authenticator: CookieAuthenticator,
     result: Future[Result])(implicit request: RequestHeader) = {
 
@@ -272,7 +272,7 @@ class CookieAuthenticatorService(
    * @param request The request header.
    * @return The manipulated result.
    */
-  protected[silhouette] def discard(
+  def discard(
     authenticator: CookieAuthenticator,
     result: Future[Result])(implicit request: RequestHeader) = {
 

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticator.scala
@@ -108,7 +108,7 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @param authenticator The authenticator to touch.
    * @return The touched authenticator on the left or the untouched authenticator on the right.
    */
-  protected[silhouette] def touch(authenticator: DummyAuthenticator) = Right(authenticator)
+  def touch(authenticator: DummyAuthenticator) = Right(authenticator)
 
   /**
    * Returns the original request, because we needn't update the authenticator in the result.
@@ -118,7 +118,7 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  protected[silhouette] def update(
+  def update(
     authenticator: DummyAuthenticator,
     result: Future[Result])(implicit request: RequestHeader) = {
 
@@ -133,7 +133,7 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  protected[silhouette] def renew(
+  def renew(
     authenticator: DummyAuthenticator,
     result: Future[Result])(implicit request: RequestHeader) = {
 
@@ -147,7 +147,7 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @param request The request header.
    * @return The manipulated result.
    */
-  protected[silhouette] def discard(
+  def discard(
     authenticator: DummyAuthenticator,
     result: Future[Result])(implicit request: RequestHeader) = {
 

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/JWTAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/JWTAuthenticator.scala
@@ -201,7 +201,7 @@ class JWTAuthenticatorService(
    * @param authenticator The authenticator to touch.
    * @return The touched authenticator on the left or the untouched authenticator on the right.
    */
-  protected[silhouette] def touch(authenticator: JWTAuthenticator): Either[JWTAuthenticator, JWTAuthenticator] = {
+  def touch(authenticator: JWTAuthenticator): Either[JWTAuthenticator, JWTAuthenticator] = {
     if (authenticator.idleTimeout.isDefined) {
       Left(authenticator.copy(lastUsedDate = clock.now))
     } else {
@@ -220,7 +220,7 @@ class JWTAuthenticatorService(
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  protected[silhouette] def update(
+  def update(
     authenticator: JWTAuthenticator,
     result: Future[Result])(implicit request: RequestHeader) = {
 
@@ -240,7 +240,7 @@ class JWTAuthenticatorService(
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  protected[silhouette] def renew(
+  def renew(
     authenticator: JWTAuthenticator,
     result: Future[Result])(implicit request: RequestHeader) = {
 
@@ -260,7 +260,7 @@ class JWTAuthenticatorService(
    * @param request The request header.
    * @return The manipulated result.
    */
-  protected[silhouette] def discard(
+  def discard(
     authenticator: JWTAuthenticator,
     result: Future[Result])(implicit request: RequestHeader) = {
 
@@ -277,7 +277,7 @@ class JWTAuthenticatorService(
    * @param authenticator The authenticator to serialize.
    * @return The serialized authenticator.
    */
-  protected[silhouette] def serialize(authenticator: JWTAuthenticator): String = {
+  def serialize(authenticator: JWTAuthenticator): String = {
     val subject = Json.toJson(authenticator.loginInfo).toString()
     val jwtBuilder = new JsonSmartJwtJsonBuilder()
       .jwtId(authenticator.id)
@@ -307,7 +307,7 @@ class JWTAuthenticatorService(
    * @param str The string representation of the authenticator.
    * @return An authenticator on success, otherwise a failure.
    */
-  protected[silhouette] def unserialize(str: String): Try[JWTAuthenticator] = {
+  def unserialize(str: String): Try[JWTAuthenticator] = {
     Try {
       val verifier = new MACVerifier(settings.sharedSecret)
       val jwsObject = JWSObject.parse(str)

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticator.scala
@@ -191,7 +191,7 @@ class SessionAuthenticatorService(
    * @param authenticator The authenticator to touch.
    * @return The touched authenticator on the left or the untouched authenticator on the right.
    */
-  protected[silhouette] def touch(
+  def touch(
     authenticator: SessionAuthenticator): Either[SessionAuthenticator, SessionAuthenticator] = {
 
     if (authenticator.idleTimeout.isDefined) {
@@ -212,7 +212,7 @@ class SessionAuthenticatorService(
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  protected[silhouette] def update(
+  def update(
     authenticator: SessionAuthenticator,
     result: Future[Result])(implicit request: RequestHeader) = {
 
@@ -230,7 +230,7 @@ class SessionAuthenticatorService(
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  protected[silhouette] def renew(
+  def renew(
     authenticator: SessionAuthenticator,
     result: Future[Result])(implicit request: RequestHeader) = {
 
@@ -248,7 +248,7 @@ class SessionAuthenticatorService(
    * @param request The request header.
    * @return The manipulated result.
    */
-  protected[silhouette] def discard(
+  def discard(
     authenticator: SessionAuthenticator,
     result: Future[Result])(implicit request: RequestHeader) = {
 


### PR DESCRIPTION
First of all, I'm really impressive by your play module. It's powerful and highly customizable. Congrats! 

So, I started to moving from securesocial to play-silhouette and I have just one problem… I try to write my own authenticator service but it's seems this isn't allowed. There are 4 methods in AuthenticatorService with access restricted to silhouette package: `touch` `update` `renew` `discard`.

I think this isn't intend and I suggest to change the method visibility to public.