### PR TITLE
Use implicit `Application` instead of the `MessagesApi` to reduce boilerplate code in the tests

### DIFF
--- a/silhouette-testkit/app/com/mohiva/play/silhouette/test/Fakes.scala
+++ b/silhouette-testkit/app/com/mohiva/play/silhouette/test/Fakes.scala
@@ -23,6 +23,7 @@ import com.mohiva.play.silhouette.api.util.Clock
 import com.mohiva.play.silhouette.impl.authenticators._
 import com.mohiva.play.silhouette.impl.daos.AuthenticatorDAO
 import com.mohiva.play.silhouette.impl.util.{ DefaultFingerprintGenerator, SecureRandomIDGenerator }
+import play.api.Application
 import play.api.i18n.MessagesApi
 import play.api.mvc.RequestHeader
 
@@ -211,7 +212,7 @@ object FakeAuthenticator {
  * @param identities A list of (login info -> identity) pairs to return inside a Silhouette action.
  * @param requestProviders The list of request providers.
  * @param eventBus The event bus implementation.
- * @param messagesApi The Play messages API.
+ * @param app The implicit Play application.
  * @tparam I The type of the identity.
  * @tparam T The type of the authenticator.
  */
@@ -219,20 +220,21 @@ case class FakeEnvironment[I <: Identity, T <: Authenticator: TypeTag](
   identities: Seq[(LoginInfo, I)],
   requestProviders: Seq[RequestProvider] = Seq(),
   eventBus: EventBus = EventBus())(
-    implicit val messagesApi: MessagesApi)
+    implicit val app: Application)
   extends Environment[I, T] {
 
   /**
-   * Gets the identity service implementation.
-   *
-   * @return The identity service implementation.
+   * The identity service implementation.
    */
   val identityService: IdentityService[I] = new FakeIdentityService[I](identities: _*)
 
   /**
-   * Gets the authenticator service implementation.
-   *
-   * @return The authenticator service implementation.
+   *  The authenticator service implementation.
    */
   val authenticatorService: AuthenticatorService[T] = FakeAuthenticatorService[T]()
+
+  /**
+   * The Play messages API.
+   */
+  val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
 }

--- a/silhouette-testkit/test/com/mohiva/play/silhouette/test/FakesSpec.scala
+++ b/silhouette-testkit/test/com/mohiva/play/silhouette/test/FakesSpec.scala
@@ -20,8 +20,6 @@ import javax.inject.Inject
 import com.mohiva.play.silhouette.api.{ Environment, LoginInfo, Silhouette }
 import com.mohiva.play.silhouette.impl.authenticators._
 import org.specs2.matcher.JsonMatchers
-import org.specs2.specification.Scope
-import play.api.i18n.MessagesApi
 import play.api.libs.json.Json
 import play.api.test.{ FakeRequest, PlaySpecification, WithApplication }
 
@@ -121,7 +119,7 @@ class FakesSpec extends PlaySpecification with JsonMatchers {
   }
 
   "The `FakeAuthenticator` factory" should {
-    "return a `SessionAuthenticator`" in new WithApplication with Context {
+    "return a `SessionAuthenticator`" in new WithApplication {
       val loginInfo = LoginInfo("test", "test")
       val identity = FakeIdentity(loginInfo)
       implicit val env = FakeEnvironment[FakeIdentity, SessionAuthenticator](Seq(loginInfo -> identity))
@@ -130,7 +128,7 @@ class FakesSpec extends PlaySpecification with JsonMatchers {
       FakeAuthenticator[SessionAuthenticator](loginInfo) must beAnInstanceOf[SessionAuthenticator]
     }
 
-    "return a `CookieAuthenticator`" in new WithApplication with Context {
+    "return a `CookieAuthenticator`" in new WithApplication {
       val loginInfo = LoginInfo("test", "test")
       val identity = FakeIdentity(loginInfo)
       implicit val env = FakeEnvironment[FakeIdentity, CookieAuthenticator](Seq(loginInfo -> identity))
@@ -139,7 +137,7 @@ class FakesSpec extends PlaySpecification with JsonMatchers {
       FakeAuthenticator[CookieAuthenticator](loginInfo) must beAnInstanceOf[CookieAuthenticator]
     }
 
-    "return a `BearerTokenAuthenticator`" in new WithApplication with Context {
+    "return a `BearerTokenAuthenticator`" in new WithApplication {
       val loginInfo = LoginInfo("test", "test")
       val identity = FakeIdentity(loginInfo)
       implicit val env = FakeEnvironment[FakeIdentity, BearerTokenAuthenticator](Seq(loginInfo -> identity))
@@ -148,7 +146,7 @@ class FakesSpec extends PlaySpecification with JsonMatchers {
       FakeAuthenticator[BearerTokenAuthenticator](loginInfo) must beAnInstanceOf[BearerTokenAuthenticator]
     }
 
-    "return a `JWTAuthenticator`" in new WithApplication with Context {
+    "return a `JWTAuthenticator`" in new WithApplication {
       val loginInfo = LoginInfo("test", "test")
       val identity = FakeIdentity(loginInfo)
       implicit val env = FakeEnvironment[FakeIdentity, JWTAuthenticator](Seq(loginInfo -> identity))
@@ -157,7 +155,7 @@ class FakesSpec extends PlaySpecification with JsonMatchers {
       FakeAuthenticator[JWTAuthenticator](loginInfo) must beAnInstanceOf[JWTAuthenticator]
     }
 
-    "return a `DummyAuthenticator`" in new WithApplication with Context {
+    "return a `DummyAuthenticator`" in new WithApplication {
       val loginInfo = LoginInfo("test", "test")
       val identity = FakeIdentity(loginInfo)
       implicit val env = FakeEnvironment[FakeIdentity, DummyAuthenticator](Seq(loginInfo -> identity))
@@ -168,7 +166,7 @@ class FakesSpec extends PlaySpecification with JsonMatchers {
   }
 
   "The `securedAction` method of the `SecuredController`" should {
-    "return a 401 status code if no authenticator was found" in new WithApplication with Context {
+    "return a 401 status code if no authenticator was found" in new WithApplication {
       val loginInfo = LoginInfo("test", "test")
       val identity = FakeIdentity(loginInfo)
       val env = FakeEnvironment[FakeIdentity, CookieAuthenticator](Seq(loginInfo -> identity))
@@ -180,7 +178,7 @@ class FakesSpec extends PlaySpecification with JsonMatchers {
       status(result) must equalTo(UNAUTHORIZED)
     }
 
-    "return a 401 status code if authenticator but no identity was found" in new WithApplication with Context {
+    "return a 401 status code if authenticator but no identity was found" in new WithApplication {
       val loginInfo = LoginInfo("test", "test")
       val identity = FakeIdentity(loginInfo)
       implicit val env = FakeEnvironment[FakeIdentity, CookieAuthenticator](Seq(loginInfo -> identity))
@@ -192,7 +190,7 @@ class FakesSpec extends PlaySpecification with JsonMatchers {
       status(result) must equalTo(UNAUTHORIZED)
     }
 
-    "return a 200 status code if authenticator and identity was found" in new WithApplication with Context {
+    "return a 200 status code if authenticator and identity was found" in new WithApplication {
       val loginInfo = LoginInfo("test", "test")
       val identity = FakeIdentity(loginInfo)
       implicit val env = FakeEnvironment[FakeIdentity, CookieAuthenticator](Seq(loginInfo -> identity))
@@ -207,7 +205,7 @@ class FakesSpec extends PlaySpecification with JsonMatchers {
   }
 
   "The `userAwareAction` method of the `SecuredController`" should {
-    "return a 401 status code if no authenticator was found" in new WithApplication with Context {
+    "return a 401 status code if no authenticator was found" in new WithApplication {
       val loginInfo = LoginInfo("test", "test")
       val identity = FakeIdentity(loginInfo)
       val env = FakeEnvironment[FakeIdentity, CookieAuthenticator](Seq(loginInfo -> identity))
@@ -219,7 +217,7 @@ class FakesSpec extends PlaySpecification with JsonMatchers {
       status(result) must equalTo(UNAUTHORIZED)
     }
 
-    "return a 401 status code if authenticator but no identity was found" in new WithApplication with Context {
+    "return a 401 status code if authenticator but no identity was found" in new WithApplication {
       val loginInfo = LoginInfo("test", "test")
       val identity = FakeIdentity(loginInfo)
       implicit val env = FakeEnvironment[FakeIdentity, CookieAuthenticator](Seq(loginInfo -> identity))
@@ -231,7 +229,7 @@ class FakesSpec extends PlaySpecification with JsonMatchers {
       status(result) must equalTo(UNAUTHORIZED)
     }
 
-    "return a 200 status code if authenticator and identity was found" in new WithApplication with Context {
+    "return a 200 status code if authenticator and identity was found" in new WithApplication {
       val loginInfo = LoginInfo("test", "test")
       val identity = FakeIdentity(loginInfo)
 
@@ -275,17 +273,5 @@ class FakesSpec extends PlaySpecification with JsonMatchers {
         case None => Unauthorized
       }
     }
-  }
-
-  /**
-   * The context.
-   */
-  trait Context extends Scope {
-    self: WithApplication =>
-
-    /**
-     * The Play messages API.
-     */
-    implicit val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
   }
 }


### PR DESCRIPTION
When running tests with `WithApplication` there is always an implicit application in scope. This reduces the need to get the `MessagesApi` from injector and declare it as implicit for the `FakeEnvironment`. Instead the `FakeEnvironment` will fetch it from injector.