### PR TITLE
Add method to skip the update of an existing authenticator in a Silhouette action

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/api/Authenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/Authenticator.scala
@@ -19,13 +19,6 @@
  */
 package com.mohiva.play.silhouette.api
 
-import com.mohiva.play.silhouette.api.Authenticator.Discard
-import com.mohiva.play.silhouette.api.Authenticator.Renew
-import play.api.libs.concurrent.Execution.Implicits._
-import play.api.mvc.Result
-
-import scala.concurrent.Future
-
 /**
  * An authenticator tracks an authenticated user.
  */
@@ -49,58 +42,6 @@ trait Authenticator {
    * @return True if the authenticator isn't expired and isn't timed out.
    */
   def isValid: Boolean
-
-  /**
-   * Discards an authenticator.
-   *
-   * @param result The result to wrap into the [[com.mohiva.play.silhouette.api.Authenticator.Discard]] result.
-   * @return A [[com.mohiva.play.silhouette.api.Authenticator.Discard]] result.
-   */
-  def discard(result: Result): Result = new Discard(result)
-
-  /**
-   * Discards an authenticator.
-   *
-   * @param result The result to wrap into the [[com.mohiva.play.silhouette.api.Authenticator.Discard]] result.
-   * @return A [[com.mohiva.play.silhouette.api.Authenticator.Discard]] result.
-   */
-  def discard(result: Future[Result]): Future[Result] = result.map(r => discard(r))
-
-  /**
-   * Renews an authenticator.
-   *
-   * @param result The result to wrap into the [[com.mohiva.play.silhouette.api.Authenticator.Renew]] result.
-   * @return A [[com.mohiva.play.silhouette.api.Authenticator.Renew]] result.
-   */
-  def renew(result: Result): Result = new Renew(result)
-
-  /**
-   * Renews an authenticator.
-   *
-   * @param result The result to wrap into the [[com.mohiva.play.silhouette.api.Authenticator.Renew]] result.
-   * @return A [[com.mohiva.play.silhouette.api.Authenticator.Renew]] result.
-   */
-  def renew(result: Future[Result]): Future[Result] = result.map(r => renew(r))
-}
-
-/**
- * The companion object.
- */
-object Authenticator {
-
-  /**
-   * A marker result which indicates that an authenticator should be discarded.
-   *
-   * @param result The wrapped result.
-   */
-  class Discard(result: Result) extends Result(result.header, result.body, result.connection)
-
-  /**
-   * A marker result which indicates that an authenticator should be renewed.
-   *
-   * @param result The wrapped result.
-   */
-  class Renew(result: Result) extends Result(result.header, result.body, result.connection)
 }
 
 /**

--- a/silhouette/app/com/mohiva/play/silhouette/api/Silhouette.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/Silhouette.scala
@@ -20,6 +20,7 @@
 package com.mohiva.play.silhouette.api
 
 import com.mohiva.play.silhouette.api.exceptions.{ NotAuthenticatedException, NotAuthorizedException }
+import com.mohiva.play.silhouette.api.services.AuthenticatorResult
 import com.mohiva.play.silhouette.api.util.DefaultEndpointHandler
 import play.api.Play
 import play.api.libs.concurrent.Execution.Implicits._
@@ -266,10 +267,7 @@ trait Silhouette[I <: Identity, A <: Authenticator] extends Controller with Logg
     private def handleInitializedAuthenticator[T](authenticator: A, block: A => Future[HandlerResult[T]])(implicit request: RequestHeader) = {
       val auth = env.authenticatorService.touch(authenticator)
       block(auth.extract).flatMap {
-        case hr @ HandlerResult(pr: Authenticator.Discard, _) =>
-          env.authenticatorService.discard(authenticator, pr).map(pr => hr.copy(pr))
-        case hr @ HandlerResult(pr: Authenticator.Renew, _) =>
-          env.authenticatorService.renew(authenticator, pr).map(pr => hr.copy(pr))
+        case hr @ HandlerResult(pr: AuthenticatorResult, _) => Future.successful(hr)
         case hr @ HandlerResult(pr, _) => auth match {
           // Authenticator was touched so we update the authenticator and maybe the result
           case Left(a) => env.authenticatorService.update(a, pr).map(pr => hr.copy(pr))
@@ -292,10 +290,7 @@ trait Silhouette[I <: Identity, A <: Authenticator] extends Controller with Logg
      */
     private def handleUninitializedAuthenticator[T](authenticator: A, block: A => Future[HandlerResult[T]])(implicit request: RequestHeader) = {
       block(authenticator).flatMap {
-        case hr @ HandlerResult(pr: Authenticator.Discard, _) =>
-          env.authenticatorService.discard(authenticator, pr).map(pr => hr.copy(pr))
-        case hr @ HandlerResult(pr: Authenticator.Renew, _) =>
-          env.authenticatorService.renew(authenticator, pr).map(pr => hr.copy(pr))
+        case hr @ HandlerResult(pr: AuthenticatorResult, _) => Future.successful(hr)
         case hr @ HandlerResult(pr, _) =>
           env.authenticatorService.init(authenticator).flatMap { value =>
             env.authenticatorService.embed(value, pr)

--- a/silhouette/app/com/mohiva/play/silhouette/api/services/AuthenticatorService.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/services/AuthenticatorService.scala
@@ -20,9 +20,60 @@
 package com.mohiva.play.silhouette.api.services
 
 import com.mohiva.play.silhouette.api.{ Authenticator, LoginInfo }
-import play.api.mvc.{ Headers, RequestHeader, Result }
+import play.api.libs.iteratee.Enumerator
+import play.api.mvc._
 
 import scala.concurrent.Future
+
+/**
+ * A marker result which indicates that an operation on an authenticator was processed and
+ * therefore it shouldn't updated automatically.
+ *
+ * Due the fact that the update method gets called on every subsequent request to update the
+ * authenticator related data in the backing store and in the result, it isn't possible to
+ * discard or renew the authenticator simultaneously. This is because the "update" method would
+ * override the result created by the "renew" or "discard" method, because it will be executed
+ * as last in the chain.
+ *
+ * As example:
+ * If we discard the session in a Silhouette action then it will be removed from session. But
+ * at the end the update method will embed the session again, because it gets called with the
+ * result of the action.
+ *
+ * @param result The result to wrap.
+ */
+class AuthenticatorResult(result: Result) extends Result(result.header, result.body, result.connection) {
+
+  /**
+   * Creates a new copy of a `AuthenticatorResult`.
+   *
+   * @param header The response header, which contains status code and HTTP headers.
+   * @param body The response body.
+   * @param connection The connection semantics to use.
+   * @return A copy of a `AuthenticatorResult`.
+   */
+  override def copy(
+    header: ResponseHeader = this.header,
+    body: Enumerator[Array[Byte]] = this.body,
+    connection: HttpConnection.Connection = this.connection) = {
+
+    AuthenticatorResult(super.copy(header, body, connection))
+  }
+}
+
+/**
+ * The companion object.
+ */
+object AuthenticatorResult {
+
+  /**
+   * Instantiates a new authenticator result.
+   *
+   * @param result The result to wrap.
+   * @return An authenticator result.
+   */
+  def apply(result: Result) = new AuthenticatorResult(result)
+}
 
 /**
  * Handles authenticators for the Silhouette module.
@@ -76,7 +127,7 @@ trait AuthenticatorService[T <: Authenticator] {
    * @param request The request header.
    * @return The manipulated result.
    */
-  def embed(value: T#Value, result: Result)(implicit request: RequestHeader): Future[Result]
+  def embed(value: T#Value, result: Result)(implicit request: RequestHeader): Future[AuthenticatorResult]
 
   /**
    * Embeds authenticator specific artifacts into the request.
@@ -94,27 +145,6 @@ trait AuthenticatorService[T <: Authenticator] {
    */
   def embed(value: T#Value, request: RequestHeader): RequestHeader
 
-  ///////////////////////////////////////////////////////////////////////////////////////////////
-  //
-  // Internal API
-  //
-  // Due the fact that the update method gets called on every subsequent request to update the
-  // authenticator related data in the backing store and in the result, it isn't possible to
-  // discard or renew the authenticator simultaneously. This is because the "update" method would
-  // override the result created by the "renew" or "discard" method, because it will be executed
-  // as last in the chain.
-  //
-  // As example:
-  // If we discard the session in a Silhouette action then it will be removed from session. But
-  // at the end the update method will embed the session again, because it gets called with the
-  // result of the action.
-  //
-  // So we restrict the access to this methods and force the developer to use the "renew" and
-  // "discard" methods on the Authenticator instance. These methods wrap the result into a marker
-  // result, for which we can execute the appropriate method on this service.
-  //
-  ///////////////////////////////////////////////////////////////////////////////////////////////
-
   /**
    * Touches an authenticator.
    *
@@ -128,7 +158,7 @@ trait AuthenticatorService[T <: Authenticator] {
    * @param authenticator The authenticator to touch.
    * @return The touched authenticator on the left or the untouched authenticator on the right.
    */
-  protected[silhouette] def touch(authenticator: T): Either[T, T]
+  def touch(authenticator: T): Either[T, T]
 
   /**
    * Updates a touched authenticator.
@@ -142,7 +172,7 @@ trait AuthenticatorService[T <: Authenticator] {
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  protected[silhouette] def update(authenticator: T, result: Result)(implicit request: RequestHeader): Future[Result]
+  def update(authenticator: T, result: Result)(implicit request: RequestHeader): Future[AuthenticatorResult]
 
   /**
    * Renews the expiration of an authenticator.
@@ -156,7 +186,19 @@ trait AuthenticatorService[T <: Authenticator] {
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  protected[silhouette] def renew(authenticator: T, result: Result)(implicit request: RequestHeader): Future[Result]
+  def renew(authenticator: T, result: Result)(implicit request: RequestHeader): Future[AuthenticatorResult]
+
+  /**
+   * Renews the expiration of an authenticator without embedding it into the result.
+   *
+   * Based on the implementation, the renew method should revoke the given authenticator first, before
+   * creating a new one. If the authenticator was updated, then the updated artifacts should be returned.
+   *
+   * @param authenticator The authenticator to renew.
+   * @param request The request header.
+   * @return The serialized expression of the authenticator.
+   */
+  def renew(authenticator: T)(implicit request: RequestHeader): Future[T#Value]
 
   /**
    * Manipulates the response and removes authenticator specific artifacts before sending it to the client.
@@ -166,7 +208,7 @@ trait AuthenticatorService[T <: Authenticator] {
    * @param request The request header.
    * @return The manipulated result.
    */
-  protected[silhouette] def discard(authenticator: T, result: Result)(implicit request: RequestHeader): Future[Result]
+  def discard(authenticator: T, result: Result)(implicit request: RequestHeader): Future[AuthenticatorResult]
 }
 
 /**

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticator.scala
@@ -15,9 +15,8 @@
  */
 package com.mohiva.play.silhouette.impl.authenticators
 
-import com.mohiva.play.silhouette.api.services.AuthenticatorService
+import com.mohiva.play.silhouette.api.services.{ AuthenticatorResult, AuthenticatorService }
 import com.mohiva.play.silhouette.api.{ Authenticator, LoginInfo }
-import play.api.libs.concurrent.Execution.Implicits._
 import play.api.mvc.{ RequestHeader, Result }
 
 import scala.concurrent.Future
@@ -90,7 +89,7 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @return The manipulated result.
    */
   def embed(value: Unit, result: Result)(implicit request: RequestHeader) = {
-    Future.successful(result)
+    Future.successful(AuthenticatorResult(result))
   }
 
   /**
@@ -108,7 +107,7 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @param authenticator The authenticator to touch.
    * @return The touched authenticator on the left or the untouched authenticator on the right.
    */
-  protected[silhouette] def touch(authenticator: DummyAuthenticator) = Right(authenticator)
+  def touch(authenticator: DummyAuthenticator) = Right(authenticator)
 
   /**
    * Returns the original request, because we needn't update the authenticator in the result.
@@ -118,12 +117,18 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  protected[silhouette] def update(
-    authenticator: DummyAuthenticator,
-    result: Result)(implicit request: RequestHeader) = {
-
-    Future.successful(result)
+  def update(authenticator: DummyAuthenticator, result: Result)(implicit request: RequestHeader) = {
+    Future.successful(AuthenticatorResult(result))
   }
+
+  /**
+   * Returns noting because this authenticator doesn't have a serialized representation.
+   *
+   * @param authenticator The authenticator to renew.
+   * @param request The request header.
+   * @return The serialized expression of the authenticator.
+   */
+  def renew(authenticator: DummyAuthenticator)(implicit request: RequestHeader) = Future.successful(())
 
   /**
    * Returns the original request, because we needn't renew the authenticator in the result.
@@ -133,11 +138,8 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  protected[silhouette] def renew(
-    authenticator: DummyAuthenticator,
-    result: Result)(implicit request: RequestHeader) = {
-
-    Future.successful(result)
+  def renew(authenticator: DummyAuthenticator, result: Result)(implicit request: RequestHeader) = {
+    Future.successful(AuthenticatorResult(result))
   }
 
   /**
@@ -147,11 +149,8 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @param request The request header.
    * @return The manipulated result.
    */
-  protected[silhouette] def discard(
-    authenticator: DummyAuthenticator,
-    result: Result)(implicit request: RequestHeader) = {
-
-    Future.successful(result)
+  def discard(authenticator: DummyAuthenticator, result: Result)(implicit request: RequestHeader) = {
+    Future.successful(AuthenticatorResult(result))
   }
 }
 

--- a/silhouette/test/com/mohiva/play/silhouette/api/SilhouetteSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/api/SilhouetteSpec.scala
@@ -18,7 +18,7 @@ package com.mohiva.play.silhouette.api
 import akka.actor.{ Actor, Props }
 import akka.testkit.TestProbe
 import com.mohiva.play.silhouette.api.exceptions.{ NotAuthorizedException, NotAuthenticatedException }
-import com.mohiva.play.silhouette.api.services.{ AuthenticatorService, IdentityService }
+import com.mohiva.play.silhouette.api.services.{ AuthenticatorResult, AuthenticatorService, IdentityService }
 import org.specs2.matcher.JsonMatchers
 import org.specs2.mock.Mockito
 import org.specs2.specification.Scope
@@ -56,7 +56,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
     "restrict access and discard authenticator if an invalid authenticator can be retrieved" in new WithDefaultGlobal {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator.copy(isValid = false)))
       env.authenticatorService.discard(any, any)(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
 
       withEvent[NotAuthenticatedEvent] {
@@ -73,7 +73,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
     "restrict access and discard authenticator if no identity could be found for an authenticator" in new WithDefaultGlobal {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.discard(any, any)(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(None)
 
@@ -91,7 +91,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
     "display local not-authenticated result if user isn't authenticated" in new WithSecuredGlobal {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.discard(any, any)(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(None)
 
@@ -110,7 +110,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
     "display global not-authenticated result if user isn't authenticated" in new WithSecuredGlobal {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.discard(any, any)(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(None)
 
@@ -124,7 +124,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
     "display fallback message if user isn't authenticated and fallback methods aren't implemented" in new WithDefaultGlobal {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.discard(any, any)(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(None)
 
@@ -139,7 +139,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.update(any, any)(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -158,7 +158,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.update(any, any)(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -190,7 +190,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.update(any, any)(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -212,7 +212,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.update(any, any)(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -229,7 +229,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.update(any, any)(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -246,7 +246,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.update(any, any)(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -266,7 +266,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.update(any, any)(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -289,7 +289,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.create(any)(any) returns Future.successful(authenticator)
       env.authenticatorService.init(any)(any) answers { p => Future.successful(p.asInstanceOf[FakeAuthenticator#Value]) }
       env.authenticatorService.embed(any, any[Result])(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -310,7 +310,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
       env.authenticatorService.update(any, any)(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
 
       withEvent[AuthenticatedEvent[FakeIdentity]] {
@@ -348,7 +348,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.create(any)(any) returns Future.successful(authenticator)
       env.authenticatorService.init(any)(any) answers { p => Future.successful(p.asInstanceOf[FakeAuthenticator#Value]) }
       env.authenticatorService.embed(any, any[Result])(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -368,7 +368,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.renew(any, any)(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -390,7 +390,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(None)
       env.authenticatorService.create(any)(any) returns Future.successful(authenticator)
       env.authenticatorService.renew(any, any)(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -410,7 +410,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.discard(any, any)(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -432,7 +432,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(None)
       env.authenticatorService.create(any)(any) returns Future.successful(authenticator)
       env.authenticatorService.discard(any, any)(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -453,7 +453,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.update(any, any)(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -487,7 +487,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.update(any, any)(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -515,7 +515,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
     "invoke action without identity and authenticator if invalid authenticator was found" in new WithDefaultGlobal {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator.copy(isValid = false)))
       env.authenticatorService.discard(any, any)(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
 
       val controller = new SecuredController(env)
@@ -530,7 +530,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.update(any, any)(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(None)
 
@@ -547,7 +547,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.update(any, any)(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -567,7 +567,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.create(any)(any) returns Future.successful(authenticator)
       env.authenticatorService.init(any)(any) answers { p => Future.successful(p.asInstanceOf[FakeAuthenticator#Value]) }
       env.authenticatorService.embed(any, any[Result])(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -585,7 +585,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
       env.authenticatorService.update(any, any)(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
 
       val controller = new SecuredController(env)
@@ -617,7 +617,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.create(any)(any) returns Future.successful(authenticator)
       env.authenticatorService.init(any)(any) answers { p => Future.successful(p.asInstanceOf[FakeAuthenticator#Value]) }
       env.authenticatorService.embed(any, any[Result])(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -634,7 +634,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.renew(any, any)(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -653,7 +653,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(None)
       env.authenticatorService.create(any)(any) returns Future.successful(authenticator)
       env.authenticatorService.renew(any, any)(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -670,7 +670,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.discard(any, any)(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -689,7 +689,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(None)
       env.authenticatorService.create(any)(any) returns Future.successful(authenticator)
       env.authenticatorService.discard(any, any)(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -718,7 +718,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.update(any, any)(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
 
@@ -736,7 +736,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
     "translate an ForbiddenException into a 403 Forbidden result" in new WithDefaultGlobal {
       env.authenticatorService.retrieve(any) returns Future.successful(None)
       env.authenticatorService.discard(any, any)(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
 
       val controller = new SecuredController(env)
@@ -749,7 +749,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
     "translate an UnauthorizedException into a 401 Unauthorized result" in new WithDefaultGlobal {
       env.authenticatorService.retrieve(any) returns Future.successful(None)
       env.authenticatorService.discard(any, any)(any) answers { (a, m) =>
-        Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
+        Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
       }
 
       val controller = new SecuredController(env)
@@ -950,7 +950,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
      * @return The result to send to the client.
      */
     def securedRenewAction = SecuredAction.async { implicit request =>
-      request.authenticator.renew(Future.successful(Ok("renewed")))
+      env.authenticatorService.renew(request.authenticator, Ok("renewed"))
     }
 
     /**
@@ -959,7 +959,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
      * @return The result to send to the client.
      */
     def securedDiscardAction = SecuredAction.async { implicit request =>
-      request.authenticator.discard(Future.successful(Ok("discarded")))
+      env.authenticatorService.discard(request.authenticator, Ok("discarded"))
     }
 
     /**
@@ -996,7 +996,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
      */
     def userAwareRenewAction = UserAwareAction.async { implicit request =>
       request.authenticator match {
-        case Some(a) => a.renew(Future.successful(Ok("renewed")))
+        case Some(a) => env.authenticatorService.renew(a, Ok("renewed"))
         case None => Future.successful(Ok("not.renewed"))
       }
     }
@@ -1008,7 +1008,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
      */
     def userAwareDiscardAction = UserAwareAction.async { implicit request =>
       request.authenticator match {
-        case Some(a) => a.discard(Future.successful(Ok("discarded")))
+        case Some(a) => env.authenticatorService.discard(a, Ok("discarded"))
         case None => Future.successful(Ok("not.discarded"))
       }
     }

--- a/silhouette/test/com/mohiva/play/silhouette/api/services/AuthenticatorResultSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/api/services/AuthenticatorResultSpec.scala
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mohiva.play.silhouette.api.services
+
+import play.api.mvc.{ Cookie, Results }
+import play.api.test.{ WithApplication, PlaySpecification }
+
+/**
+ * Test case for the [[com.mohiva.play.silhouette.api.services.AuthenticatorResult]] class.
+ */
+class AuthenticatorResultSpec extends PlaySpecification {
+
+  "The `copy` method" should {
+    "return new a new instance of an authenticator result" in {
+      val result = Results.Ok
+      val authenticatorResult = AuthenticatorResult(result)
+
+      authenticatorResult.copy(result.header, result.body, result.connection) must beAnInstanceOf[AuthenticatorResult]
+    }
+  }
+
+  "The `withSession` method" should {
+    "return new a new instance of an authenticator result" in new WithApplication {
+      val result = Results.Ok
+      val authenticatorResult = AuthenticatorResult(result)
+
+      authenticatorResult.withSession("name" -> "value") must beAnInstanceOf[AuthenticatorResult]
+    }
+  }
+
+  "The `withCookies` method" should {
+    "return new a new instance of an authenticator result" in new WithApplication {
+      val result = Results.Ok
+      val authenticatorResult = AuthenticatorResult(result)
+
+      authenticatorResult.withCookies(Cookie("name", "value")) must beAnInstanceOf[AuthenticatorResult]
+    }
+  }
+
+  "The `withHeaders` method" should {
+    "return new a new instance of an authenticator result" in new WithApplication {
+      val result = Results.Ok
+      val authenticatorResult = AuthenticatorResult(result)
+
+      authenticatorResult.withHeaders("name" -> "value") must beAnInstanceOf[AuthenticatorResult]
+    }
+  }
+}

--- a/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticatorSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticatorSpec.scala
@@ -16,6 +16,7 @@
 package com.mohiva.play.silhouette.impl.authenticators
 
 import com.mohiva.play.silhouette.api.LoginInfo
+import com.mohiva.play.silhouette.api.services.AuthenticatorResult
 import org.specs2.mock.Mockito
 import org.specs2.specification.Scope
 import play.api.mvc.Results
@@ -61,7 +62,7 @@ class DummyAuthenticatorSpec extends PlaySpecification with Mockito {
   "The result `embed` method of the service" should {
     "return the original response" in new Context {
       implicit val request = FakeRequest()
-      val result = Results.Ok
+      val result = AuthenticatorResult(Results.Ok)
 
       await(service.embed((), result)) must be equalTo result
     }
@@ -87,7 +88,7 @@ class DummyAuthenticatorSpec extends PlaySpecification with Mockito {
   "The `update` method of the service" should {
     "return the original result" in new Context {
       implicit val request = FakeRequest()
-      val result = Results.Ok
+      val result = AuthenticatorResult(Results.Ok)
 
       await(service.update(authenticator, result)) must be equalTo result
     }
@@ -96,7 +97,7 @@ class DummyAuthenticatorSpec extends PlaySpecification with Mockito {
   "The `renew` method of the service" should {
     "return the original result" in new Context {
       implicit val request = FakeRequest()
-      val result = Results.Ok
+      val result = AuthenticatorResult(Results.Ok)
 
       await(service.renew(authenticator, result)) must be equalTo result
     }
@@ -105,7 +106,7 @@ class DummyAuthenticatorSpec extends PlaySpecification with Mockito {
   "The `discard` method of the service" should {
     "return the original result" in new Context {
       implicit val request = FakeRequest()
-      val result = Results.Ok
+      val result = AuthenticatorResult(Results.Ok)
 
       await(service.discard(authenticator, result)) must be equalTo result
     }


### PR DESCRIPTION
In every Silhouette action, an authenticator gets automatically [updated](https://github.com/mohiva/play-silhouette/blob/master/silhouette/app/com/mohiva/play/silhouette/api/Silhouette.scala#L275) on every request. This must be done with the result of the action, because every authenticator can update client side data. The problem is now that it isn't possible to manipulate an authenticator manually inside an action, because it gets automatically overridden with the updated authenticator. To work around this issue I've created the methods [discard](https://github.com/mohiva/play-silhouette/blob/master/silhouette/app/com/mohiva/play/silhouette/api/Authenticator.scala#L59) and [renew](https://github.com/mohiva/play-silhouette/blob/master/silhouette/app/com/mohiva/play/silhouette/api/Authenticator.scala#L75) in the current stable version. I've also [limited the access](https://github.com/mohiva/play-silhouette/blob/master/silhouette/app/com/mohiva/play/silhouette/api/services/AuthenticatorService.scala#L97) to the authenticator service to prevent the users for misusage.

Now it seems that this isn't enough, because of [this issue](https://groups.google.com/forum/#!topic/play-silhouette/nNz8lh2O-6Y).

My proposal to fix this issue is to implement an additional `skip` method equally to the `discard` and `renew` methods. I'd also remove the access restriction for the authenticator service to fix #315 because this misusage is also possible with this restriction. With the open access to the service, there is no need more for the `discard` and `renew` methods of the authenticator because the service can now be used directly.

As result we had only the `skip` method, which instructs Silhouette to skip the update of the authenticator, so that an manually updated authenticator can be send to the client.

@igorbernstein @rfranco Any suggestions?