### PR TITLE
Authenticator result alternative

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/api/Authenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/Authenticator.scala
@@ -42,6 +42,23 @@ trait Authenticator {
    * @return True if the authenticator isn't expired and isn't timed out.
    */
   def isValid: Boolean
+
+  /**
+   * A flag which indicates that an operation on an authenticator was processed and
+   * therefore not updated automatically.
+   *
+   * Due the fact that the update method gets called on every subsequent request to update the
+   * authenticator related data in the backing store and in the result, it isn't possible to
+   * discard or renew the authenticator simultaneously. This is because the "update" method would
+   * override the result created by the "renew" or "discard" method, because it will be executed
+   * as last in the chain.
+   *
+   * As example:
+   * If we discard the session in a Silhouette action then it will be removed from session. But
+   * at the end the update method will embed the session again, because it gets called with the
+   * result of the action.
+   */
+  private[silhouette] var skipUpdate = false
 }
 
 /**

--- a/silhouette/app/com/mohiva/play/silhouette/api/Authenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/Authenticator.scala
@@ -19,13 +19,6 @@
  */
 package com.mohiva.play.silhouette.api
 
-import com.mohiva.play.silhouette.api.Authenticator.Discard
-import com.mohiva.play.silhouette.api.Authenticator.Renew
-import play.api.libs.concurrent.Execution.Implicits._
-import play.api.mvc.Result
-
-import scala.concurrent.Future
-
 /**
  * An authenticator tracks an authenticated user.
  */
@@ -49,58 +42,6 @@ trait Authenticator {
    * @return True if the authenticator isn't expired and isn't timed out.
    */
   def isValid: Boolean
-
-  /**
-   * Discards an authenticator.
-   *
-   * @param result The result to wrap into the [[com.mohiva.play.silhouette.api.Authenticator.Discard]] result.
-   * @return A [[com.mohiva.play.silhouette.api.Authenticator.Discard]] result.
-   */
-  def discard(result: Result): Result = new Discard(result)
-
-  /**
-   * Discards an authenticator.
-   *
-   * @param result The result to wrap into the [[com.mohiva.play.silhouette.api.Authenticator.Discard]] result.
-   * @return A [[com.mohiva.play.silhouette.api.Authenticator.Discard]] result.
-   */
-  def discard(result: Future[Result]): Future[Result] = result.map(r => discard(r))
-
-  /**
-   * Renews an authenticator.
-   *
-   * @param result The result to wrap into the [[com.mohiva.play.silhouette.api.Authenticator.Renew]] result.
-   * @return A [[com.mohiva.play.silhouette.api.Authenticator.Renew]] result.
-   */
-  def renew(result: Result): Result = new Renew(result)
-
-  /**
-   * Renews an authenticator.
-   *
-   * @param result The result to wrap into the [[com.mohiva.play.silhouette.api.Authenticator.Renew]] result.
-   * @return A [[com.mohiva.play.silhouette.api.Authenticator.Renew]] result.
-   */
-  def renew(result: Future[Result]): Future[Result] = result.map(r => renew(r))
-}
-
-/**
- * The companion object.
- */
-object Authenticator {
-
-  /**
-   * A marker result which indicates that an authenticator should be discarded.
-   *
-   * @param result The wrapped result.
-   */
-  class Discard(result: Result) extends Result(result.header, result.body, result.connection)
-
-  /**
-   * A marker result which indicates that an authenticator should be renewed.
-   *
-   * @param result The wrapped result.
-   */
-  class Renew(result: Result) extends Result(result.header, result.body, result.connection)
 }
 
 /**

--- a/silhouette/app/com/mohiva/play/silhouette/api/Silhouette.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/Silhouette.scala
@@ -20,6 +20,7 @@
 package com.mohiva.play.silhouette.api
 
 import com.mohiva.play.silhouette.api.exceptions.{ NotAuthenticatedException, NotAuthorizedException }
+import com.mohiva.play.silhouette.api.services.AuthenticatorResult
 import com.mohiva.play.silhouette.api.util.DefaultEndpointHandler
 import play.api.Play
 import play.api.libs.concurrent.Execution.Implicits._
@@ -266,10 +267,7 @@ trait Silhouette[I <: Identity, A <: Authenticator] extends Controller with Logg
     private def handleInitializedAuthenticator[T](authenticator: A, block: A => Future[HandlerResult[T]])(implicit request: RequestHeader) = {
       val auth = env.authenticatorService.touch(authenticator)
       block(auth.extract).flatMap {
-        case hr @ HandlerResult(pr: Authenticator.Discard, _) =>
-          env.authenticatorService.discard(authenticator, pr).map(pr => hr.copy(pr))
-        case hr @ HandlerResult(pr: Authenticator.Renew, _) =>
-          env.authenticatorService.renew(authenticator, pr).map(pr => hr.copy(pr))
+        case hr @ HandlerResult(pr: AuthenticatorResult, _) => Future.successful(hr)
         case hr @ HandlerResult(pr, _) => auth match {
           // Authenticator was touched so we update the authenticator and maybe the result
           case Left(a) => env.authenticatorService.update(a, pr).map(pr => hr.copy(pr))
@@ -292,10 +290,7 @@ trait Silhouette[I <: Identity, A <: Authenticator] extends Controller with Logg
      */
     private def handleUninitializedAuthenticator[T](authenticator: A, block: A => Future[HandlerResult[T]])(implicit request: RequestHeader) = {
       block(authenticator).flatMap {
-        case hr @ HandlerResult(pr: Authenticator.Discard, _) =>
-          env.authenticatorService.discard(authenticator, pr).map(pr => hr.copy(pr))
-        case hr @ HandlerResult(pr: Authenticator.Renew, _) =>
-          env.authenticatorService.renew(authenticator, pr).map(pr => hr.copy(pr))
+        case hr @ HandlerResult(pr: AuthenticatorResult, _) => Future.successful(hr)
         case hr @ HandlerResult(pr, _) =>
           env.authenticatorService.init(authenticator).flatMap { value =>
             env.authenticatorService.embed(value, pr)

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/BearerTokenAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/BearerTokenAuthenticator.scala
@@ -158,9 +158,7 @@ class BearerTokenAuthenticatorService(
    * @return The manipulated result.
    */
   def embed(token: String, result: Result)(implicit request: RequestHeader) = {
-    Future.successful(
-      result.withHeaders(settings.headerName -> token)
-    )
+    Future.successful(result.withHeaders(settings.headerName -> token))
   }
 
   /**
@@ -180,9 +178,7 @@ class BearerTokenAuthenticatorService(
    * @param authenticator The authenticator to touch.
    * @return The touched authenticator on the left or the untouched authenticator on the right.
    */
-  protected[silhouette] def touch(
-    authenticator: BearerTokenAuthenticator): Either[BearerTokenAuthenticator, BearerTokenAuthenticator] = {
-
+  def touch(authenticator: BearerTokenAuthenticator): Either[BearerTokenAuthenticator, BearerTokenAuthenticator] = {
     if (authenticator.idleTimeout.isDefined) {
       Left(authenticator.copy(lastUsedDate = clock.now))
     } else {
@@ -201,10 +197,7 @@ class BearerTokenAuthenticatorService(
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  protected[silhouette] def update(
-    authenticator: BearerTokenAuthenticator,
-    result: Result)(implicit request: RequestHeader) = {
-
+  def update(authenticator: BearerTokenAuthenticator, result: Result)(implicit request: RequestHeader) = {
     dao.save(authenticator).map { a =>
       result
     }.recover {
@@ -221,10 +214,7 @@ class BearerTokenAuthenticatorService(
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  protected[silhouette] def renew(
-    authenticator: BearerTokenAuthenticator,
-    result: Result)(implicit request: RequestHeader) = {
-
+  def renew(authenticator: BearerTokenAuthenticator, result: Result)(implicit request: RequestHeader) = {
     dao.remove(authenticator.id).flatMap { _ =>
       create(authenticator.loginInfo).flatMap { a =>
         init(a).flatMap(v => embed(v, result))
@@ -241,10 +231,7 @@ class BearerTokenAuthenticatorService(
    * @param request The request header.
    * @return The manipulated result.
    */
-  protected[silhouette] def discard(
-    authenticator: BearerTokenAuthenticator,
-    result: Result)(implicit request: RequestHeader) = {
-
+  def discard(authenticator: BearerTokenAuthenticator, result: Result)(implicit request: RequestHeader) = {
     dao.remove(authenticator.id).map { _ =>
       result
     }.recover {

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/BearerTokenAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/BearerTokenAuthenticator.scala
@@ -198,6 +198,7 @@ class BearerTokenAuthenticatorService(
    * @return The original or a manipulated result.
    */
   def update(authenticator: BearerTokenAuthenticator, result: Result)(implicit request: RequestHeader) = {
+    authenticator.skipUpdate = true
     dao.save(authenticator).map { a =>
       result
     }.recover {
@@ -215,6 +216,7 @@ class BearerTokenAuthenticatorService(
    * @return The original or a manipulated result.
    */
   def renew(authenticator: BearerTokenAuthenticator, result: Result)(implicit request: RequestHeader) = {
+    authenticator.skipUpdate = true
     dao.remove(authenticator.id).flatMap { _ =>
       create(authenticator.loginInfo).flatMap { a =>
         init(a).flatMap(v => embed(v, result))
@@ -232,6 +234,7 @@ class BearerTokenAuthenticatorService(
    * @return The manipulated result.
    */
   def discard(authenticator: BearerTokenAuthenticator, result: Result)(implicit request: RequestHeader) = {
+    authenticator.skipUpdate = true
     dao.remove(authenticator.id).map { _ =>
       result
     }.recover {

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticator.scala
@@ -231,6 +231,7 @@ class CookieAuthenticatorService(
    * @return The original or a manipulated result.
    */
   def update(authenticator: CookieAuthenticator, result: Result)(implicit request: RequestHeader) = {
+    authenticator.skipUpdate = true
     dao.save(authenticator).map { a =>
       result
     }.recover {
@@ -248,6 +249,7 @@ class CookieAuthenticatorService(
    * @return The original or a manipulated result.
    */
   def renew(authenticator: CookieAuthenticator, result: Result)(implicit request: RequestHeader) = {
+    authenticator.skipUpdate = true
     dao.remove(authenticator.id).flatMap { _ =>
       create(authenticator.loginInfo).flatMap { a =>
         init(a).flatMap(v => embed(v, result))
@@ -265,6 +267,7 @@ class CookieAuthenticatorService(
    * @return The manipulated result.
    */
   def discard(authenticator: CookieAuthenticator, result: Result)(implicit request: RequestHeader) = {
+    authenticator.skipUpdate = true
     dao.remove(authenticator.id).map { _ =>
       result.discardingCookies(DiscardingCookie(
         name = settings.cookieName,

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticator.scala
@@ -211,9 +211,7 @@ class CookieAuthenticatorService(
    * @param authenticator The authenticator to touch.
    * @return The touched authenticator on the left or the untouched authenticator on the right.
    */
-  protected[silhouette] def touch(
-    authenticator: CookieAuthenticator): Either[CookieAuthenticator, CookieAuthenticator] = {
-
+  def touch(authenticator: CookieAuthenticator): Either[CookieAuthenticator, CookieAuthenticator] = {
     if (authenticator.idleTimeout.isDefined) {
       Left(authenticator.copy(lastUsedDate = clock.now))
     } else {
@@ -232,10 +230,7 @@ class CookieAuthenticatorService(
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  protected[silhouette] def update(
-    authenticator: CookieAuthenticator,
-    result: Result)(implicit request: RequestHeader) = {
-
+  def update(authenticator: CookieAuthenticator, result: Result)(implicit request: RequestHeader) = {
     dao.save(authenticator).map { a =>
       result
     }.recover {
@@ -252,10 +247,7 @@ class CookieAuthenticatorService(
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  protected[silhouette] def renew(
-    authenticator: CookieAuthenticator,
-    result: Result)(implicit request: RequestHeader) = {
-
+  def renew(authenticator: CookieAuthenticator, result: Result)(implicit request: RequestHeader) = {
     dao.remove(authenticator.id).flatMap { _ =>
       create(authenticator.loginInfo).flatMap { a =>
         init(a).flatMap(v => embed(v, result))
@@ -272,10 +264,7 @@ class CookieAuthenticatorService(
    * @param request The request header.
    * @return The manipulated result.
    */
-  protected[silhouette] def discard(
-    authenticator: CookieAuthenticator,
-    result: Result)(implicit request: RequestHeader) = {
-
+  def discard(authenticator: CookieAuthenticator, result: Result)(implicit request: RequestHeader) = {
     dao.remove(authenticator.id).map { _ =>
       result.discardingCookies(DiscardingCookie(
         name = settings.cookieName,

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticator.scala
@@ -117,6 +117,7 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @return The original or a manipulated result.
    */
   def update(authenticator: DummyAuthenticator, result: Result)(implicit request: RequestHeader) = {
+    authenticator.skipUpdate = true
     Future.successful(result)
   }
 
@@ -129,6 +130,7 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @return The original or a manipulated result.
    */
   def renew(authenticator: DummyAuthenticator, result: Result)(implicit request: RequestHeader) = {
+    authenticator.skipUpdate = true
     Future.successful(result)
   }
 
@@ -140,6 +142,7 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @return The manipulated result.
    */
   def discard(authenticator: DummyAuthenticator, result: Result)(implicit request: RequestHeader) = {
+    authenticator.skipUpdate = true
     Future.successful(result)
   }
 }

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticator.scala
@@ -89,9 +89,7 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @param request The request header.
    * @return The manipulated result.
    */
-  def embed(value: Unit, result: Result)(implicit request: RequestHeader) = {
-    Future.successful(result)
-  }
+  def embed(value: Unit, result: Result)(implicit request: RequestHeader) = Future.successful(result)
 
   /**
    * Returns the original request, because we needn't add the authenticator to the request.
@@ -108,7 +106,7 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @param authenticator The authenticator to touch.
    * @return The touched authenticator on the left or the untouched authenticator on the right.
    */
-  protected[silhouette] def touch(authenticator: DummyAuthenticator) = Right(authenticator)
+  def touch(authenticator: DummyAuthenticator) = Right(authenticator)
 
   /**
    * Returns the original request, because we needn't update the authenticator in the result.
@@ -118,10 +116,7 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  protected[silhouette] def update(
-    authenticator: DummyAuthenticator,
-    result: Result)(implicit request: RequestHeader) = {
-
+  def update(authenticator: DummyAuthenticator, result: Result)(implicit request: RequestHeader) = {
     Future.successful(result)
   }
 
@@ -133,10 +128,7 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  protected[silhouette] def renew(
-    authenticator: DummyAuthenticator,
-    result: Result)(implicit request: RequestHeader) = {
-
+  def renew(authenticator: DummyAuthenticator, result: Result)(implicit request: RequestHeader) = {
     Future.successful(result)
   }
 
@@ -147,10 +139,7 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @param request The request header.
    * @return The manipulated result.
    */
-  protected[silhouette] def discard(
-    authenticator: DummyAuthenticator,
-    result: Result)(implicit request: RequestHeader) = {
-
+  def discard(authenticator: DummyAuthenticator, result: Result)(implicit request: RequestHeader) = {
     Future.successful(result)
   }
 }

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/JWTAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/JWTAuthenticator.scala
@@ -221,6 +221,7 @@ class JWTAuthenticatorService(
    * @return The original or a manipulated result.
    */
   def update(authenticator: JWTAuthenticator, result: Result)(implicit request: RequestHeader) = {
+    authenticator.skipUpdate = true
     dao.fold(Future.successful(authenticator))(_.save(authenticator)).map { a =>
       result.withHeaders(settings.headerName -> serialize(a))
     }.recover {
@@ -238,6 +239,7 @@ class JWTAuthenticatorService(
    * @return The original or a manipulated result.
    */
   def renew(authenticator: JWTAuthenticator, result: Result)(implicit request: RequestHeader) = {
+    authenticator.skipUpdate = true
     dao.fold(Future.successful(()))(_.remove(authenticator.id)).flatMap { _ =>
       create(authenticator.loginInfo).flatMap { a =>
         init(a).flatMap(v => embed(v, result))
@@ -255,6 +257,7 @@ class JWTAuthenticatorService(
    * @return The manipulated result.
    */
   def discard(authenticator: JWTAuthenticator, result: Result)(implicit request: RequestHeader) = {
+    authenticator.skipUpdate = true
     dao.fold(Future.successful(()))(_.remove(authenticator.id)).map { _ =>
       result
     }.recover {

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/JWTAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/JWTAuthenticator.scala
@@ -201,7 +201,7 @@ class JWTAuthenticatorService(
    * @param authenticator The authenticator to touch.
    * @return The touched authenticator on the left or the untouched authenticator on the right.
    */
-  protected[silhouette] def touch(authenticator: JWTAuthenticator): Either[JWTAuthenticator, JWTAuthenticator] = {
+  def touch(authenticator: JWTAuthenticator): Either[JWTAuthenticator, JWTAuthenticator] = {
     if (authenticator.idleTimeout.isDefined) {
       Left(authenticator.copy(lastUsedDate = clock.now))
     } else {
@@ -220,10 +220,7 @@ class JWTAuthenticatorService(
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  protected[silhouette] def update(
-    authenticator: JWTAuthenticator,
-    result: Result)(implicit request: RequestHeader) = {
-
+  def update(authenticator: JWTAuthenticator, result: Result)(implicit request: RequestHeader) = {
     dao.fold(Future.successful(authenticator))(_.save(authenticator)).map { a =>
       result.withHeaders(settings.headerName -> serialize(a))
     }.recover {
@@ -240,10 +237,7 @@ class JWTAuthenticatorService(
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  protected[silhouette] def renew(
-    authenticator: JWTAuthenticator,
-    result: Result)(implicit request: RequestHeader) = {
-
+  def renew(authenticator: JWTAuthenticator, result: Result)(implicit request: RequestHeader) = {
     dao.fold(Future.successful(()))(_.remove(authenticator.id)).flatMap { _ =>
       create(authenticator.loginInfo).flatMap { a =>
         init(a).flatMap(v => embed(v, result))
@@ -260,10 +254,7 @@ class JWTAuthenticatorService(
    * @param request The request header.
    * @return The manipulated result.
    */
-  protected[silhouette] def discard(
-    authenticator: JWTAuthenticator,
-    result: Result)(implicit request: RequestHeader) = {
-
+  def discard(authenticator: JWTAuthenticator, result: Result)(implicit request: RequestHeader) = {
     dao.fold(Future.successful(()))(_.remove(authenticator.id)).map { _ =>
       result
     }.recover {
@@ -286,7 +277,7 @@ class JWTAuthenticatorService(
       .issuedAt(authenticator.lastUsedDate.getMillis / 1000)
       .expirationTime(authenticator.expirationDate.getMillis / 1000)
 
-    authenticator.customClaims.map { data =>
+    authenticator.customClaims.foreach { data =>
       serializeCustomClaims(data).foreach {
         case (key, value) =>
           if (ReservedClaims.contains(key)) {

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticator.scala
@@ -191,9 +191,7 @@ class SessionAuthenticatorService(
    * @param authenticator The authenticator to touch.
    * @return The touched authenticator on the left or the untouched authenticator on the right.
    */
-  protected[silhouette] def touch(
-    authenticator: SessionAuthenticator): Either[SessionAuthenticator, SessionAuthenticator] = {
-
+  def touch(authenticator: SessionAuthenticator): Either[SessionAuthenticator, SessionAuthenticator] = {
     if (authenticator.idleTimeout.isDefined) {
       Left(authenticator.copy(lastUsedDate = clock.now))
     } else {
@@ -212,16 +210,12 @@ class SessionAuthenticatorService(
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  protected[silhouette] def update(
-    authenticator: SessionAuthenticator,
-    result: Result)(implicit request: RequestHeader) = {
-
-    Future {
+  def update(authenticator: SessionAuthenticator, result: Result)(implicit request: RequestHeader) = {
+    Future.from(Try {
       result.addingToSession(settings.sessionKey -> serialize(authenticator))
     }.recover {
       case e => throw new AuthenticatorUpdateException(UpdateError.format(ID, authenticator), e)
-    }
-
+    })
   }
 
   /**
@@ -233,10 +227,7 @@ class SessionAuthenticatorService(
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  protected[silhouette] def renew(
-    authenticator: SessionAuthenticator,
-    result: Result)(implicit request: RequestHeader) = {
-
+  def renew(authenticator: SessionAuthenticator, result: Result)(implicit request: RequestHeader) = {
     create(authenticator.loginInfo).flatMap { a =>
       init(a).flatMap(v => embed(v, result))
     }.recover {
@@ -251,16 +242,12 @@ class SessionAuthenticatorService(
    * @param request The request header.
    * @return The manipulated result.
    */
-  protected[silhouette] def discard(
-    authenticator: SessionAuthenticator,
-    result: Result)(implicit request: RequestHeader) = {
-
-    Future {
+  def discard(authenticator: SessionAuthenticator, result: Result)(implicit request: RequestHeader) = {
+    Future.from(Try {
       result.removingFromSession(settings.sessionKey)
     }.recover {
       case e => throw new AuthenticatorDiscardingException(DiscardError.format(ID, authenticator), e)
-    }
-
+    })
   }
 
   /**

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticator.scala
@@ -211,6 +211,7 @@ class SessionAuthenticatorService(
    * @return The original or a manipulated result.
    */
   def update(authenticator: SessionAuthenticator, result: Result)(implicit request: RequestHeader) = {
+    authenticator.skipUpdate = true
     Future.from(Try {
       result.addingToSession(settings.sessionKey -> serialize(authenticator))
     }.recover {
@@ -228,6 +229,7 @@ class SessionAuthenticatorService(
    * @return The original or a manipulated result.
    */
   def renew(authenticator: SessionAuthenticator, result: Result)(implicit request: RequestHeader) = {
+    authenticator.skipUpdate = true
     create(authenticator.loginInfo).flatMap { a =>
       init(a).flatMap(v => embed(v, result))
     }.recover {
@@ -243,6 +245,7 @@ class SessionAuthenticatorService(
    * @return The manipulated result.
    */
   def discard(authenticator: SessionAuthenticator, result: Result)(implicit request: RequestHeader) = {
+    authenticator.skipUpdate = true
     Future.from(Try {
       result.removingFromSession(settings.sessionKey)
     }.recover {

--- a/silhouette/test/com/mohiva/play/silhouette/api/SilhouetteSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/api/SilhouetteSpec.scala
@@ -32,6 +32,7 @@ import play.api.test.{ FakeApplication, FakeRequest, PlaySpecification, WithAppl
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import scala.language.postfixOps
 import scala.reflect.ClassTag
 
 /**
@@ -950,7 +951,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
      * @return The result to send to the client.
      */
     def securedRenewAction = SecuredAction.async { implicit request =>
-      request.authenticator.renew(Future.successful(Ok("renewed")))
+      env.authenticatorService.renew(request.authenticator, Ok("renewed"))
     }
 
     /**
@@ -959,7 +960,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
      * @return The result to send to the client.
      */
     def securedDiscardAction = SecuredAction.async { implicit request =>
-      request.authenticator.discard(Future.successful(Ok("discarded")))
+      env.authenticatorService.discard(request.authenticator, Ok("discarded"))
     }
 
     /**
@@ -996,7 +997,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
      */
     def userAwareRenewAction = UserAwareAction.async { implicit request =>
       request.authenticator match {
-        case Some(a) => a.renew(Future.successful(Ok("renewed")))
+        case Some(a) => env.authenticatorService.renew(a, Ok("renewed"))
         case None => Future.successful(Ok("not.renewed"))
       }
     }
@@ -1008,7 +1009,7 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
      */
     def userAwareDiscardAction = UserAwareAction.async { implicit request =>
       request.authenticator match {
-        case Some(a) => a.discard(Future.successful(Ok("discarded")))
+        case Some(a) => env.authenticatorService.discard(a, Ok("discarded"))
         case None => Future.successful(Ok("not.discarded"))
       }
     }

--- a/silhouette/test/com/mohiva/play/silhouette/api/SilhouetteSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/api/SilhouetteSpec.scala
@@ -32,7 +32,6 @@ import play.api.test.{ FakeApplication, FakeRequest, PlaySpecification, WithAppl
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.language.postfixOps
 import scala.reflect.ClassTag
 
 /**
@@ -369,6 +368,9 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.renew(any, any)(any) answers { (a, m) =>
+        val authenticator = a.asInstanceOf[Array[Any]](0).asInstanceOf[Authenticator]
+        authenticator.skipUpdate = true
+
         Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
@@ -391,6 +393,9 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(None)
       env.authenticatorService.create(any)(any) returns Future.successful(authenticator)
       env.authenticatorService.renew(any, any)(any) answers { (a, m) =>
+        val authenticator = a.asInstanceOf[Array[Any]](0).asInstanceOf[Authenticator]
+        authenticator.skipUpdate = true
+
         Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
@@ -411,6 +416,9 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.discard(any, any)(any) answers { (a, m) =>
+        val authenticator = a.asInstanceOf[Array[Any]](0).asInstanceOf[Authenticator]
+        authenticator.skipUpdate = true
+
         Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
@@ -433,6 +441,9 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(None)
       env.authenticatorService.create(any)(any) returns Future.successful(authenticator)
       env.authenticatorService.discard(any, any)(any) answers { (a, m) =>
+        val authenticator = a.asInstanceOf[Array[Any]](0).asInstanceOf[Authenticator]
+        authenticator.skipUpdate = true
+
         Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
@@ -635,6 +646,9 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.renew(any, any)(any) answers { (a, m) =>
+        val authenticator = a.asInstanceOf[Array[Any]](0).asInstanceOf[Authenticator]
+        authenticator.skipUpdate = true
+
         Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
@@ -654,6 +668,9 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(None)
       env.authenticatorService.create(any)(any) returns Future.successful(authenticator)
       env.authenticatorService.renew(any, any)(any) answers { (a, m) =>
+        val authenticator = a.asInstanceOf[Array[Any]](0).asInstanceOf[Authenticator]
+        authenticator.skipUpdate = true
+
         Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
@@ -671,6 +688,9 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
       env.authenticatorService.touch(any) returns Left(authenticator)
       env.authenticatorService.discard(any, any)(any) answers { (a, m) =>
+        val authenticator = a.asInstanceOf[Array[Any]](0).asInstanceOf[Authenticator]
+        authenticator.skipUpdate = true
+
         Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
@@ -690,6 +710,9 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
       env.authenticatorService.retrieve(any) returns Future.successful(None)
       env.authenticatorService.create(any)(any) returns Future.successful(authenticator)
       env.authenticatorService.discard(any, any)(any) answers { (a, m) =>
+        val authenticator = a.asInstanceOf[Array[Any]](0).asInstanceOf[Authenticator]
+        authenticator.skipUpdate = true
+
         Future.successful(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result])
       }
       env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))


### PR DESCRIPTION
This is an alternative pull request to fix #323. Instead of using a marker `Result` it uses a mutable flag in the `Authenticator` instance. This doesn't work with the embed method, because this method gets no authenticator passed. But it can be used with all other methods which manipulates/creates an authenticator. The other pull request with the marker `Result` works only with the methods that returns a `Result`.

There are some points which can be changed:
- We could allow to set the flag from outside of Silhouette
- We could set the flag also in the `create` and `init` methods

@igorbernstein  @rfranco What do you think?