### PR TITLE
Add Tag Manifest for CacheLayer

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/api/util/CacheLayer.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/util/CacheLayer.scala
@@ -31,7 +31,7 @@ trait CacheLayer {
    * @tparam T The type of the object to return.
    * @return The found value or None if no value could be found.
    */
-  def find[T: ClassTag](key: String): Future[Option[T]]
+  def find[T: ClassTag: Manifest](key: String): Future[Option[T]]
 
   /**
    * Save a value in cache.

--- a/silhouette/app/com/mohiva/play/silhouette/impl/daos/CacheAuthenticatorDAO.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/daos/CacheAuthenticatorDAO.scala
@@ -28,7 +28,7 @@ import scala.reflect.ClassTag
  * @param cacheLayer The cache layer implementation.
  * @tparam T The type of the authenticator to store.
  */
-class CacheAuthenticatorDAO[T <: StorableAuthenticator: ClassTag](cacheLayer: CacheLayer) extends AuthenticatorDAO[T] {
+class CacheAuthenticatorDAO[T <: StorableAuthenticator: ClassTag: Manifest](cacheLayer: CacheLayer) extends AuthenticatorDAO[T] {
 
   /**
    * Finds the authenticator for the given ID.

--- a/silhouette/app/com/mohiva/play/silhouette/impl/util/PlayCacheLayer.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/util/PlayCacheLayer.scala
@@ -51,7 +51,7 @@ class PlayCacheLayer @Inject() (cacheApi: CacheApi) extends CacheLayer {
    * @tparam T The type of the object to return.
    * @return The found value or None if no value could be found.
    */
-  def find[T: ClassTag](key: String): Future[Option[T]] = Future.successful(cacheApi.get[T](key))
+  def find[T: ClassTag: Manifest](key: String): Future[Option[T]] = Future.successful(cacheApi.get[T](key))
 
   /**
    * Remove a value from the cache.


### PR DESCRIPTION
As is said in #346 ,  I wish to manage the session myself and I can avoid the sessions' lost when I restart the server.

Another solution is configure the `JWTAuthenticatorService` and use a customized `CacheLayer` implementation.

Store the sessions into redis needs to serialize&unzerialize the value between T and String. Unzerialization need to get Manifest information.

I wish this pull request will be approved and someone like me may implement the `CacheLayer` more grace.



