### PR TITLE
Provider API enhancements 

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -32,7 +32,7 @@ object BasicSettings extends AutoPlugin {
 
   override def projectSettings = Seq(
     organization := "com.mohiva",
-    version := "2.0",
+    version := "2.1-SNAPSHOT",
     resolvers ++= Dependencies.resolvers,
     scalaVersion := Dependencies.Versions.scalaVersion,
     crossScalaVersions := Dependencies.Versions.crossScala,

--- a/silhouette-testkit/app/com/mohiva/play/silhouette/test/Fakes.scala
+++ b/silhouette-testkit/app/com/mohiva/play/silhouette/test/Fakes.scala
@@ -197,14 +197,14 @@ object FakeAuthenticator {
  * A fake environment implementation.
  *
  * @param identities A list of (login info -> identity) pairs to return inside a Silhouette action.
- * @param providers The list of authentication providers.
+ * @param requestProviders The list of request providers.
  * @param eventBus The event bus implementation.
  * @tparam I The type of the identity.
  * @tparam T The type of the authenticator.
  */
 case class FakeEnvironment[I <: Identity, T <: Authenticator: TypeTag](
   identities: Seq[(LoginInfo, I)],
-  providers: Map[String, Provider] = Map(),
+  requestProviders: Seq[RequestProvider] = Seq(),
   eventBus: EventBus = EventBus())
   extends Environment[I, T] {
 

--- a/silhouette/app/com/mohiva/play/silhouette/api/Environment.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/Environment.scala
@@ -37,11 +37,11 @@ trait Environment[I <: Identity, T <: Authenticator] {
   def authenticatorService: AuthenticatorService[T]
 
   /**
-   * Gets the list of authentication providers.
+   * Gets the list of request providers.
    *
-   * @return The list of authentication providers.
+   * @return The list of request providers.
    */
-  def providers: Map[String, Provider]
+  def requestProviders: Seq[RequestProvider]
 
   /**
    * The event bus implementation.
@@ -58,11 +58,11 @@ object Environment {
   def apply[I <: Identity, T <: Authenticator](
     identityServiceImpl: IdentityService[I],
     authenticatorServiceImpl: AuthenticatorService[T],
-    providersImpl: Map[String, Provider],
+    requestProvidersImpl: Seq[RequestProvider],
     eventBusImpl: EventBus) = new Environment[I, T] {
     val identityService = identityServiceImpl
     val authenticatorService = authenticatorServiceImpl
-    val providers = providersImpl
+    val requestProviders = requestProvidersImpl
     val eventBus = eventBusImpl
   }
 }

--- a/silhouette/app/com/mohiva/play/silhouette/api/Silhouette.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/Silhouette.scala
@@ -325,19 +325,7 @@ trait Silhouette[I <: Identity, A <: Authenticator] extends Controller with Logg
         }
       }
 
-      auth(requestProviders)
-    }
-
-    /**
-     * Gets the list of request providers.
-     *
-     * @return The list of request providers.
-     */
-    private def requestProviders: Seq[RequestProvider] = {
-      env.providers.map {
-        case (id, provider: RequestProvider) => Some(provider)
-        case _ => None
-      }.flatten[RequestProvider].toSeq
+      auth(env.requestProviders)
     }
   }
 

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth1Provider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth1Provider.scala
@@ -42,7 +42,7 @@ abstract class OAuth1Provider(
   httpLayer: HTTPLayer,
   service: OAuth1Service,
   tokenSecretProvider: OAuth1TokenSecretProvider,
-  settings: OAuth1Settings)
+  val settings: OAuth1Settings)
   extends SocialProvider with Logger {
 
   /**
@@ -64,6 +64,11 @@ abstract class OAuth1Provider(
    * The type of the auth info.
    */
   type A = OAuth1Info
+
+  /**
+   * The settings type.
+   */
+  type Settings = OAuth1Settings
 
   /**
    * Starts the authentication process.

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth2Provider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth2Provider.scala
@@ -78,13 +78,18 @@ object OAuth2Info {
  * @param stateProvider The state provider implementation.
  * @param settings The provider settings.
  */
-abstract class OAuth2Provider(httpLayer: HTTPLayer, stateProvider: OAuth2StateProvider, settings: OAuth2Settings)
+abstract class OAuth2Provider(httpLayer: HTTPLayer, stateProvider: OAuth2StateProvider, val settings: OAuth2Settings)
   extends SocialProvider with Logger {
 
   /**
    * The type of the auth info.
    */
   type A = OAuth2Info
+
+  /**
+   * The settings type.
+   */
+  type Settings = OAuth2Settings
 
   /**
    * A list with headers to send to the API.

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/OpenIDProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/OpenIDProvider.scala
@@ -34,13 +34,18 @@ import scala.concurrent.Future
  * @param service The OpenID service implementation.
  * @param settings The OpenID provider settings.
  */
-abstract class OpenIDProvider(httpLayer: HTTPLayer, service: OpenIDService, settings: OpenIDSettings)
+abstract class OpenIDProvider(httpLayer: HTTPLayer, service: OpenIDService, val settings: OpenIDSettings)
   extends SocialProvider with Logger {
 
   /**
    * The type of the auth info.
    */
   type A = OpenIDInfo
+
+  /**
+   * The settings type.
+   */
+  type Settings = OpenIDSettings
 
   /**
    * Starts the authentication process.

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth1/LinkedInProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth1/LinkedInProvider.scala
@@ -54,9 +54,7 @@ abstract class LinkedInProvider(
   type Content = JsValue
 
   /**
-   * Gets the provider ID.
-   *
-   * @return The provider ID.
+   * The provider ID.
    */
   val id = ID
 

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth1/TwitterProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth1/TwitterProvider.scala
@@ -53,9 +53,7 @@ abstract class TwitterProvider(
   type Content = JsValue
 
   /**
-   * Gets the provider ID.
-   *
-   * @return The provider ID.
+   * The provider ID.
    */
   val id = ID
 

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth1/XingProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth1/XingProvider.scala
@@ -53,9 +53,7 @@ abstract class XingProvider(
   type Content = JsValue
 
   /**
-   * Gets the provider ID.
-   *
-   * @return The provider ID.
+   * The provider ID.
    */
   val id = ID
 

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/ClefProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/ClefProvider.scala
@@ -43,9 +43,7 @@ abstract class ClefProvider(httpLayer: HTTPLayer, stateProvider: OAuth2StateProv
   type Content = JsValue
 
   /**
-   * Gets the provider ID.
-   *
-   * @return The provider ID.
+   * The provider ID.
    */
   val id = ID
 

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/DropboxProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/DropboxProvider.scala
@@ -45,9 +45,7 @@ abstract class DropboxProvider(httpLayer: HTTPLayer, stateProvider: OAuth2StateP
   type Content = JsValue
 
   /**
-   * Gets the provider ID.
-   *
-   * @return The provider ID.
+   * The provider ID.
    */
   val id = ID
 

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/FacebookProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/FacebookProvider.scala
@@ -52,9 +52,7 @@ abstract class FacebookProvider(httpLayer: HTTPLayer, stateProvider: OAuth2State
   type Content = JsValue
 
   /**
-   * Gets the provider ID.
-   *
-   * @return The provider ID.
+   * The provider ID.
    */
   val id = ID
 

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/FoursquareProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/FoursquareProvider.scala
@@ -40,7 +40,7 @@ import scala.concurrent.Future
  * @see https://developer.foursquare.com/overview/responses
  * @see https://developer.foursquare.com/docs/explore
  */
-abstract class FoursquareProvider(httpLayer: HTTPLayer, stateProvider: OAuth2StateProvider, protected val settings: OAuth2Settings)
+abstract class FoursquareProvider(httpLayer: HTTPLayer, stateProvider: OAuth2StateProvider, settings: OAuth2Settings)
   extends OAuth2Provider(httpLayer, stateProvider, settings) {
 
   /**
@@ -49,9 +49,7 @@ abstract class FoursquareProvider(httpLayer: HTTPLayer, stateProvider: OAuth2Sta
   type Content = JsValue
 
   /**
-   * Gets the provider ID.
-   *
-   * @return The provider ID.
+   * The provider ID.
    */
   val id = ID
 

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/GitHubProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/GitHubProvider.scala
@@ -48,9 +48,7 @@ abstract class GitHubProvider(httpLayer: HTTPLayer, stateProvider: OAuth2StatePr
   type Content = JsValue
 
   /**
-   * Gets the provider ID.
-   *
-   * @return The provider ID.
+   * The provider ID.
    */
   val id = ID
 

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/GoogleProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/GoogleProvider.scala
@@ -50,9 +50,7 @@ abstract class GoogleProvider(httpLayer: HTTPLayer, stateProvider: OAuth2StatePr
   type Content = JsValue
 
   /**
-   * Gets the provider ID.
-   *
-   * @return The provider ID.
+   * The provider ID.
    */
   val id = ID
 

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/InstagramProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/InstagramProvider.scala
@@ -48,9 +48,7 @@ abstract class InstagramProvider(httpLayer: HTTPLayer, stateProvider: OAuth2Stat
   type Content = JsValue
 
   /**
-   * Gets the provider ID.
-   *
-   * @return The provider ID.
+   * The provider ID.
    */
   val id = ID
 

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/LinkedInProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/LinkedInProvider.scala
@@ -49,9 +49,7 @@ abstract class LinkedInProvider(httpLayer: HTTPLayer, stateProvider: OAuth2State
   type Content = JsValue
 
   /**
-   * Gets the provider ID.
-   *
-   * @return The provider ID.
+   * The provider ID.
    */
   val id = ID
 

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/VKProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/VKProvider.scala
@@ -53,9 +53,7 @@ abstract class VKProvider(httpLayer: HTTPLayer, stateProvider: OAuth2StateProvid
   type Content = (JsValue, OAuth2Info)
 
   /**
-   * Gets the provider ID.
-   *
-   * @return The provider ID.
+   * The provider ID.
    */
   val id = ID
 

--- a/silhouette/test/com/mohiva/play/silhouette/api/SilhouetteSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/api/SilhouetteSpec.scala
@@ -786,7 +786,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
     lazy val env = Environment[FakeIdentity, FakeAuthenticator](
       mock[IdentityService[FakeIdentity]],
       mock[AuthenticatorService[FakeAuthenticator]],
-      Map(),
+      Seq(),
       new EventBus
     )
 
@@ -861,7 +861,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
     /**
      * A non request provider.
      */
-    lazy val nonRequestProvider = mock[Provider]
+    lazy val nonRequestProvider = mock[RequestProvider]
 
     /**
      * The Silhouette environment.
@@ -869,10 +869,10 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
     override lazy val env = Environment[FakeIdentity, FakeAuthenticator](
       mock[IdentityService[FakeIdentity]],
       mock[AuthenticatorService[FakeAuthenticator]],
-      Map(
-        "token-request" -> tokenRequestProvider,
-        "basic-auth-request" -> basicAuthRequestProvider,
-        "non-request" -> nonRequestProvider
+      Seq(
+        tokenRequestProvider,
+        basicAuthRequestProvider,
+        nonRequestProvider
       ),
       new EventBus
     )

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/OAuth1ProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/OAuth1ProviderSpec.scala
@@ -81,15 +81,15 @@ abstract class OAuth1ProviderSpec extends SocialProviderSpec[OAuth1Info] {
     }
 
     "resolves relative redirectURLs before starting the flow" in new WithApplication {
-      verifyCallbackURLResolution("/callback-url", false, "http://www.example.com/callback-url")
+      verifyCallbackURLResolution("/callback-url", secure = false, "http://www.example.com/callback-url")
     }
 
     "resolves path relative redirectURLS before starting the flow" in new WithApplication {
-      verifyCallbackURLResolution("callback-url", false, "http://www.example.com/request-path/callback-url")
+      verifyCallbackURLResolution("callback-url", secure = false, "http://www.example.com/request-path/callback-url")
     }
 
     "resolves relative redirectURLs before starting the flow over https" in new WithApplication {
-      verifyCallbackURLResolution("/callback-url", true, "https://www.example.com/callback-url")
+      verifyCallbackURLResolution("/callback-url", secure = true, "https://www.example.com/callback-url")
     }
 
     def verifyCallbackURLResolution(callbackURL: String, secure: Boolean, resolvedCallbackURL: String) = {
@@ -130,6 +130,13 @@ abstract class OAuth1ProviderSpec extends SocialProviderSpec[OAuth1Info] {
       authInfo(c.provider.authenticate()) {
         case authInfo => authInfo must be equalTo c.oAuthInfo
       }
+    }
+  }
+
+  "The `settings` method" should {
+    val c = context
+    "return the settings instance" in {
+      c.provider.settings must be equalTo c.oAuthSettings
     }
   }
 

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/OAuth2ProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/OAuth2ProviderSpec.scala
@@ -111,15 +111,15 @@ abstract class OAuth2ProviderSpec extends SocialProviderSpec[OAuth2Info] {
     }
 
     "resolves relative redirectURLs before starting the flow" in new WithApplication {
-      verifyRelativeRedirectResolution("/redirect-url", false, "http://www.example.com/redirect-url")
+      verifyRelativeRedirectResolution("/redirect-url", secure = false, "http://www.example.com/redirect-url")
     }
 
     "resolves path relative redirectURLs before starting the flow" in new WithApplication {
-      verifyRelativeRedirectResolution("redirect-url", false, "http://www.example.com/request-path/redirect-url")
+      verifyRelativeRedirectResolution("redirect-url", secure = false, "http://www.example.com/request-path/redirect-url")
     }
 
     "resolves relative redirectURLs before starting the flow over https" in new WithApplication {
-      verifyRelativeRedirectResolution("/redirect-url", true, "https://www.example.com/redirect-url")
+      verifyRelativeRedirectResolution("/redirect-url", secure = true, "https://www.example.com/redirect-url")
     }
 
     def verifyRelativeRedirectResolution(redirectURL: String, secure: Boolean, resolvedRedirectURL: String) = {
@@ -199,6 +199,13 @@ abstract class OAuth2ProviderSpec extends SocialProviderSpec[OAuth2Info] {
       failed[RuntimeException](c.provider.authenticate()) {
         case e => e.getMessage must startWith("success")
       }
+    }
+  }
+
+  "The `settings` method" should {
+    val c = context
+    "return the settings instance" in {
+      c.provider.settings must be equalTo c.oAuthSettings
     }
   }
 

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/OpenIDProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/OpenIDProviderSpec.scala
@@ -93,15 +93,15 @@ abstract class OpenIDProviderSpec extends SocialProviderSpec[OpenIDInfo] {
     }
 
     "resolves relative callbackURLs before starting the flow" in new WithApplication {
-      verifyRelativeCallbackURLResolution("/callback-url", false, "http://www.example.com/callback-url")
+      verifyRelativeCallbackURLResolution("/callback-url", secure = false, "http://www.example.com/callback-url")
     }
 
     "resolves path relative callbackURLs before starting the flow" in new WithApplication {
-      verifyRelativeCallbackURLResolution("callback-url", false, "http://www.example.com/request-path/callback-url")
+      verifyRelativeCallbackURLResolution("callback-url", secure = false, "http://www.example.com/request-path/callback-url")
     }
 
     "resolves relative callbackURLs before starting the flow over https" in new WithApplication {
-      verifyRelativeCallbackURLResolution("/callback-url", true, "https://www.example.com/callback-url")
+      verifyRelativeCallbackURLResolution("/callback-url", secure = true, "https://www.example.com/callback-url")
     }
 
     def verifyRelativeCallbackURLResolution(callbackURL: String, secure: Boolean, resolvedCallbackURL: String) = {
@@ -131,6 +131,13 @@ abstract class OpenIDProviderSpec extends SocialProviderSpec[OpenIDInfo] {
       authInfo(c.provider.authenticate()) {
         case authInfo => authInfo must be equalTo c.openIDInfo
       }
+    }
+  }
+
+  "The `settings` method" should {
+    val c = context
+    "return the settings instance" in {
+      c.provider.settings must be equalTo c.openIDSettings
     }
   }
 

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/SocialProviderRegistrySpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/SocialProviderRegistrySpec.scala
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mohiva.play.silhouette.impl.providers
+
+import com.mohiva.play.silhouette.impl.providers.oauth1.TwitterProvider
+import com.mohiva.play.silhouette.impl.providers.oauth2.{ GoogleProvider, FacebookProvider }
+import com.mohiva.play.silhouette.impl.providers.openid.YahooProvider
+import org.specs2.mock.Mockito
+import org.specs2.specification.Scope
+import play.api.test.PlaySpecification
+
+/**
+ * Test case for the [[com.mohiva.play.silhouette.impl.providers.SocialProviderRegistry]] class.
+ */
+class SocialProviderRegistrySpec extends PlaySpecification with Mockito {
+
+  "The `get` method" should {
+    "return a provider by its type" in new Context {
+      registry.get[GoogleProvider] must beSome(providers(1))
+    }
+
+    "return None if no provider for the given type exists" in new Context {
+      registry.get[YahooProvider] must beNone
+    }
+
+    "return a provider by its ID" in new Context {
+      registry.get(GoogleProvider.ID) must beSome(providers(1))
+    }
+
+    "return None if no provider for the given ID exists" in new Context {
+      registry.get(YahooProvider.ID) must beNone
+    }
+  }
+
+  /**
+   * The context.
+   */
+  trait Context extends Scope {
+
+    /**
+     * Some social providers.
+     */
+    val providers = {
+      val facebook = mock[FacebookProvider]
+      facebook.id returns FacebookProvider.ID
+      val google = mock[GoogleProvider]
+      google.id returns GoogleProvider.ID
+      val twitter = mock[TwitterProvider]
+      twitter.id returns TwitterProvider.ID
+
+      Seq(
+        facebook,
+        google,
+        twitter
+      )
+    }
+
+    /**
+     * The registry to test.
+     */
+    val registry = SocialProviderRegistry(providers)
+  }
+}


### PR DESCRIPTION
Hi Christian,

I was working on an example Silhouette app based on your seed and ran across an api awkwardness:

Its a bit weird to be lumping all the providers into a single Map...it requires an upcast in SocialAuthController and requires you to handle configuration errors in the CredentialsAuthController  (missing credentials provider).  I was wondering if you would be open to changing the Environment#providers to Environment#requestProviders and updating the seed to inject the CredentialsProvider & SocialProviders in the CredentialsAuthController & SocialAuthController respectfully?

