### PR TITLE
Allow to override the provider and authentication config locally

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ resolvers += "Sonatype snapshots" at "https://oss.sonatype.org/content/repositor
 
 resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.0-RC1")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.0-RC5")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.1")
 

--- a/silhouette/app/com/mohiva/play/silhouette/api/services/AuthenticatorService.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/services/AuthenticatorService.scala
@@ -83,6 +83,31 @@ object AuthenticatorResult {
 trait AuthenticatorService[T <: Authenticator] {
 
   /**
+   * The type of the concrete implementation of this abstract type.
+   */
+  type Self <: AuthenticatorService[T]
+
+  /**
+   * The type of the settings.
+   */
+  type Settings
+
+  /**
+   * Gets the authenticator settings.
+   *
+   * @return The authenticator settings.
+   */
+  def settings: Settings
+
+  /**
+   * Gets an authenticator service initialized with a new settings object.
+   *
+   * @param f A function which gets the settings passed and returns different settings.
+   * @return An instance of the authenticator service initialized with new settings.
+   */
+  def withSettings(f: Settings => Settings): Self
+
+  /**
    * Creates a new authenticator for the specified login info.
    *
    * @param loginInfo The login info for which the authenticator should be created.
@@ -165,6 +190,18 @@ trait AuthenticatorService[T <: Authenticator] {
   def update(authenticator: T, result: Result)(implicit request: RequestHeader): Future[AuthenticatorResult]
 
   /**
+   * Renews the expiration of an authenticator without embedding it into the result.
+   *
+   * Based on the implementation, the renew method should revoke the given authenticator first, before
+   * creating a new one. If the authenticator was updated, then the updated artifacts should be returned.
+   *
+   * @param authenticator The authenticator to renew.
+   * @param request The request header.
+   * @return The serialized expression of the authenticator.
+   */
+  def renew(authenticator: T)(implicit request: RequestHeader): Future[T#Value]
+
+  /**
    * Renews the expiration of an authenticator.
    *
    * Based on the implementation, the renew method should revoke the given authenticator first, before
@@ -177,18 +214,6 @@ trait AuthenticatorService[T <: Authenticator] {
    * @return The original or a manipulated result.
    */
   def renew(authenticator: T, result: Result)(implicit request: RequestHeader): Future[AuthenticatorResult]
-
-  /**
-   * Renews the expiration of an authenticator without embedding it into the result.
-   *
-   * Based on the implementation, the renew method should revoke the given authenticator first, before
-   * creating a new one. If the authenticator was updated, then the updated artifacts should be returned.
-   *
-   * @param authenticator The authenticator to renew.
-   * @param request The request header.
-   * @return The serialized expression of the authenticator.
-   */
-  def renew(authenticator: T)(implicit request: RequestHeader): Future[T#Value]
 
   /**
    * Manipulates the response and removes authenticator specific artifacts before sending it to the client.

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticator.scala
@@ -49,13 +49,38 @@ case class DummyAuthenticator(loginInfo: LoginInfo) extends Authenticator {
 class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator] {
 
   /**
+   * The type of this class.
+   */
+  type Self = DummyAuthenticatorService
+
+  /**
+   * The type of the settings.
+   */
+  type Settings = Unit
+
+  /**
+   * Gets the authenticator settings.
+   *
+   * @return The authenticator settings.
+   */
+  def settings = ()
+
+  /**
+   * Gets an authenticator service initialized with a new settings object.
+   *
+   * @param f A function which gets the settings passed and returns different settings.
+   * @return An instance of the authenticator service initialized with new settings.
+   */
+  def withSettings(f: Unit => Unit) = new DummyAuthenticatorService()
+
+  /**
    * Creates a new authenticator for the specified login info.
    *
    * @param loginInfo The login info for which the authenticator should be created.
    * @param request The request header.
    * @return An authenticator.
    */
-  def create(loginInfo: LoginInfo)(implicit request: RequestHeader) = {
+  def create(loginInfo: LoginInfo)(implicit request: RequestHeader): Future[DummyAuthenticator] = {
     Future.successful(DummyAuthenticator(loginInfo))
   }
 
@@ -69,7 +94,7 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @param request The request header.
    * @return Always None because .
    */
-  def retrieve(implicit request: RequestHeader) = Future.successful(None)
+  def retrieve(implicit request: RequestHeader): Future[Option[DummyAuthenticator]] = Future.successful(None)
 
   /**
    * Returns noting because this authenticator doesn't have a serialized representation.
@@ -78,7 +103,7 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @param request The request header.
    * @return The serialized authenticator value.
    */
-  def init(authenticator: DummyAuthenticator)(implicit request: RequestHeader) = Future.successful(())
+  def init(authenticator: DummyAuthenticator)(implicit request: RequestHeader): Future[Unit] = Future.successful(())
 
   /**
    * Returns the original result, because we needn't add the authenticator to the result.
@@ -88,7 +113,7 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @param request The request header.
    * @return The manipulated result.
    */
-  def embed(value: Unit, result: Result)(implicit request: RequestHeader) = {
+  def embed(value: Unit, result: Result)(implicit request: RequestHeader): Future[AuthenticatorResult] = {
     Future.successful(AuthenticatorResult(result))
   }
 
@@ -99,7 +124,7 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @param request The request header.
    * @return The manipulated request header.
    */
-  def embed(value: Unit, request: RequestHeader) = request
+  def embed(value: Unit, request: RequestHeader): RequestHeader = request
 
   /**
    * @inheritdoc
@@ -107,7 +132,7 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @param authenticator The authenticator to touch.
    * @return The touched authenticator on the left or the untouched authenticator on the right.
    */
-  def touch(authenticator: DummyAuthenticator) = Right(authenticator)
+  def touch(authenticator: DummyAuthenticator): Either[DummyAuthenticator, DummyAuthenticator] = Right(authenticator)
 
   /**
    * Returns the original request, because we needn't update the authenticator in the result.
@@ -117,7 +142,10 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  def update(authenticator: DummyAuthenticator, result: Result)(implicit request: RequestHeader) = {
+  def update(
+    authenticator: DummyAuthenticator,
+    result: Result)(implicit request: RequestHeader): Future[AuthenticatorResult] = {
+
     Future.successful(AuthenticatorResult(result))
   }
 
@@ -128,7 +156,7 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @param request The request header.
    * @return The serialized expression of the authenticator.
    */
-  def renew(authenticator: DummyAuthenticator)(implicit request: RequestHeader) = Future.successful(())
+  def renew(authenticator: DummyAuthenticator)(implicit request: RequestHeader): Future[Unit] = Future.successful(())
 
   /**
    * Returns the original request, because we needn't renew the authenticator in the result.
@@ -138,7 +166,10 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  def renew(authenticator: DummyAuthenticator, result: Result)(implicit request: RequestHeader) = {
+  def renew(
+    authenticator: DummyAuthenticator,
+    result: Result)(implicit request: RequestHeader): Future[AuthenticatorResult] = {
+
     Future.successful(AuthenticatorResult(result))
   }
 
@@ -149,7 +180,10 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @param request The request header.
    * @return The manipulated result.
    */
-  def discard(authenticator: DummyAuthenticator, result: Result)(implicit request: RequestHeader) = {
+  def discard(
+    authenticator: DummyAuthenticator,
+    result: Result)(implicit request: RequestHeader): Future[AuthenticatorResult] = {
+
     Future.successful(AuthenticatorResult(result))
   }
 }

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth1Provider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth1Provider.scala
@@ -30,19 +30,9 @@ import play.api.mvc._
 import scala.concurrent.Future
 
 /**
- * Base class for all OAuth1 providers.
- *
- * @param httpLayer The HTTP layer implementation.
- * @param service The OAuth1 service implementation.
- * @param tokenSecretProvider The OAuth1 token secret provider implementation.
- * @param settings The OAuth1 provider settings.
+ * Base implementation for all OAuth1 providers.
  */
-abstract class OAuth1Provider(
-  httpLayer: HTTPLayer,
-  service: OAuth1Service,
-  tokenSecretProvider: OAuth1TokenSecretProvider,
-  val settings: OAuth1Settings)
-  extends SocialProvider with Logger {
+trait OAuth1Provider extends SocialProvider with Logger {
 
   /**
    * Check if services uses 1.0a specification because it address the session fixation attack identified
@@ -68,6 +58,21 @@ abstract class OAuth1Provider(
    * The settings type.
    */
   type Settings = OAuth1Settings
+
+  /**
+   * The HTTP layer implementation.
+   */
+  protected val httpLayer: HTTPLayer
+
+  /**
+   * The OAuth1 service implementation.
+   */
+  protected val service: OAuth1Service
+
+  /**
+   * The OAuth1 token secret provider implementation.
+   */
+  protected val tokenSecretProvider: OAuth1TokenSecretProvider
 
   /**
    * Starts the authentication process.

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth2Provider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth2Provider.scala
@@ -71,14 +71,9 @@ object OAuth2Info {
 }
 
 /**
- * Base class for all OAuth2 providers.
- *
- * @param httpLayer The HTTP layer implementation.
- * @param stateProvider The state provider implementation.
- * @param settings The provider settings.
+ * Base implementation for all OAuth2 providers.
  */
-abstract class OAuth2Provider(httpLayer: HTTPLayer, stateProvider: OAuth2StateProvider, val settings: OAuth2Settings)
-  extends SocialProvider with Logger {
+trait OAuth2Provider extends SocialProvider with Logger {
 
   /**
    * The type of the auth info.
@@ -89,6 +84,16 @@ abstract class OAuth2Provider(httpLayer: HTTPLayer, stateProvider: OAuth2StatePr
    * The settings type.
    */
   type Settings = OAuth2Settings
+
+  /**
+   * The HTTP layer implementation.
+   */
+  protected val httpLayer: HTTPLayer
+
+  /**
+   * The state provider implementation.
+   */
+  protected val stateProvider: OAuth2StateProvider
 
   /**
    * A list with headers to send to the API.

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/OpenIDProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/OpenIDProvider.scala
@@ -27,14 +27,9 @@ import play.api.mvc._
 import scala.concurrent.Future
 
 /**
- * Base class for all OpenID providers.
- *
- * @param httpLayer The HTTP layer implementation.
- * @param service The OpenID service implementation.
- * @param settings The OpenID provider settings.
+ * Base implementation for all OpenID providers.
  */
-abstract class OpenIDProvider(httpLayer: HTTPLayer, service: OpenIDService, val settings: OpenIDSettings)
-  extends SocialProvider with Logger {
+trait OpenIDProvider extends SocialProvider with Logger {
 
   /**
    * The type of the auth info.
@@ -45,6 +40,16 @@ abstract class OpenIDProvider(httpLayer: HTTPLayer, service: OpenIDService, val 
    * The settings type.
    */
   type Settings = OpenIDSettings
+
+  /**
+   * The HTTP layer implementation.
+   */
+  protected val httpLayer: HTTPLayer
+
+  /**
+   * The OpenID service implementation.
+   */
+  protected val service: OpenIDService
 
   /**
    * Starts the authentication process.

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/SocialProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/SocialProvider.scala
@@ -33,6 +33,11 @@ import scala.reflect.ClassTag
 trait SocialProvider extends Provider with SocialProfileBuilder {
 
   /**
+   * The type of the concrete implementation of this abstract type.
+   */
+  type Self <: SocialProvider
+
+  /**
    * The type of the auth info.
    */
   type A <: AuthInfo
@@ -48,6 +53,14 @@ trait SocialProvider extends Provider with SocialProfileBuilder {
    * @return The provider settings.
    */
   def settings: Settings
+
+  /**
+   * Gets a provider initialized with a new settings object.
+   *
+   * @param f A function which gets the settings passed and returns different settings.
+   * @return An instance of the provider initialized with new settings.
+   */
+  def withSettings(f: Settings => Settings): Self
 
   /**
    * Authenticates the user and returns the auth information.
@@ -118,6 +131,16 @@ case class SocialProviderRegistry(providers: Seq[SocialProvider]) {
    * @return Some social provider or None if no provider for the given ID could be found.
    */
   def get(id: String): Option[SocialProvider] = providers.find(_.id == id)
+
+  /**
+   * Gets a list of providers that match a certain type.
+   *
+   * @tparam T The type of the provider.
+   * @return A list of providers that match a certain type.
+   */
+  def getSeq[T: ClassTag]: Seq[T] = {
+    providers.filter(p => TypeUtils.isInstance(p, implicitly[ClassTag[T]].runtimeClass)).map(_.asInstanceOf[T])
+  }
 }
 
 /**

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/openid/SteamProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/openid/SteamProvider.scala
@@ -23,16 +23,11 @@ import com.mohiva.play.silhouette.impl.providers.openid.SteamProvider._
 import scala.concurrent.Future
 
 /**
- * A Steam OpenID Provider.
- *
- * @param httpLayer The HTTP layer implementation.
- * @param service The OpenID service implementation.
- * @param settings The OpenID provider settings.
+ * Base Steam OpenID Provider.
  *
  * @see https://steamcommunity.com/dev
  */
-abstract class SteamProvider(httpLayer: HTTPLayer, service: OpenIDService, settings: OpenIDSettings)
-  extends OpenIDProvider(httpLayer, service, settings) {
+trait BaseSteamProvider extends OpenIDProvider {
 
   /**
    * The content type to parse a profile from.
@@ -79,15 +74,35 @@ class SteamProfileParser extends SocialProfileParser[OpenIDInfo, CommonSocialPro
 }
 
 /**
- * The profile builder for the common social profile.
+ * The Steam OAuth2 Provider.
+ *
+ * @param httpLayer The HTTP layer implementation.
+ * @param service The OpenID service implementation.
+ * @param settings The OpenID provider settings.
  */
-trait SteamProfileBuilder extends CommonSocialProfileBuilder {
-  self: SteamProvider =>
+class SteamProvider(
+  protected val httpLayer: HTTPLayer,
+  protected val service: OpenIDService,
+  val settings: OpenIDSettings)
+  extends BaseSteamProvider with CommonSocialProfileBuilder {
+
+  /**
+   * The type of this class.
+   */
+  type Self = SteamProvider
 
   /**
    * The profile parser implementation.
    */
   val profileParser = new SteamProfileParser
+
+  /**
+   * Gets a provider initialized with a new settings object.
+   *
+   * @param f A function which gets the settings passed and returns different settings.
+   * @return An instance of the provider initialized with new settings.
+   */
+  def withSettings(f: (Settings) => Settings) = new SteamProvider(httpLayer, service, f(settings))
 }
 
 /**
@@ -99,16 +114,4 @@ object SteamProvider {
    * The Steam constants.
    */
   val ID = "steam"
-
-  /**
-   * Creates an instance of the provider.
-   *
-   * @param httpLayer The HTTP layer implementation.
-   * @param service The OpenID service implementation.
-   * @param settings The OpenID provider settings.
-   * @return An instance of this provider.
-   */
-  def apply(httpLayer: HTTPLayer, service: OpenIDService, settings: OpenIDSettings) = {
-    new SteamProvider(httpLayer, service, settings) with SteamProfileBuilder
-  }
 }

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/openid/YahooProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/openid/YahooProvider.scala
@@ -23,16 +23,11 @@ import com.mohiva.play.silhouette.impl.providers.openid.YahooProvider._
 import scala.concurrent.Future
 
 /**
- * A Yahoo OpenID Provider.
- *
- * @param httpLayer The HTTP layer implementation.
- * @param service The OpenID service implementation.
- * @param settings The OpenID provider settings.
+ * Base Yahoo OpenID Provider.
  *
  * @see https://developer.yahoo.com/openid/index.html
  */
-abstract class YahooProvider(httpLayer: HTTPLayer, service: OpenIDService, settings: OpenIDSettings)
-  extends OpenIDProvider(httpLayer, service, settings) {
+trait BaseYahooProvider extends OpenIDProvider {
 
   /**
    * The content type to parse a profile from.
@@ -84,15 +79,35 @@ class YahooProfileParser extends SocialProfileParser[OpenIDInfo, CommonSocialPro
 }
 
 /**
- * The profile builder for the common social profile.
+ * The Yahoo OAuth2 Provider.
+ *
+ * @param httpLayer The HTTP layer implementation.
+ * @param service The OpenID service implementation.
+ * @param settings The OpenID provider settings.
  */
-trait YahooProfileBuilder extends CommonSocialProfileBuilder {
-  self: YahooProvider =>
+class YahooProvider(
+  protected val httpLayer: HTTPLayer,
+  protected val service: OpenIDService,
+  val settings: OpenIDSettings)
+  extends BaseYahooProvider with CommonSocialProfileBuilder {
+
+  /**
+   * The type of this class.
+   */
+  type Self = YahooProvider
 
   /**
    * The profile parser implementation.
    */
   val profileParser = new YahooProfileParser
+
+  /**
+   * Gets a provider initialized with a new settings object.
+   *
+   * @param f A function which gets the settings passed and returns different settings.
+   * @return An instance of the provider initialized with new settings.
+   */
+  def withSettings(f: (Settings) => Settings) = new YahooProvider(httpLayer, service, f(settings))
 }
 
 /**
@@ -104,16 +119,4 @@ object YahooProvider {
    * The Yahoo constants.
    */
   val ID = "yahoo"
-
-  /**
-   * Creates an instance of the provider.
-   *
-   * @param httpLayer The HTTP layer implementation.
-   * @param service The OpenID service implementation.
-   * @param settings The OpenID provider settings.
-   * @return An instance of this provider.
-   */
-  def apply(httpLayer: HTTPLayer, service: OpenIDService, settings: OpenIDSettings) = {
-    new YahooProvider(httpLayer, service, settings) with YahooProfileBuilder
-  }
 }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/BearerTokenAuthenticatorSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/BearerTokenAuthenticatorSpec.scala
@@ -53,6 +53,16 @@ class BearerTokenAuthenticatorSpec extends PlaySpecification with Mockito {
     }
   }
 
+  "The `withSettings` method of the service" should {
+    "create a new instance with customized settings" in new Context {
+      val s = service.withSettings { s =>
+        s.copy("new-header-name")
+      }
+
+      s.settings.headerName must be equalTo "new-header-name"
+    }
+  }
+
   "The `create` method of the service" should {
     "return an authenticator with the generated ID" in new Context {
       implicit val request = FakeRequest()

--- a/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticatorSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticatorSpec.scala
@@ -22,8 +22,6 @@ import org.specs2.specification.Scope
 import play.api.mvc.Results
 import play.api.test.{ FakeRequest, PlaySpecification, WithApplication }
 
-import scala.concurrent.Future
-
 /**
  * Test case for the [[com.mohiva.play.silhouette.impl.authenticators.DummyAuthenticator]].
  */
@@ -32,6 +30,12 @@ class DummyAuthenticatorSpec extends PlaySpecification with Mockito {
   "The `isValid` method of the authenticator" should {
     "return true" in new Context {
       authenticator.isValid must beTrue
+    }
+  }
+
+  "The `withSettings` method of the service" should {
+    "create a new instance with customized settings" in new Context {
+      service.withSettings(identity) must beAnInstanceOf[DummyAuthenticatorService]
     }
   }
 

--- a/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/JWTAuthenticatorSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/JWTAuthenticatorSpec.scala
@@ -197,6 +197,16 @@ class JWTAuthenticatorSpec extends PlaySpecification with Mockito with JsonMatch
     }
   }
 
+  "The `withSettings` method of the service" should {
+    "create a new instance with customized settings" in new Context {
+      val s = service(None).withSettings { s =>
+        s.copy("new-header-name")
+      }
+
+      s.settings.headerName must be equalTo "new-header-name"
+    }
+  }
+
   "The `create` method of the service" should {
     "return an authenticator with the generated ID" in new Context {
       implicit val request = FakeRequest()

--- a/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticatorSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticatorSpec.scala
@@ -55,6 +55,16 @@ class SessionAuthenticatorSpec extends PlaySpecification with Mockito {
     }
   }
 
+  "The `withSettings` method of the service" should {
+    "create a new instance with customized settings" in new Context {
+      val s = service.withSettings { s =>
+        s.copy("new-session-key")
+      }
+
+      s.settings.sessionKey must be equalTo "new-session-key"
+    }
+  }
+
   "The `create` method of the service" should {
     "return a fingerprinted authenticator" in new Context {
       implicit val request = FakeRequest()

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/SocialProviderRegistrySpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/SocialProviderRegistrySpec.scala
@@ -45,6 +45,14 @@ class SocialProviderRegistrySpec extends PlaySpecification with Mockito {
     }
   }
 
+  "The `getSeq` method" should {
+    "return a list of providers by it's sub type" in new Context {
+      val list = registry.getSeq[OAuth2Provider]
+      list(0).id must be equalTo providers(0).id
+      list(1).id must be equalTo providers(1).id
+    }
+  }
+
   /**
    * The context.
    */

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/LinkedInProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/LinkedInProviderSpec.scala
@@ -31,6 +31,16 @@ import scala.concurrent.Future
  */
 class LinkedInProviderSpec extends OAuth1ProviderSpec {
 
+  "The `withSettings` method" should {
+    "create a new instance with customized settings" in new WithApplication with Context {
+      val s = provider.withSettings { s =>
+        s.copy("new-request-token-url")
+      }
+
+      s.settings.requestTokenURL must be equalTo "new-request-token-url"
+    }
+  }
+
   "The `retrieveProfile` method" should {
     "fail with ProfileRetrievalException if API returns error" in new WithApplication with Context {
       val requestHolder = mock[WSRequest]
@@ -112,6 +122,6 @@ class LinkedInProviderSpec extends OAuth1ProviderSpec {
     /**
      * The provider to test.
      */
-    lazy val provider = LinkedInProvider(httpLayer, oAuthService, oAuthTokenSecretProvider, oAuthSettings)
+    lazy val provider = new LinkedInProvider(httpLayer, oAuthService, oAuthTokenSecretProvider, oAuthSettings)
   }
 }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/TwitterProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/TwitterProviderSpec.scala
@@ -31,6 +31,16 @@ import scala.concurrent.Future
  */
 class TwitterProviderSpec extends OAuth1ProviderSpec {
 
+  "The `withSettings` method" should {
+    "create a new instance with customized settings" in new WithApplication with Context {
+      val s = provider.withSettings { s =>
+        s.copy("new-request-token-url")
+      }
+
+      s.settings.requestTokenURL must be equalTo "new-request-token-url"
+    }
+  }
+
   "The `retrieveProfile` method" should {
     "fail with ProfileRetrievalException if API returns error" in new WithApplication with Context {
       val requestHolder = mock[WSRequest]
@@ -106,6 +116,6 @@ class TwitterProviderSpec extends OAuth1ProviderSpec {
     /**
      * The provider to test.
      */
-    lazy val provider = TwitterProvider(httpLayer, oAuthService, oAuthTokenSecretProvider, oAuthSettings)
+    lazy val provider = new TwitterProvider(httpLayer, oAuthService, oAuthTokenSecretProvider, oAuthSettings)
   }
 }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/XingProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/XingProviderSpec.scala
@@ -31,6 +31,16 @@ import scala.concurrent.Future
  */
 class XingProviderSpec extends OAuth1ProviderSpec {
 
+  "The `withSettings` method" should {
+    "create a new instance with customized settings" in new WithApplication with Context {
+      val s = provider.withSettings { s =>
+        s.copy("new-request-token-url")
+      }
+
+      s.settings.requestTokenURL must be equalTo "new-request-token-url"
+    }
+  }
+
   "The `retrieveProfile` method" should {
     "fail with ProfileRetrievalException if API returns error" in new WithApplication with Context {
       val requestHolder = mock[WSRequest]
@@ -109,6 +119,6 @@ class XingProviderSpec extends OAuth1ProviderSpec {
     /**
      * The provider to test.
      */
-    lazy val provider = XingProvider(httpLayer, oAuthService, oAuthTokenSecretProvider, oAuthSettings)
+    lazy val provider = new XingProvider(httpLayer, oAuthService, oAuthTokenSecretProvider, oAuthSettings)
   }
 }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/ClefProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/ClefProviderSpec.scala
@@ -33,6 +33,16 @@ import scala.concurrent.Future
  */
 class ClefProviderSpec extends OAuth2ProviderSpec {
 
+  "The `withSettings` method" should {
+    "create a new instance with customized settings" in new WithApplication with Context {
+      val s = provider.withSettings { s =>
+        s.copy(accessTokenURL = "new-access-token-url")
+      }
+
+      s.settings.accessTokenURL must be equalTo "new-access-token-url"
+    }
+  }
+
   "The `authenticate` method" should {
     "fail with UnexpectedResponseException if OAuth2Info can be build because of an unexpected response" in new WithApplication with Context {
       val requestHolder = mock[WSRequest]
@@ -139,6 +149,6 @@ class ClefProviderSpec extends OAuth2ProviderSpec {
     /**
      * The provider to test.
      */
-    lazy val provider = ClefProvider(httpLayer, stateProvider, oAuthSettings)
+    lazy val provider = new ClefProvider(httpLayer, stateProvider, oAuthSettings)
   }
 }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/DropboxProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/DropboxProviderSpec.scala
@@ -33,6 +33,16 @@ import scala.concurrent.Future
  */
 class DropboxProviderSpec extends OAuth2ProviderSpec {
 
+  "The `withSettings` method" should {
+    "create a new instance with customized settings" in new WithApplication with Context {
+      val s = provider.withSettings { s =>
+        s.copy(accessTokenURL = "new-access-token-url")
+      }
+
+      s.settings.accessTokenURL must be equalTo "new-access-token-url"
+    }
+  }
+
   "The `authenticate` method" should {
     "fail with UnexpectedResponseException if OAuth2Info can be build because of an unexpected response" in new WithApplication with Context {
       val requestHolder = mock[WSRequest]
@@ -153,6 +163,6 @@ class DropboxProviderSpec extends OAuth2ProviderSpec {
     /**
      * The provider to test.
      */
-    lazy val provider = DropboxProvider(httpLayer, stateProvider, oAuthSettings)
+    lazy val provider = new DropboxProvider(httpLayer, stateProvider, oAuthSettings)
   }
 }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/FacebookProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/FacebookProviderSpec.scala
@@ -32,6 +32,16 @@ import scala.concurrent.Future
  */
 class FacebookProviderSpec extends OAuth2ProviderSpec {
 
+  "The `withSettings` method" should {
+    "create a new instance with customized settings" in new WithApplication with Context {
+      val s = provider.withSettings { s =>
+        s.copy(accessTokenURL = "new-access-token-url")
+      }
+
+      s.settings.accessTokenURL must be equalTo "new-access-token-url"
+    }
+  }
+
   "The `authenticate` method" should {
     "fail with UnexpectedResponseException if OAuth2Info can be build because of an invalid response" in new WithApplication with Context {
       val requestHolder = mock[WSRequest]
@@ -183,6 +193,6 @@ class FacebookProviderSpec extends OAuth2ProviderSpec {
     /**
      * The provider to test.
      */
-    lazy val provider = FacebookProvider(httpLayer, stateProvider, oAuthSettings)
+    lazy val provider = new FacebookProvider(httpLayer, stateProvider, oAuthSettings)
   }
 }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/GitHubProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/GitHubProviderSpec.scala
@@ -34,6 +34,16 @@ import scala.concurrent.Future
  */
 class GitHubProviderSpec extends OAuth2ProviderSpec {
 
+  "The `withSettings` method" should {
+    "create a new instance with customized settings" in new WithApplication with Context {
+      val s = provider.withSettings { s =>
+        s.copy(accessTokenURL = "new-access-token-url")
+      }
+
+      s.settings.accessTokenURL must be equalTo "new-access-token-url"
+    }
+  }
+
   "The `authenticate` method" should {
     "fail with UnexpectedResponseException if OAuth2Info can be build because of an unexpected response" in new WithApplication with Context {
       val requestHolder = mock[WSRequest]
@@ -146,6 +156,6 @@ class GitHubProviderSpec extends OAuth2ProviderSpec {
     /**
      * The provider to test.
      */
-    lazy val provider = GitHubProvider(httpLayer, stateProvider, oAuthSettings)
+    lazy val provider = new GitHubProvider(httpLayer, stateProvider, oAuthSettings)
   }
 }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/GoogleProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/GoogleProviderSpec.scala
@@ -33,6 +33,16 @@ import scala.concurrent.Future
  */
 class GoogleProviderSpec extends OAuth2ProviderSpec {
 
+  "The `withSettings` method" should {
+    "create a new instance with customized settings" in new WithApplication with Context {
+      val s = provider.withSettings { s =>
+        s.copy(accessTokenURL = "new-access-token-url")
+      }
+
+      s.settings.accessTokenURL must be equalTo "new-access-token-url"
+    }
+  }
+
   "The `authenticate` method" should {
     "fail with UnexpectedResponseException if OAuth2Info can be build because of an unexpected response" in new WithApplication with Context {
       val requestHolder = mock[WSRequest]
@@ -167,6 +177,6 @@ class GoogleProviderSpec extends OAuth2ProviderSpec {
     /**
      * The provider to test.
      */
-    lazy val provider = GoogleProvider(httpLayer, stateProvider, oAuthSettings)
+    lazy val provider = new GoogleProvider(httpLayer, stateProvider, oAuthSettings)
   }
 }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/InstagramProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/InstagramProviderSpec.scala
@@ -33,6 +33,16 @@ import scala.concurrent.Future
  */
 class InstagramProviderSpec extends OAuth2ProviderSpec {
 
+  "The `withSettings` method" should {
+    "create a new instance with customized settings" in new WithApplication with Context {
+      val s = provider.withSettings { s =>
+        s.copy(accessTokenURL = "new-access-token-url")
+      }
+
+      s.settings.accessTokenURL must be equalTo "new-access-token-url"
+    }
+  }
+
   "The `authenticate` method" should {
     "fail with UnexpectedResponseException if OAuth2Info can be build because of an unexpected response" in new WithApplication with Context {
       val requestHolder = mock[WSRequest]
@@ -145,6 +155,6 @@ class InstagramProviderSpec extends OAuth2ProviderSpec {
     /**
      * The provider to test.
      */
-    lazy val provider = InstagramProvider(httpLayer, stateProvider, oAuthSettings)
+    lazy val provider = new InstagramProvider(httpLayer, stateProvider, oAuthSettings)
   }
 }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/LinkedInProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/LinkedInProviderSpec.scala
@@ -33,6 +33,16 @@ import scala.concurrent.Future
  */
 class LinkedInProviderSpec extends OAuth2ProviderSpec {
 
+  "The `withSettings` method" should {
+    "create a new instance with customized settings" in new WithApplication with Context {
+      val s = provider.withSettings { s =>
+        s.copy(accessTokenURL = "new-access-token-url")
+      }
+
+      s.settings.accessTokenURL must be equalTo "new-access-token-url"
+    }
+  }
+
   "The `authenticate` method" should {
     "fail with UnexpectedResponseException if OAuth2Info can be build because of an unexpected response" in new WithApplication with Context {
       val requestHolder = mock[WSRequest]
@@ -150,6 +160,6 @@ class LinkedInProviderSpec extends OAuth2ProviderSpec {
     /**
      * The provider to test.
      */
-    lazy val provider = LinkedInProvider(httpLayer, stateProvider, oAuthSettings)
+    lazy val provider = new LinkedInProvider(httpLayer, stateProvider, oAuthSettings)
   }
 }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/VKProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/VKProviderSpec.scala
@@ -33,6 +33,16 @@ import scala.concurrent.Future
  */
 class VKProviderSpec extends OAuth2ProviderSpec {
 
+  "The `withSettings` method" should {
+    "create a new instance with customized settings" in new WithApplication with Context {
+      val s = provider.withSettings { s =>
+        s.copy(accessTokenURL = "new-access-token-url")
+      }
+
+      s.settings.accessTokenURL must be equalTo "new-access-token-url"
+    }
+  }
+
   "The `authenticate` method" should {
     "fail with UnexpectedResponseException if OAuth2Info can be build because of an unexpected response" in new WithApplication with Context {
       val requestHolder = mock[WSRequest]
@@ -165,6 +175,6 @@ class VKProviderSpec extends OAuth2ProviderSpec {
     /**
      * The provider to test.
      */
-    lazy val provider = VKProvider(httpLayer, stateProvider, oAuthSettings)
+    lazy val provider = new VKProvider(httpLayer, stateProvider, oAuthSettings)
   }
 }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/state/CookieStateSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/state/CookieStateSpec.scala
@@ -162,7 +162,8 @@ class CookieStateSpec extends PlaySpecification with Mockito with JsonMatchers {
       cookies(result).get(settings.cookieName) should beSome[Cookie].which { c =>
         c.name must be equalTo settings.cookieName
         c.value must be equalTo state.serialize
-        c.maxAge must beSome(settings.expirationTime)
+        // https://github.com/mohiva/play-silhouette/issues/273
+        c.maxAge must beSome[Int].which(_ <= settings.expirationTime)
         c.path must be equalTo settings.cookiePath
         c.domain must be equalTo settings.cookieDomain
         c.secure must be equalTo settings.secureCookie

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/openid/SteamProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/openid/SteamProviderSpec.scala
@@ -24,6 +24,16 @@ import play.api.test.WithApplication
  */
 class SteamProviderSpec extends OpenIDProviderSpec {
 
+  "The `withSettings` method" should {
+    "create a new instance with customized settings" in new WithApplication with Context {
+      val s = provider.withSettings { s =>
+        s.copy("new-provider-url")
+      }
+
+      s.settings.providerURL must be equalTo "new-provider-url"
+    }
+  }
+
   "The `retrieveProfile` method" should {
     "return the social profile" in new WithApplication with Context {
       profile(provider.retrieveProfile(openIDInfo)) {
@@ -63,6 +73,6 @@ class SteamProviderSpec extends OpenIDProviderSpec {
     /**
      * The provider to test.
      */
-    lazy val provider = SteamProvider(httpLayer, openIDService, openIDSettings)
+    lazy val provider = new SteamProvider(httpLayer, openIDService, openIDSettings)
   }
 }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/openid/YahooProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/openid/YahooProviderSpec.scala
@@ -24,6 +24,16 @@ import play.api.test.WithApplication
  */
 class YahooProviderSpec extends OpenIDProviderSpec {
 
+  "The `withSettings` method" should {
+    "create a new instance with customized settings" in new WithApplication with Context {
+      val s = provider.withSettings { s =>
+        s.copy("new-provider-url")
+      }
+
+      s.settings.providerURL must be equalTo "new-provider-url"
+    }
+  }
+
   "The `retrieveProfile` method" should {
     "return the social profile" in new WithApplication with Context {
       profile(provider.retrieveProfile(openIDInfo)) {
@@ -76,6 +86,6 @@ class YahooProviderSpec extends OpenIDProviderSpec {
     /**
      * The provider to test.
      */
-    lazy val provider = YahooProvider(httpLayer, openIDService, openIDSettings)
+    lazy val provider = new YahooProvider(httpLayer, openIDService, openIDSettings)
   }
 }


### PR DESCRIPTION
This allows to override the config of a provider or authenticator instance:

```scala
provider.withSettings { config =>
  config.copy("new-value")
}.authenticate()
```

This fixes also #296 and it allows to override authenticator related settings to better implement a remember-me functionality.