### PR TITLE
Allow to return a Future in the Authorization.isAuthorized method

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/api/Authorization.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/Authorization.scala
@@ -21,6 +21,8 @@ package com.mohiva.play.silhouette.api
 
 import play.api.i18n.Messages
 import play.api.mvc.RequestHeader
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
 
 /**
  * A trait to define Authorization objects that let you hook
@@ -38,7 +40,7 @@ trait Authorization[I <: Identity] {
    * @param messages The messages for the current language.
    * @return True if the user is authorized, false otherwise.
    */
-  def isAuthorized(identity: I)(implicit request: RequestHeader, messages: Messages): Boolean
+  def isAuthorized(identity: I)(implicit request: RequestHeader, messages: Messages): Future[Boolean]
 }
 
 /**
@@ -59,8 +61,8 @@ object Authorization {
      * @return The authorization.
      */
     def unary_! : Authorization[I] = new Authorization[I] {
-      def isAuthorized(identity: I)(implicit request: RequestHeader, messages: Messages): Boolean = {
-        !self.isAuthorized(identity)
+      def isAuthorized(identity: I)(implicit request: RequestHeader, messages: Messages): Future[Boolean] = {
+        self.isAuthorized(identity).map(x => !x)
       }
     }
 
@@ -71,8 +73,13 @@ object Authorization {
      * @return The authorization.
      */
     def &&(authorization: Authorization[I]): Authorization[I] = new Authorization[I] {
-      def isAuthorized(identity: I)(implicit request: RequestHeader, messages: Messages): Boolean = {
-        self.isAuthorized(identity) && authorization.isAuthorized(identity)
+      def isAuthorized(identity: I)(implicit request: RequestHeader, messages: Messages): Future[Boolean] = {
+        val leftF = self.isAuthorized(identity)
+        val rightF = authorization.isAuthorized(identity)
+        for {
+          left <- leftF
+          right <- rightF
+        } yield left && right
       }
     }
 
@@ -83,8 +90,13 @@ object Authorization {
      * @return The authorization.
      */
     def ||(authorization: Authorization[I]): Authorization[I] = new Authorization[I] {
-      def isAuthorized(identity: I)(implicit request: RequestHeader, messages: Messages): Boolean = {
-        self.isAuthorized(identity) || authorization.isAuthorized(identity)
+      def isAuthorized(identity: I)(implicit request: RequestHeader, messages: Messages): Future[Boolean] = {
+        val leftF = self.isAuthorized(identity)
+        val rightF = authorization.isAuthorized(identity)
+        for {
+          left <- leftF
+          right <- rightF
+        } yield left || right
       }
     }
   }

--- a/silhouette/test/com/mohiva/play/silhouette/api/SilhouetteSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/api/SilhouetteSpec.scala
@@ -1060,6 +1060,8 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
      * @param messages The messages for the current language.
      * @return True if the user is authorized, false otherwise.
      */
-    def isAuthorized(identity: FakeIdentity)(implicit request: RequestHeader, messages: Messages): Boolean = isAuthorized
+    def isAuthorized(identity: FakeIdentity)(implicit request: RequestHeader, messages: Messages): Future[Boolean] = {
+      Future.successful(isAuthorized)
+    }
   }
 }


### PR DESCRIPTION
isAuthorized method use Futures, so now it is possible to avoid Await when you use a DB (like MongoDb) to know if a user is authorized.