### PR TITLE
Don't wrap results in Futures when passing them to authenticators

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/api/services/AuthenticatorService.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/services/AuthenticatorService.scala
@@ -76,7 +76,7 @@ trait AuthenticatorService[T <: Authenticator] {
    * @param request The request header.
    * @return The manipulated result.
    */
-  def embed(value: T#Value, result: Future[Result])(implicit request: RequestHeader): Future[Result]
+  def embed(value: T#Value, result: Result)(implicit request: RequestHeader): Future[Result]
 
   /**
    * Embeds authenticator specific artifacts into the request.
@@ -142,7 +142,7 @@ trait AuthenticatorService[T <: Authenticator] {
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  protected[silhouette] def update(authenticator: T, result: Future[Result])(implicit request: RequestHeader): Future[Result]
+  protected[silhouette] def update(authenticator: T, result: Result)(implicit request: RequestHeader): Future[Result]
 
   /**
    * Renews the expiration of an authenticator.
@@ -156,7 +156,7 @@ trait AuthenticatorService[T <: Authenticator] {
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  protected[silhouette] def renew(authenticator: T, result: Future[Result])(implicit request: RequestHeader): Future[Result]
+  protected[silhouette] def renew(authenticator: T, result: Result)(implicit request: RequestHeader): Future[Result]
 
   /**
    * Manipulates the response and removes authenticator specific artifacts before sending it to the client.
@@ -166,7 +166,7 @@ trait AuthenticatorService[T <: Authenticator] {
    * @param request The request header.
    * @return The manipulated result.
    */
-  protected[silhouette] def discard(authenticator: T, result: Future[Result])(implicit request: RequestHeader): Future[Result]
+  protected[silhouette] def discard(authenticator: T, result: Result)(implicit request: RequestHeader): Future[Result]
 }
 
 /**

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/BearerTokenAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/BearerTokenAuthenticator.scala
@@ -157,8 +157,10 @@ class BearerTokenAuthenticatorService(
    * @param request The request header.
    * @return The manipulated result.
    */
-  def embed(token: String, result: Future[Result])(implicit request: RequestHeader) = {
-    result.map(_.withHeaders(settings.headerName -> token))
+  def embed(token: String, result: Result)(implicit request: RequestHeader) = {
+    Future.successful(
+      result.withHeaders(settings.headerName -> token)
+    )
   }
 
   /**
@@ -201,9 +203,9 @@ class BearerTokenAuthenticatorService(
    */
   protected[silhouette] def update(
     authenticator: BearerTokenAuthenticator,
-    result: Future[Result])(implicit request: RequestHeader) = {
+    result: Result)(implicit request: RequestHeader) = {
 
-    dao.save(authenticator).flatMap { a =>
+    dao.save(authenticator).map { a =>
       result
     }.recover {
       case e => throw new AuthenticatorUpdateException(UpdateError.format(ID, authenticator), e)
@@ -221,7 +223,7 @@ class BearerTokenAuthenticatorService(
    */
   protected[silhouette] def renew(
     authenticator: BearerTokenAuthenticator,
-    result: Future[Result])(implicit request: RequestHeader) = {
+    result: Result)(implicit request: RequestHeader) = {
 
     dao.remove(authenticator.id).flatMap { _ =>
       create(authenticator.loginInfo).flatMap { a =>
@@ -241,9 +243,9 @@ class BearerTokenAuthenticatorService(
    */
   protected[silhouette] def discard(
     authenticator: BearerTokenAuthenticator,
-    result: Future[Result])(implicit request: RequestHeader) = {
+    result: Result)(implicit request: RequestHeader) = {
 
-    dao.remove(authenticator.id).flatMap { _ =>
+    dao.remove(authenticator.id).map { _ =>
       result
     }.recover {
       case e => throw new AuthenticatorDiscardingException(DiscardError.format(ID, authenticator), e)

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticator.scala
@@ -89,8 +89,8 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @param request The request header.
    * @return The manipulated result.
    */
-  def embed(value: Unit, result: Future[Result])(implicit request: RequestHeader) = {
-    result
+  def embed(value: Unit, result: Result)(implicit request: RequestHeader) = {
+    Future.successful(result)
   }
 
   /**
@@ -120,9 +120,9 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    */
   protected[silhouette] def update(
     authenticator: DummyAuthenticator,
-    result: Future[Result])(implicit request: RequestHeader) = {
+    result: Result)(implicit request: RequestHeader) = {
 
-    result
+    Future.successful(result)
   }
 
   /**
@@ -135,9 +135,9 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    */
   protected[silhouette] def renew(
     authenticator: DummyAuthenticator,
-    result: Future[Result])(implicit request: RequestHeader) = {
+    result: Result)(implicit request: RequestHeader) = {
 
-    result
+    Future.successful(result)
   }
 
   /**
@@ -149,9 +149,9 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    */
   protected[silhouette] def discard(
     authenticator: DummyAuthenticator,
-    result: Future[Result])(implicit request: RequestHeader) = {
+    result: Result)(implicit request: RequestHeader) = {
 
-    result
+    Future.successful(result)
   }
 }
 

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticator.scala
@@ -167,8 +167,8 @@ class SessionAuthenticatorService(
    * @param result The result to manipulate.
    * @return The manipulated result.
    */
-  def embed(session: Session, result: Future[Result])(implicit request: RequestHeader) = {
-    result.map(_.addingToSession(session.data.toSeq: _*))
+  def embed(session: Session, result: Result)(implicit request: RequestHeader) = {
+    Future.successful(result.addingToSession(session.data.toSeq: _*))
   }
 
   /**
@@ -214,11 +214,14 @@ class SessionAuthenticatorService(
    */
   protected[silhouette] def update(
     authenticator: SessionAuthenticator,
-    result: Future[Result])(implicit request: RequestHeader) = {
+    result: Result)(implicit request: RequestHeader) = {
 
-    result.map(_.addingToSession(settings.sessionKey -> serialize(authenticator))).recover {
+    Future {
+      result.addingToSession(settings.sessionKey -> serialize(authenticator))
+    }.recover {
       case e => throw new AuthenticatorUpdateException(UpdateError.format(ID, authenticator), e)
     }
+
   }
 
   /**
@@ -232,7 +235,7 @@ class SessionAuthenticatorService(
    */
   protected[silhouette] def renew(
     authenticator: SessionAuthenticator,
-    result: Future[Result])(implicit request: RequestHeader) = {
+    result: Result)(implicit request: RequestHeader) = {
 
     create(authenticator.loginInfo).flatMap { a =>
       init(a).flatMap(v => embed(v, result))
@@ -250,11 +253,14 @@ class SessionAuthenticatorService(
    */
   protected[silhouette] def discard(
     authenticator: SessionAuthenticator,
-    result: Future[Result])(implicit request: RequestHeader) = {
+    result: Result)(implicit request: RequestHeader) = {
 
-    result.map(_.removingFromSession(settings.sessionKey)).recover {
+    Future {
+      result.removingFromSession(settings.sessionKey)
+    }.recover {
       case e => throw new AuthenticatorDiscardingException(DiscardError.format(ID, authenticator), e)
     }
+
   }
 
   /**

--- a/silhouette/test/com/mohiva/play/silhouette/api/SilhouetteSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/api/SilhouetteSpec.scala
@@ -56,7 +56,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
     "restrict access and discard authenticator if an invalid authenticator can be retrieved" in new WithDefaultGlobal {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator.copy(isValid = false)))
       env.authenticatorService.discard(any, any)(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
 
       withEvent[NotAuthenticatedEvent] {
@@ -73,7 +73,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
     "restrict access and discard authenticator if no identity could be found for an authenticator" in new WithDefaultGlobal {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.discard(any, any)(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(None)
 
@@ -91,7 +91,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
     "display local not-authenticated result if user isn't authenticated" in new WithSecuredGlobal {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.discard(any, any)(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(None)
 
@@ -110,7 +110,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
     "display global not-authenticated result if user isn't authenticated" in new WithSecuredGlobal {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.discard(any, any)(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(None)
 
@@ -124,7 +124,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
     "display fallback message if user isn't authenticated and fallback methods aren't implemented" in new WithDefaultGlobal {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.discard(any, any)(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(None)
 
@@ -139,7 +139,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.update(any, any)(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -158,7 +158,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.update(any, any)(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -190,7 +190,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.update(any, any)(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -212,7 +212,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.update(any, any)(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -229,7 +229,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.update(any, any)(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -246,7 +246,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.update(any, any)(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -266,7 +266,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.update(any, any)(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -288,8 +288,8 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(None)
       env.authenticatorService.create(any)(any) returns Future.successful(authenticator)
       env.authenticatorService.init(any)(any) answers { p => Future.successful(p.asInstanceOf[FakeAuthenticator#Value]) }
-      env.authenticatorService.embed(any, any[Future[Result]])(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+      env.authenticatorService.embed(any, any[Result])(any) answers { (a, m) =>
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -310,7 +310,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
       env.authenticatorService.update(any, any)(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
 
       withEvent[AuthenticatedEvent[FakeIdentity]] {
@@ -347,8 +347,8 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(None)
       env.authenticatorService.create(any)(any) returns Future.successful(authenticator)
       env.authenticatorService.init(any)(any) answers { p => Future.successful(p.asInstanceOf[FakeAuthenticator#Value]) }
-      env.authenticatorService.embed(any, any[Future[Result]])(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+      env.authenticatorService.embed(any, any[Result])(any) answers { (a, m) =>
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -368,7 +368,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.renew(any, any)(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -390,7 +390,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(None)
       env.authenticatorService.create(any)(any) returns Future.successful(authenticator)
       env.authenticatorService.renew(any, any)(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -410,7 +410,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.discard(any, any)(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -432,7 +432,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(None)
       env.authenticatorService.create(any)(any) returns Future.successful(authenticator)
       env.authenticatorService.discard(any, any)(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -453,7 +453,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.update(any, any)(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -487,7 +487,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.update(any, any)(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -515,7 +515,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
     "invoke action without identity and authenticator if invalid authenticator was found" in new WithDefaultGlobal {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator.copy(isValid = false)))
       env.authenticatorService.discard(any, any)(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
 
       val controller = new SecuredController(env)
@@ -530,7 +530,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.update(any, any)(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(None)
 
@@ -547,7 +547,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.update(any, any)(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -566,8 +566,8 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(None)
       env.authenticatorService.create(any)(any) returns Future.successful(authenticator)
       env.authenticatorService.init(any)(any) answers { p => Future.successful(p.asInstanceOf[FakeAuthenticator#Value]) }
-      env.authenticatorService.embed(any, any[Future[Result]])(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+      env.authenticatorService.embed(any, any[Result])(any) answers { (a, m) =>
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -585,7 +585,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
       env.authenticatorService.update(any, any)(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
 
       val controller = new SecuredController(env)
@@ -616,8 +616,8 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(None)
       env.authenticatorService.create(any)(any) returns Future.successful(authenticator)
       env.authenticatorService.init(any)(any) answers { p => Future.successful(p.asInstanceOf[FakeAuthenticator#Value]) }
-      env.authenticatorService.embed(any, any[Future[Result]])(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+      env.authenticatorService.embed(any, any[Result])(any) answers { (a, m) =>
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -634,7 +634,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.renew(any, any)(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -653,7 +653,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(None)
       env.authenticatorService.create(any)(any) returns Future.successful(authenticator)
       env.authenticatorService.renew(any, any)(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -670,7 +670,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.discard(any, any)(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -689,7 +689,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(None)
       env.authenticatorService.create(any)(any) returns Future.successful(authenticator)
       env.authenticatorService.discard(any, any)(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -718,7 +718,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.update(any, any)(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -736,7 +736,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
     "translate an ForbiddenException into a 403 Forbidden result" in new WithDefaultGlobal {
       env.authenticatorService.retrieve(any) returns Future.successful(None)
       env.authenticatorService.discard(any, any)(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
 
       val controller = new SecuredController(env)
@@ -749,7 +749,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
     "translate an UnauthorizedException into a 401 Unauthorized result" in new WithDefaultGlobal {
       env.authenticatorService.retrieve(any) returns Future.successful(None)
       env.authenticatorService.discard(any, any)(any) answers { (a, m) =>
-        a.asInstanceOf[Array[Any]](1).asInstanceOf[Future[Result]]
+        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
 
       val controller = new SecuredController(env)

--- a/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/BearerTokenAuthenticatorSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/BearerTokenAuthenticatorSpec.scala
@@ -170,7 +170,7 @@ class BearerTokenAuthenticatorSpec extends PlaySpecification with Mockito {
     "return the response with a header" in new Context {
       implicit val request = FakeRequest()
       val value = authenticator.id
-      val result = service.embed(value, Future.successful(Results.Status(200)))
+      val result = service.embed(value, Results.Ok)
 
       header(settings.headerName, result) should beSome(authenticator.id)
     }
@@ -228,7 +228,7 @@ class BearerTokenAuthenticatorSpec extends PlaySpecification with Mockito {
 
       implicit val request = FakeRequest()
 
-      await(service.update(authenticator, Future.successful(Results.Ok)))
+      await(service.update(authenticator, Results.Ok))
 
       there was one(dao).save(authenticator)
     }
@@ -237,7 +237,7 @@ class BearerTokenAuthenticatorSpec extends PlaySpecification with Mockito {
       dao.save(any) answers { p => Future.successful(p.asInstanceOf[BearerTokenAuthenticator]) }
 
       implicit val request = FakeRequest()
-      val result = service.update(authenticator, Future.successful(Results.Ok))
+      val result = service.update(authenticator, Results.Ok)
 
       status(result) must be equalTo OK
     }
@@ -247,7 +247,7 @@ class BearerTokenAuthenticatorSpec extends PlaySpecification with Mockito {
 
       implicit val request = FakeRequest()
 
-      await(service.update(authenticator, Future.successful(Results.Ok))) must throwA[AuthenticatorUpdateException].like {
+      await(service.update(authenticator, Results.Ok)) must throwA[AuthenticatorUpdateException].like {
         case e =>
           e.getMessage must startWith(UpdateError.format(ID, ""))
       }
@@ -265,7 +265,7 @@ class BearerTokenAuthenticatorSpec extends PlaySpecification with Mockito {
       idGenerator.generate returns Future.successful(id)
       clock.now returns now
 
-      await(service.renew(authenticator, Future.successful(Results.Ok)))
+      await(service.renew(authenticator, Results.Ok))
 
       there was one(dao).remove(authenticator.id)
     }
@@ -280,7 +280,7 @@ class BearerTokenAuthenticatorSpec extends PlaySpecification with Mockito {
       idGenerator.generate returns Future.successful(id)
       clock.now returns now
 
-      val result = service.renew(authenticator, Future.successful(Results.Ok))
+      val result = service.renew(authenticator, Results.Ok)
 
       header(settings.headerName, result) should beSome(id)
     }
@@ -295,7 +295,7 @@ class BearerTokenAuthenticatorSpec extends PlaySpecification with Mockito {
       idGenerator.generate returns Future.successful(id)
       clock.now returns now
 
-      await(service.renew(authenticator, Future.successful(Results.Ok))) must throwA[AuthenticatorRenewalException].like {
+      await(service.renew(authenticator, Results.Ok)) must throwA[AuthenticatorRenewalException].like {
         case e =>
           e.getMessage must startWith(RenewError.format(ID, ""))
       }
@@ -308,14 +308,14 @@ class BearerTokenAuthenticatorSpec extends PlaySpecification with Mockito {
 
       dao.remove(authenticator.id) returns Future.successful(authenticator)
 
-      await(service.discard(authenticator, Future.successful(Results.Status(200))))
+      await(service.discard(authenticator, Results.Ok))
 
       there was one(dao).remove(authenticator.id)
     }
 
     "throws an AuthenticatorDiscardingException exception if an error occurred during discarding" in new Context {
       implicit val request = FakeRequest()
-      val okResult = Future.successful(Results.Status(200))
+      val okResult = Results.Ok
 
       dao.remove(authenticator.id) returns Future.failed(new Exception("Cannot remove authenticator"))
 

--- a/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticatorSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticatorSpec.scala
@@ -217,7 +217,7 @@ class CookieAuthenticatorSpec extends PlaySpecification with Mockito {
       dao.save(any) returns Future.successful(authenticator)
 
       implicit val request = FakeRequest()
-      val result = service.embed(cookie, Future.successful(Results.Status(200)))
+      val result = service.embed(cookie, Results.Ok)
 
       cookies(result).get(settings.cookieName) should beSome[Cookie].which(cookieMatcher)
     }
@@ -281,7 +281,7 @@ class CookieAuthenticatorSpec extends PlaySpecification with Mockito {
 
       implicit val request = FakeRequest()
 
-      await(service.update(authenticator, Future.successful(Results.Ok)))
+      await(service.update(authenticator, Results.Ok))
 
       there was one(dao).save(authenticator)
     }
@@ -290,7 +290,7 @@ class CookieAuthenticatorSpec extends PlaySpecification with Mockito {
       dao.save(any) answers { p => Future.successful(p.asInstanceOf[CookieAuthenticator]) }
 
       implicit val request = FakeRequest()
-      val result = service.update(authenticator, Future.successful(Results.Ok))
+      val result = service.update(authenticator, Results.Ok)
 
       status(result) must be equalTo OK
     }
@@ -300,7 +300,7 @@ class CookieAuthenticatorSpec extends PlaySpecification with Mockito {
 
       implicit val request = FakeRequest()
 
-      await(service.update(authenticator, Future.successful(Results.Ok))) must throwA[AuthenticatorUpdateException].like {
+      await(service.update(authenticator, Results.Ok)) must throwA[AuthenticatorUpdateException].like {
         case e =>
           e.getMessage must startWith(UpdateError.format(ID, ""))
       }
@@ -318,7 +318,7 @@ class CookieAuthenticatorSpec extends PlaySpecification with Mockito {
       idGenerator.generate returns Future.successful(id)
       clock.now returns now
 
-      await(service.renew(authenticator, Future.successful(Results.Ok)))
+      await(service.renew(authenticator, Results.Ok))
 
       there was one(dao).remove(authenticator.id)
     }
@@ -333,7 +333,7 @@ class CookieAuthenticatorSpec extends PlaySpecification with Mockito {
       idGenerator.generate returns Future.successful(id)
       clock.now returns now
 
-      val result = service.renew(authenticator, Future.successful(Results.Ok))
+      val result = service.renew(authenticator, Results.Ok)
 
       cookies(result).get(settings.cookieName) should beSome[Cookie].which { c =>
         c.name must be equalTo settings.cookieName
@@ -358,7 +358,7 @@ class CookieAuthenticatorSpec extends PlaySpecification with Mockito {
       idGenerator.generate returns Future.successful(id)
       clock.now returns now
 
-      await(service.renew(authenticator, Future.successful(Results.Ok))) must throwA[AuthenticatorRenewalException].like {
+      await(service.renew(authenticator, Results.Ok)) must throwA[AuthenticatorRenewalException].like {
         case e =>
           e.getMessage must startWith(RenewError.format(ID, ""))
       }
@@ -371,7 +371,7 @@ class CookieAuthenticatorSpec extends PlaySpecification with Mockito {
 
       dao.remove(any) returns Future.successful(())
 
-      val result = service.discard(authenticator, Future.successful(Results.Status(200).withCookies(cookie)))
+      val result = service.discard(authenticator, Results.Ok.withCookies(cookie))
 
       cookies(result).get(settings.cookieName) should beSome[Cookie].which { c =>
         c.name must be equalTo settings.cookieName
@@ -386,7 +386,7 @@ class CookieAuthenticatorSpec extends PlaySpecification with Mockito {
 
     "throws an AuthenticatorDiscardingException exception if an error occurred during discarding" in new Context {
       implicit val request = FakeRequest()
-      val okResult = Future.successful(Results.Status(200))
+      val okResult = Results.Ok
 
       dao.remove(any) returns Future.failed(new Exception("Cannot store authenticator"))
 

--- a/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticatorSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticatorSpec.scala
@@ -61,9 +61,9 @@ class DummyAuthenticatorSpec extends PlaySpecification with Mockito {
   "The result `embed` method of the service" should {
     "return the original response" in new Context {
       implicit val request = FakeRequest()
-      val result = Future.successful(Results.Status(200))
+      val result = Results.Ok
 
-      service.embed((), result) must be equalTo result
+      await(service.embed((), result)) must be equalTo result
     }
   }
 
@@ -87,27 +87,27 @@ class DummyAuthenticatorSpec extends PlaySpecification with Mockito {
   "The `update` method of the service" should {
     "return the original result" in new Context {
       implicit val request = FakeRequest()
-      val result = Future.successful(Results.Ok)
+      val result = Results.Ok
 
-      service.update(authenticator, result) must be equalTo result
+      await(service.update(authenticator, result)) must be equalTo result
     }
   }
 
   "The `renew` method of the service" should {
     "return the original result" in new Context {
       implicit val request = FakeRequest()
-      val result = Future.successful(Results.Ok)
+      val result = Results.Ok
 
-      service.renew(authenticator, result) must be equalTo result
+      await(service.renew(authenticator, result)) must be equalTo result
     }
   }
 
   "The `discard` method of the service" should {
     "return the original result" in new Context {
       implicit val request = FakeRequest()
-      val result = Future.successful(Results.Ok)
+      val result = Results.Ok
 
-      service.discard(authenticator, result) must be equalTo result
+      await(service.discard(authenticator, result)) must be equalTo result
     }
   }
 

--- a/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/JWTAuthenticatorSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/JWTAuthenticatorSpec.scala
@@ -325,7 +325,7 @@ class JWTAuthenticatorSpec extends PlaySpecification with Mockito with JsonMatch
       dao.save(any) returns Future.failed(new Exception("Cannot store authenticator"))
 
       implicit val request = FakeRequest()
-      val okResult = Future.successful(Results.Status(200))
+      val okResult = Future.successful(Results.Ok)
 
       await(service(Some(dao)).init(authenticator)) must throwA[AuthenticatorInitializationException].like {
         case e =>
@@ -340,7 +340,7 @@ class JWTAuthenticatorSpec extends PlaySpecification with Mockito with JsonMatch
       implicit val request = FakeRequest()
       val token = service(None).serialize(authenticator)
 
-      val result = service(Some(dao)).embed(token, Future.successful(Results.Status(200)))
+      val result = service(Some(dao)).embed(token, Results.Ok)
 
       header(settings.headerName, result) should beSome(token)
     }
@@ -404,7 +404,7 @@ class JWTAuthenticatorSpec extends PlaySpecification with Mockito with JsonMatch
 
       implicit val request = FakeRequest()
 
-      await(service(Some(dao)).update(authenticator, Future.successful(Results.Ok)))
+      await(service(Some(dao)).update(authenticator, Results.Ok))
 
       there was one(dao).save(authenticator)
     }
@@ -413,7 +413,7 @@ class JWTAuthenticatorSpec extends PlaySpecification with Mockito with JsonMatch
       dao.save(any) answers { p => Future.successful(p.asInstanceOf[JWTAuthenticator]) }
 
       implicit val request = FakeRequest()
-      val result = service(Some(dao)).update(authenticator, Future.successful(Results.Ok))
+      val result = service(Some(dao)).update(authenticator, Results.Ok)
 
       status(result) must be equalTo OK
       header(settings.headerName, result) should beSome(service(None).serialize(authenticator))
@@ -424,7 +424,7 @@ class JWTAuthenticatorSpec extends PlaySpecification with Mockito with JsonMatch
       dao.save(any) answers { p => Future.successful(p.asInstanceOf[JWTAuthenticator]) }
 
       implicit val request = FakeRequest()
-      val result = service(None).update(authenticator, Future.successful(Results.Ok))
+      val result = service(None).update(authenticator, Results.Ok)
 
       status(result) must be equalTo OK
       header(settings.headerName, result) should beSome(service(None).serialize(authenticator))
@@ -436,7 +436,7 @@ class JWTAuthenticatorSpec extends PlaySpecification with Mockito with JsonMatch
 
       implicit val request = FakeRequest()
 
-      await(service(Some(dao)).update(authenticator, Future.successful(Results.Ok))) must throwA[AuthenticatorUpdateException].like {
+      await(service(Some(dao)).update(authenticator, Results.Ok)) must throwA[AuthenticatorUpdateException].like {
         case e =>
           e.getMessage must startWith(UpdateError.format(ID, ""))
       }
@@ -454,7 +454,7 @@ class JWTAuthenticatorSpec extends PlaySpecification with Mockito with JsonMatch
       idGenerator.generate returns Future.successful(id)
       clock.now returns now
 
-      val result = service(Some(dao)).renew(authenticator, Future.successful(Results.Ok))
+      val result = service(Some(dao)).renew(authenticator, Results.Ok)
 
       header(settings.headerName, result) should beSome(service(None).serialize(authenticator.copy(
         id = id,
@@ -472,7 +472,7 @@ class JWTAuthenticatorSpec extends PlaySpecification with Mockito with JsonMatch
       idGenerator.generate returns Future.successful(id)
       clock.now returns now
 
-      val result = service(None).renew(authenticator, Future.successful(Results.Ok))
+      val result = service(None).renew(authenticator, Results.Ok)
 
       header(settings.headerName, result) should beSome(service(None).serialize(authenticator.copy(
         id = id,
@@ -493,7 +493,7 @@ class JWTAuthenticatorSpec extends PlaySpecification with Mockito with JsonMatch
       idGenerator.generate returns Future.successful(id)
       clock.now returns now
 
-      await(service(Some(dao)).renew(authenticator, Future.successful(Results.Ok))) must throwA[AuthenticatorRenewalException].like {
+      await(service(Some(dao)).renew(authenticator, Results.Ok)) must throwA[AuthenticatorRenewalException].like {
         case e =>
           e.getMessage must startWith(RenewError.format(ID, ""))
       }
@@ -506,7 +506,7 @@ class JWTAuthenticatorSpec extends PlaySpecification with Mockito with JsonMatch
 
       dao.remove(authenticator.id) returns Future.successful(authenticator)
 
-      await(service(Some(dao)).discard(authenticator, Future.successful(Results.Status(200))))
+      await(service(Some(dao)).discard(authenticator, Results.Ok))
 
       there was one(dao).remove(authenticator.id)
     }
@@ -514,14 +514,14 @@ class JWTAuthenticatorSpec extends PlaySpecification with Mockito with JsonMatch
     "do not remove the authenticator from backing store if DAO is disabled" in new Context {
       implicit val request = FakeRequest()
 
-      await(service(None).discard(authenticator, Future.successful(Results.Status(200))))
+      await(service(None).discard(authenticator, Results.Ok))
 
       there was no(dao).remove(authenticator.id)
     }
 
     "throws an AuthenticatorDiscardingException exception if an error occurred during discarding" in new Context {
       implicit val request = FakeRequest()
-      val okResult = Future.successful(Results.Status(200))
+      val okResult = Results.Ok
 
       dao.remove(authenticator.id) returns Future.failed(new Exception("Cannot remove authenticator"))
 

--- a/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticatorSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticatorSpec.scala
@@ -244,7 +244,7 @@ class SessionAuthenticatorSpec extends PlaySpecification with Mockito {
 
       implicit val request = FakeRequest()
       val data = Crypto.encryptAES(Json.toJson(authenticator).toString())
-      val result = service.embed(Session(Map(settings.sessionKey -> data)), Future.successful(Results.Ok))
+      val result = service.embed(Session(Map(settings.sessionKey -> data)), Results.Ok)
 
       session(result).get(settings.sessionKey) should beSome(data)
     }
@@ -254,7 +254,7 @@ class SessionAuthenticatorSpec extends PlaySpecification with Mockito {
 
       implicit val request = FakeRequest().withSession(settings.sessionKey -> "existing")
       val data = Crypto.encryptAES(Json.toJson(authenticator).toString())
-      val result = service.embed(Session(Map(settings.sessionKey -> data)), Future.successful(Results.Ok))
+      val result = service.embed(Session(Map(settings.sessionKey -> data)), Results.Ok)
 
       session(result).get(settings.sessionKey) should beSome(data)
     }
@@ -264,9 +264,9 @@ class SessionAuthenticatorSpec extends PlaySpecification with Mockito {
 
       implicit val request = FakeRequest().withSession("request-other" -> "keep")
       val data = Crypto.encryptAES(Json.toJson(authenticator).toString())
-      val result = service.embed(Session(Map(settings.sessionKey -> data)), Future.successful(Results.Ok.addingToSession(
+      val result = service.embed(Session(Map(settings.sessionKey -> data)), Results.Ok.addingToSession(
         "result-other" -> "keep"
-      )))
+      ))
 
       session(result).get(settings.sessionKey) should beSome(data)
       session(result).get("request-other") should beSome("keep")
@@ -324,7 +324,7 @@ class SessionAuthenticatorSpec extends PlaySpecification with Mockito {
 
       implicit val request = FakeRequest()
       val data = Base64.encode(Json.toJson(authenticator))
-      val result = service.update(authenticator, Future.successful(Results.Ok))
+      val result = service.update(authenticator, Results.Ok)
 
       status(result) must be equalTo OK
       session(result).get(settings.sessionKey) should beSome(data)
@@ -335,7 +335,7 @@ class SessionAuthenticatorSpec extends PlaySpecification with Mockito {
 
       implicit val request = FakeRequest()
       val data = Crypto.encryptAES(Json.toJson(authenticator).toString())
-      val result = service.update(authenticator, Future.successful(Results.Ok))
+      val result = service.update(authenticator, Results.Ok)
 
       status(result) must be equalTo OK
       session(result).get(settings.sessionKey) should beSome(data)
@@ -346,7 +346,7 @@ class SessionAuthenticatorSpec extends PlaySpecification with Mockito {
 
       implicit val request = FakeRequest().withSession(settings.sessionKey -> "existing")
       val data = Crypto.encryptAES(Json.toJson(authenticator).toString())
-      val result = service.update(authenticator, Future.successful(Results.Ok))
+      val result = service.update(authenticator, Results.Ok)
 
       session(result).get(settings.sessionKey) should beSome(data)
     }
@@ -356,9 +356,9 @@ class SessionAuthenticatorSpec extends PlaySpecification with Mockito {
 
       implicit val request = FakeRequest().withSession("request-other" -> "keep")
       val data = Crypto.encryptAES(Json.toJson(authenticator).toString())
-      val result = service.update(authenticator, Future.successful(Results.Ok.addingToSession(
+      val result = service.update(authenticator, Results.Ok.addingToSession(
         "result-other" -> "keep"
-      )))
+      ))
 
       session(result).get(settings.sessionKey) should beSome(data)
       session(result).get("request-other") should beSome("keep")
@@ -370,7 +370,7 @@ class SessionAuthenticatorSpec extends PlaySpecification with Mockito {
 
       request.session throws new RuntimeException("Cannot get session")
 
-      await(service.update(authenticator, Future.successful(Results.Ok))) must throwA[AuthenticatorUpdateException].like {
+      await(service.update(authenticator, Results.Ok)) must throwA[AuthenticatorUpdateException].like {
         case e =>
           e.getMessage must startWith(UpdateError.format(ID, ""))
       }
@@ -390,7 +390,7 @@ class SessionAuthenticatorSpec extends PlaySpecification with Mockito {
       settings.useFingerprinting returns false
       clock.now returns now
 
-      val result = service.renew(authenticator, Future.successful(Results.Ok))
+      val result = service.renew(authenticator, Results.Ok)
 
       session(result).get(settings.sessionKey) should beSome(data)
     }
@@ -407,7 +407,7 @@ class SessionAuthenticatorSpec extends PlaySpecification with Mockito {
       settings.useFingerprinting returns false
       clock.now returns now
 
-      val result = service.renew(authenticator, Future.successful(Results.Ok))
+      val result = service.renew(authenticator, Results.Ok)
 
       session(result).get(settings.sessionKey) should beSome(data)
     }
@@ -424,7 +424,7 @@ class SessionAuthenticatorSpec extends PlaySpecification with Mockito {
       settings.useFingerprinting returns false
       clock.now returns now
 
-      val result = service.renew(authenticator, Future.successful(Results.Ok))
+      val result = service.renew(authenticator, Results.Ok)
 
       session(result).get(settings.sessionKey) should beSome(data)
     }
@@ -441,9 +441,9 @@ class SessionAuthenticatorSpec extends PlaySpecification with Mockito {
       settings.useFingerprinting returns false
       clock.now returns now
 
-      val result = service.renew(authenticator, Future.successful(Results.Ok.addingToSession(
+      val result = service.renew(authenticator, Results.Ok.addingToSession(
         "result-other" -> "keep"
-      )))
+      ))
 
       session(result).get(settings.sessionKey) should beSome(data)
       session(result).get("request-other") should beSome("keep")
@@ -459,7 +459,7 @@ class SessionAuthenticatorSpec extends PlaySpecification with Mockito {
       settings.useFingerprinting returns false
       clock.now returns now
 
-      await(service.renew(authenticator, Future.successful(Results.Ok))) must throwA[AuthenticatorRenewalException].like {
+      await(service.renew(authenticator, Results.Ok)) must throwA[AuthenticatorRenewalException].like {
         case e =>
           e.getMessage must startWith(RenewError.format(ID, ""))
       }
@@ -469,18 +469,18 @@ class SessionAuthenticatorSpec extends PlaySpecification with Mockito {
   "The `discard` method of the service" should {
     "discard the authenticator from session" in new WithApplication with Context {
       implicit val request = FakeRequest()
-      val result = service.discard(authenticator, Future.successful(Results.Ok.withSession(
+      val result = service.discard(authenticator, Results.Ok.withSession(
         settings.sessionKey -> "test"
-      )))
+      ))
 
       session(result).get(settings.sessionKey) should beNone
     }
 
     "non authenticator related session data" in new WithApplication with Context {
       implicit val request = FakeRequest().withSession("request-other" -> "keep", settings.sessionKey -> "test")
-      val result = service.discard(authenticator, Future.successful(Results.Ok.addingToSession(
+      val result = service.discard(authenticator, Results.Ok.addingToSession(
         "result-other" -> "keep"
-      )))
+      ))
 
       session(result).get(settings.sessionKey) should beNone
       session(result).get("request-other") should beSome("keep")
@@ -493,7 +493,7 @@ class SessionAuthenticatorSpec extends PlaySpecification with Mockito {
 
       result.removingFromSession(any)(any) throws new RuntimeException("Cannot get session")
 
-      await(service.discard(authenticator, Future.successful(result))) must throwA[AuthenticatorDiscardingException].like {
+      await(service.discard(authenticator, result)) must throwA[AuthenticatorDiscardingException].like {
         case e =>
           e.getMessage must startWith(DiscardError.format(ID, ""))
       }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/secrets/CookieSecretSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/secrets/CookieSecretSpec.scala
@@ -117,7 +117,7 @@ class CookieSecretSpec extends PlaySpecification with Mockito with JsonMatchers 
   "The `publish` method of the provider" should {
     "add the secret to the cookie" in new WithApplication with Context {
       implicit val req = FakeRequest(GET, "/")
-      val result = Future.successful(provider.publish(Results.Status(200), secret))
+      val result = Future.successful(provider.publish(Results.Ok, secret))
 
       cookies(result).get(settings.cookieName) should beSome[Cookie].which { c =>
         c.name must be equalTo settings.cookieName

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/state/CookieStateSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/state/CookieStateSpec.scala
@@ -157,7 +157,7 @@ class CookieStateSpec extends PlaySpecification with Mockito with JsonMatchers {
   "The `publish` method of the provider" should {
     "add the state to the cookie" in new Context {
       implicit val req = FakeRequest(GET, "/")
-      val result = Future.successful(provider.publish(Results.Status(200), state))
+      val result = Future.successful(provider.publish(Results.Ok, state))
 
       cookies(result).get(settings.cookieName) should beSome[Cookie].which { c =>
         c.name must be equalTo settings.cookieName

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/state/DummyStateSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/state/DummyStateSpec.scala
@@ -57,7 +57,7 @@ class DummyStateSpec extends PlaySpecification with Mockito with JsonMatchers {
   "The `publish` method of the provider" should {
     "return the original result" in new Context {
       implicit val req = FakeRequest(GET, "/")
-      val result = Results.Status(200)
+      val result = Results.Ok
 
       provider.publish(result, state) must be equalTo result
     }


### PR DESCRIPTION
This PR is to address #320.  It's still a work in progress. I still need to take a pass to make sure all is well.

As per #320, I removed the Future wrapper for embed's Result param, which cascaded to update, renew and discard methods as well. As you can see in the PR, it removed the need for a lot of Future wrapping.  The only place where complexity was added is [Silhouette#invokeBlock](https://github.com/igorbernstein/play-silhouette/blob/immediate-authenticator-result-params/silhouette/app/com/mohiva/play/silhouette/api/Silhouette.scala#L387-L389) when invoking the handleNotAuthenticated event handler.