### PR TITLE
BasicAuthProvider should check the method is Basic

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/BasicAuthProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/BasicAuthProvider.scala
@@ -89,11 +89,12 @@ class BasicAuthProvider(
    */
   def getCredentials(request: RequestHeader): Option[Credentials] = {
     request.headers.get(HeaderNames.AUTHORIZATION) match {
-      case Some(header) => Base64.decode(header.replace("Basic ", "")).split(":") match {
-        case credentials if credentials.length == 2 => Some(Credentials(credentials(0), credentials(1)))
-        case _ => None
-      }
-      case None => None
+      case Some(header) if header.startsWith("Basic ") =>
+        Base64.decode(header.replace("Basic ", "")).split(":") match {
+          case credentials if credentials.length == 2 => Some(Credentials(credentials(0), credentials(1)))
+          case _ => None
+        }
+      case _ => None
     }
   }
 }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/BasicAuthProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/BasicAuthProviderSpec.scala
@@ -102,6 +102,12 @@ class BasicAuthProviderSpec extends PlaySpecification with Mockito {
       await(provider.authenticate(request)) must beSome(loginInfo)
       there was one(authInfoRepository).update(loginInfo, passwordInfo)
     }
+
+    "return None if Authorization method is not Basic and Base64 decoded header has ':'" in new WithApplication with Context {
+      val request = FakeRequest().withHeaders(AUTHORIZATION -> Base64.encode("NotBasic foo:bar"))
+
+      await(provider.authenticate(request)) must beNone
+    }
   }
 
   /**


### PR DESCRIPTION
I ran across this issue when I send requests where the Authorization header was a JWT Bearer such as:

    Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJlNGU1N2Y1NzJhMGU4MjRjMGQxYjZhMzIzMzIxNmUzMmZhYjBiNzMyNDdmNzY3MTBkMmM1OGE2OTEwODA4MmYzZDJlYTVlYTk1YjA0YTA2NjgzM2FjMzU0ZDQwYjk3Y2UxMTE0ZmUyNWNmMjEzYjJkYzllOTAzOWQ0NjQ1OGQ1YyIsImlzcyI6InBsYXktc2lsaG91ZXR0ZSIsImV4cCI6MTQzMDg0NTMxMSwiaWF0IjoxNDMwODAyMTExLCJqdGkiOiJmN2Y1ZThjNmE1MjliYTlkZGYwNjViZjQ5ZGY0MDVjYjQ1ZWEyNmQ3ZTc3NDI5M2Y3NGFhZWVjNTU0ODg1MTVmNTYzMzM5MTM4OGQzY2I3ODA0ZmM4MDIzZjU4ODMzYjk3OGUyMmUxYTZmYzdmNmVkZDJjN2Y5NTVjNDJkM2ZjYTQ2MzVlODZlMzliZjVmZWJjMmI0MzliNzQ2MDU1YzllZjc1ZWFmNzc2MzMxZGU1Yjg4ZmQwMGNhY2U2MjJjZDk0YWMzMzIzNzhkNjNmOTNjZjhkZDUzZGUzODdjYWJiNTgzYTMzYTFjMDIwYjY5MjQ2YTc0MGNhOTY3NDg5ZTRjIn0.mWXfWsFomqMnMBHgZUoHNTONmAbrKoUIpG5stzrjNHo

When the `BasicAuthProvider` tries to parse the credentials it Base64 decodes `"Bearer eyJ0eXAiOiJKV1Q..."` and since the resulting string has a `:` in it thinks it's a Basic Auth header. This PR makes sure the header is Basic Auth and returns `None` otherwise.