### PR TITLE
Alter the library methods to propagate an implicit ExecutionContext

### DIFF
--- a/silhouette-testkit/test/com/mohiva/play/silhouette/test/FakesSpec.scala
+++ b/silhouette-testkit/test/com/mohiva/play/silhouette/test/FakesSpec.scala
@@ -21,6 +21,7 @@ import com.mohiva.play.silhouette.api.{ Environment, LoginInfo, Silhouette }
 import com.mohiva.play.silhouette.impl.authenticators._
 import org.specs2.matcher.JsonMatchers
 import play.api.i18n.MessagesApi
+import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.Json
 import play.api.test.{ FakeRequest, PlaySpecification, WithApplication }
 

--- a/silhouette/app/com/mohiva/play/silhouette/api/Authorization.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/Authorization.scala
@@ -21,8 +21,7 @@ package com.mohiva.play.silhouette.api
 
 import play.api.i18n.Messages
 import play.api.mvc.RequestHeader
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{ ExecutionContext, Future }
 
 /**
  * A trait to define Authorization objects that let you hook
@@ -49,28 +48,30 @@ trait Authorization[I <: Identity] {
 object Authorization {
 
   /**
-   * Defines additional methods on an Authorization instance.
+   * Defines additional methods on an `Authorization` instance.
    *
-   * @param self The authorization.
+   * @param self The `Authorization` instance on which the additional methods should be defined.
+   * @param ec The execution context to handle the asynchronous operations.
    */
-  implicit final class RichAuthorization[I <: Identity](self: Authorization[I]) {
+  implicit final class RichAuthorization[I <: Identity](self: Authorization[I])(implicit ec: ExecutionContext) {
 
     /**
-     * Negation (not) operator.
+     * Performs a logical negation on an `Authorization` result.
      *
-     * @return The authorization.
+     * @return An `Authorization` which performs a logical negation on an `Authorization` result.
      */
     def unary_! : Authorization[I] = new Authorization[I] {
-      def isAuthorized(identity: I)(implicit request: RequestHeader, messages: Messages): Future[Boolean] = {
+      def isAuthorized(identity: I)(
+        implicit request: RequestHeader, messages: Messages): Future[Boolean] = {
         self.isAuthorized(identity).map(x => !x)
       }
     }
 
     /**
-     * Conjunction (and) operator.
+     * Performs a logical AND operation with two `Authorization` instances.
      *
-     * @param authorization The authorization to be conjunction.
-     * @return The authorization.
+     * @param authorization The right hand operand.
+     * @return An authorization which performs a logical AND operation with two `Authorization` instances.
      */
     def &&(authorization: Authorization[I]): Authorization[I] = new Authorization[I] {
       def isAuthorized(identity: I)(implicit request: RequestHeader, messages: Messages): Future[Boolean] = {
@@ -84,10 +85,10 @@ object Authorization {
     }
 
     /**
-     * Disjunction (or) operator.
+     * Performs a logical OR operation with two `Authorization` instances.
      *
-     * @param authorization The authorization to be disjunction.
-     * @return The authorization.
+     * @param authorization The right hand operand.
+     * @return An authorization which performs a logical OR operation with two `Authorization` instances.
      */
     def ||(authorization: Authorization[I]): Authorization[I] = new Authorization[I] {
       def isAuthorized(identity: I)(implicit request: RequestHeader, messages: Messages): Future[Boolean] = {

--- a/silhouette/app/com/mohiva/play/silhouette/api/Environment.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/Environment.scala
@@ -16,11 +16,14 @@
 package com.mohiva.play.silhouette.api
 
 import com.mohiva.play.silhouette.api.services.{ AuthenticatorService, IdentityService }
+import com.mohiva.play.silhouette.api.util.ExecutionContextProvider
+
+import scala.concurrent.ExecutionContext
 
 /**
  * The environment needed to instantiate a Silhouette controller.
  */
-trait Environment[I <: Identity, T <: Authenticator] {
+trait Environment[I <: Identity, T <: Authenticator] extends ExecutionContextProvider {
 
   /**
    * Gets the identity service implementation.
@@ -59,10 +62,11 @@ object Environment {
     identityServiceImpl: IdentityService[I],
     authenticatorServiceImpl: AuthenticatorService[T],
     requestProvidersImpl: Seq[RequestProvider],
-    eventBusImpl: EventBus) = new Environment[I, T] {
+    eventBusImpl: EventBus)(implicit ec: ExecutionContext) = new Environment[I, T] {
     val identityService = identityServiceImpl
     val authenticatorService = authenticatorServiceImpl
     val requestProviders = requestProvidersImpl
     val eventBus = eventBusImpl
+    val executionContext = ec
   }
 }

--- a/silhouette/app/com/mohiva/play/silhouette/api/services/AuthenticatorService.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/services/AuthenticatorService.scala
@@ -19,6 +19,7 @@
  */
 package com.mohiva.play.silhouette.api.services
 
+import com.mohiva.play.silhouette.api.util.ExecutionContextProvider
 import com.mohiva.play.silhouette.api.{ Authenticator, LoginInfo }
 import play.api.libs.iteratee.Enumerator
 import play.api.mvc._
@@ -80,7 +81,7 @@ object AuthenticatorResult {
  *
  * @tparam T The type of the authenticator this service is responsible for.
  */
-trait AuthenticatorService[T <: Authenticator] {
+trait AuthenticatorService[T <: Authenticator] extends ExecutionContextProvider {
 
   /**
    * The type of the concrete implementation of this abstract type.

--- a/silhouette/app/com/mohiva/play/silhouette/api/util/ExecutionContextProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/util/ExecutionContextProvider.scala
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mohiva.play.silhouette.api.util
+
+import scala.concurrent.ExecutionContext
+
+/**
+ * A trait that can be mixed in to provide an execution context.
+ */
+trait ExecutionContextProvider {
+
+  /**
+   * The execution context to handle the asynchronous operations.
+   */
+  implicit val executionContext: ExecutionContext
+}

--- a/silhouette/app/com/mohiva/play/silhouette/api/util/HTTPLayer.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/util/HTTPLayer.scala
@@ -18,15 +18,17 @@ package com.mohiva.play.silhouette.api.util
 import play.api.Play.current
 import play.api.libs.ws._
 
+import scala.concurrent.ExecutionContext
+
 /**
  * A trait which provides a mockable implementation for the HTTP layer.
  */
-trait HTTPLayer {
+trait HTTPLayer extends ExecutionContextProvider {
 
   /**
    * Prepare a new request. You can then construct it by chaining calls.
    *
-   * @param url the URL to request
+   * @param url The URL to request.
    */
   def url(url: String): WSRequest
 }
@@ -36,13 +38,15 @@ trait HTTPLayer {
  *
  * It makes no sense to move the HTTPLayer implementation to the contrib package, because the complete
  * Silhouette module is bound to Play's HTTP implementation. So this layer exists only for mocking purpose.
+ *
+ * @param executionContext The execution context to handle the asynchronous operations.
  */
-class PlayHTTPLayer extends HTTPLayer {
+class PlayHTTPLayer(implicit val executionContext: ExecutionContext) extends HTTPLayer {
 
   /**
    * Prepare a new request. You can then construct it by chaining calls.
    *
-   * @param url the URL to request
+   * @param url The URL to request.
    */
   def url(url: String): WSRequest = WS.url(url)
 }

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticator.scala
@@ -19,7 +19,7 @@ import com.mohiva.play.silhouette.api.services.{ AuthenticatorResult, Authentica
 import com.mohiva.play.silhouette.api.{ Authenticator, LoginInfo }
 import play.api.mvc.{ RequestHeader, Result }
 
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 
 /**
  * An authenticator that can be used if a client doesn't need an authenticator to
@@ -45,8 +45,11 @@ case class DummyAuthenticator(loginInfo: LoginInfo) extends Authenticator {
 
 /**
  * The service that handles the dummy token authenticator.
+ *
+ * @param executionContext The execution context to handle the asynchronous operations.
  */
-class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator] {
+class DummyAuthenticatorService(implicit val executionContext: ExecutionContext)
+  extends AuthenticatorService[DummyAuthenticator] {
 
   /**
    * The type of this class.
@@ -94,7 +97,9 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @param request The request header.
    * @return Always None because .
    */
-  override def retrieve(implicit request: RequestHeader): Future[Option[DummyAuthenticator]] = Future.successful(None)
+  override def retrieve(implicit request: RequestHeader): Future[Option[DummyAuthenticator]] = {
+    Future.successful(None)
+  }
 
   /**
    * Returns noting because this authenticator doesn't have a serialized representation.
@@ -103,7 +108,9 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @param request The request header.
    * @return The serialized authenticator value.
    */
-  override def init(authenticator: DummyAuthenticator)(implicit request: RequestHeader): Future[Unit] = Future.successful(())
+  override def init(authenticator: DummyAuthenticator)(implicit request: RequestHeader): Future[Unit] = {
+    Future.successful(())
+  }
 
   /**
    * Returns the original result, because we needn't add the authenticator to the result.
@@ -132,7 +139,9 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @param authenticator The authenticator to touch.
    * @return The touched authenticator on the left or the untouched authenticator on the right.
    */
-  override def touch(authenticator: DummyAuthenticator): Either[DummyAuthenticator, DummyAuthenticator] = Right(authenticator)
+  override def touch(authenticator: DummyAuthenticator): Either[DummyAuthenticator, DummyAuthenticator] = {
+    Right(authenticator)
+  }
 
   /**
    * Returns the original request, because we needn't update the authenticator in the result.
@@ -142,9 +151,8 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  override def update(
-    authenticator: DummyAuthenticator,
-    result: Result)(implicit request: RequestHeader): Future[AuthenticatorResult] = {
+  override def update(authenticator: DummyAuthenticator, result: Result)(
+    implicit request: RequestHeader): Future[AuthenticatorResult] = {
 
     Future.successful(AuthenticatorResult(result))
   }
@@ -156,7 +164,9 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @param request The request header.
    * @return The serialized expression of the authenticator.
    */
-  override def renew(authenticator: DummyAuthenticator)(implicit request: RequestHeader): Future[Unit] = Future.successful(())
+  override def renew(authenticator: DummyAuthenticator)(implicit request: RequestHeader): Future[Unit] = {
+    Future.successful(())
+  }
 
   /**
    * Returns the original request, because we needn't renew the authenticator in the result.
@@ -166,9 +176,8 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @param request The request header.
    * @return The original or a manipulated result.
    */
-  override def renew(
-    authenticator: DummyAuthenticator,
-    result: Result)(implicit request: RequestHeader): Future[AuthenticatorResult] = {
+  override def renew(authenticator: DummyAuthenticator, result: Result)(
+    implicit request: RequestHeader): Future[AuthenticatorResult] = {
 
     Future.successful(AuthenticatorResult(result))
   }
@@ -180,9 +189,8 @@ class DummyAuthenticatorService extends AuthenticatorService[DummyAuthenticator]
    * @param request The request header.
    * @return The manipulated result.
    */
-  override def discard(
-    authenticator: DummyAuthenticator,
-    result: Result)(implicit request: RequestHeader): Future[AuthenticatorResult] = {
+  override def discard(authenticator: DummyAuthenticator, result: Result)(
+    implicit request: RequestHeader): Future[AuthenticatorResult] = {
 
     Future.successful(AuthenticatorResult(result))
   }

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth1Provider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth1Provider.scala
@@ -20,14 +20,13 @@
 package com.mohiva.play.silhouette.impl.providers
 
 import com.mohiva.play.silhouette.api._
-import com.mohiva.play.silhouette.api.util.{ ExtractableRequest, HTTPLayer }
+import com.mohiva.play.silhouette.api.util.ExtractableRequest
 import com.mohiva.play.silhouette.impl.exceptions.{ AccessDeniedException, UnexpectedResponseException }
 import com.mohiva.play.silhouette.impl.providers.OAuth1Provider._
-import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.ws.WSSignatureCalculator
 import play.api.mvc._
 
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 
 /**
  * Base implementation for all OAuth1 providers.
@@ -58,11 +57,6 @@ trait OAuth1Provider extends SocialProvider with Logger {
    * The settings type.
    */
   type Settings = OAuth1Settings
-
-  /**
-   * The HTTP layer implementation.
-   */
-  protected val httpLayer: HTTPLayer
 
   /**
    * The OAuth1 service implementation.
@@ -151,18 +145,20 @@ trait OAuth1Service {
    * Retrieves the request info and secret.
    *
    * @param callbackURL The URL where the provider should redirect to (usually a URL on the current app).
+   * @param ec The execution context to handle the asynchronous operations.
    * @return A OAuth1Info in case of success, Exception otherwise.
    */
-  def retrieveRequestToken(callbackURL: String): Future[OAuth1Info]
+  def retrieveRequestToken(callbackURL: String)(implicit ec: ExecutionContext): Future[OAuth1Info]
 
   /**
    * Exchange a request info for an access info.
    *
    * @param oAuthInfo The info/secret pair obtained from a previous call.
    * @param verifier A string you got through your user with redirection.
+   * @param ec The execution context to handle the asynchronous operations.
    * @return A OAuth1Info in case of success, Exception otherwise.
    */
-  def retrieveAccessToken(oAuthInfo: OAuth1Info, verifier: String): Future[OAuth1Info]
+  def retrieveAccessToken(oAuthInfo: OAuth1Info, verifier: String)(implicit ec: ExecutionContext): Future[OAuth1Info]
 
   /**
    * The URL to which the user needs to be redirected to grant authorization to your application.
@@ -228,19 +224,21 @@ trait OAuth1TokenSecretProvider {
    *
    * @param info The OAuth info returned from the provider.
    * @param request The current request.
+   * @param ec The execution context to handle the asynchronous operations.
    * @tparam B The type of the request body.
    * @return The build secret.
    */
-  def build[B](info: OAuth1Info)(implicit request: ExtractableRequest[B]): Future[Secret]
+  def build[B](info: OAuth1Info)(implicit request: ExtractableRequest[B], ec: ExecutionContext): Future[Secret]
 
   /**
    * Retrieves the token secret.
    *
    * @param request The current request.
+   * @param ec The execution context to handle the asynchronous operations.
    * @tparam B The type of the request body.
    * @return A secret on success, otherwise an failure.
    */
-  def retrieve[B](implicit request: ExtractableRequest[B]): Future[Secret]
+  def retrieve[B](implicit request: ExtractableRequest[B], ec: ExecutionContext): Future[Secret]
 
   /**
    * Publishes the secret to the client.

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth2Provider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth2Provider.scala
@@ -23,17 +23,16 @@ import java.net.URLEncoder._
 
 import com.mohiva.play.silhouette.api._
 import com.mohiva.play.silhouette.api.exceptions._
-import com.mohiva.play.silhouette.api.util.{ ExtractableRequest, HTTPLayer }
+import com.mohiva.play.silhouette.api.util.ExtractableRequest
 import com.mohiva.play.silhouette.impl.exceptions.{ AccessDeniedException, UnexpectedResponseException }
 import com.mohiva.play.silhouette.impl.providers.OAuth2Provider._
 import com.mohiva.play.silhouette.{ impl, _ }
-import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
 import play.api.libs.ws.WSResponse
 import play.api.mvc._
 
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success, Try }
 
 /**
@@ -84,11 +83,6 @@ trait OAuth2Provider extends SocialProvider with Logger {
    * The settings type.
    */
   type Settings = OAuth2Settings
-
-  /**
-   * The HTTP layer implementation.
-   */
-  protected val httpLayer: HTTPLayer
 
   /**
    * The state provider implementation.
@@ -245,19 +239,21 @@ trait OAuth2StateProvider {
    * Builds the state.
    *
    * @param request The current request.
+   * @param ec The execution context to handle the asynchronous operations.
    * @tparam B The type of the request body.
    * @return The build state.
    */
-  def build[B](implicit request: ExtractableRequest[B]): Future[State]
+  def build[B](implicit request: ExtractableRequest[B], ec: ExecutionContext): Future[State]
 
   /**
    * Validates the provider and the client state.
    *
    * @param request The current request.
+   * @param ec The execution context to handle the asynchronous operations.
    * @tparam B The type of the request body.
    * @return The state on success, otherwise an failure.
    */
-  def validate[B](implicit request: ExtractableRequest[B]): Future[State]
+  def validate[B](implicit request: ExtractableRequest[B], ec: ExecutionContext): Future[State]
 
   /**
    * Publishes the state to the client.

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/OpenIDProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/OpenIDProvider.scala
@@ -18,13 +18,12 @@ package com.mohiva.play.silhouette.impl.providers
 import java.net.URLEncoder
 
 import com.mohiva.play.silhouette.api._
-import com.mohiva.play.silhouette.api.util.{ ExtractableRequest, HTTPLayer }
+import com.mohiva.play.silhouette.api.util.ExtractableRequest
 import com.mohiva.play.silhouette.impl.exceptions.UnexpectedResponseException
 import com.mohiva.play.silhouette.impl.providers.OpenIDProvider._
-import play.api.libs.concurrent.Execution.Implicits._
 import play.api.mvc._
 
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 
 /**
  * Base implementation for all OpenID providers.
@@ -40,11 +39,6 @@ trait OpenIDProvider extends SocialProvider with Logger {
    * The settings type.
    */
   type Settings = OpenIDSettings
-
-  /**
-   * The HTTP layer implementation.
-   */
-  protected val httpLayer: HTTPLayer
 
   /**
    * The OpenID service implementation.
@@ -131,18 +125,20 @@ trait OpenIDService {
    *
    * @param openID The OpenID to use for authentication.
    * @param resolvedCallbackURL The full callback URL to the application after a successful authentication.
+   * @param ec The execution context to handle the asynchronous operations.
    * @return The redirect URL where the user should be redirected to start the OpenID authentication process.
    */
-  def redirectURL(openID: String, resolvedCallbackURL: String): Future[String]
+  def redirectURL(openID: String, resolvedCallbackURL: String)(implicit ec: ExecutionContext): Future[String]
 
   /**
    * From a request corresponding to the callback from the OpenID server, check the identity of the current user.
    *
    * @param request The current request.
+   * @param ec The execution context to handle the asynchronous operations.
    * @tparam B The type of the request body.
    * @return A OpenIDInfo in case of success, Exception otherwise.
    */
-  def verifiedID[B](implicit request: Request[B]): Future[OpenIDInfo]
+  def verifiedID[B](implicit request: Request[B], ec: ExecutionContext): Future[OpenIDInfo]
 }
 
 /**

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/SocialProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/SocialProvider.scala
@@ -16,12 +16,11 @@
 package com.mohiva.play.silhouette.impl.providers
 
 import java.net.URI
-import com.mohiva.play.silhouette.api.util.ExtractableRequest
+import com.mohiva.play.silhouette.api.util.{ HTTPLayer, ExecutionContextProvider, ExtractableRequest }
 import com.mohiva.play.silhouette.api.{ AuthInfo, LoginInfo, Provider }
 import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
 import com.mohiva.play.silhouette.impl.providers.SocialProfileBuilder._
 import org.apache.commons.lang3.reflect.TypeUtils
-import play.api.libs.concurrent.Execution.Implicits._
 import play.api.mvc.{ RequestHeader, Result }
 
 import scala.concurrent.Future
@@ -30,7 +29,7 @@ import scala.reflect.ClassTag
 /**
  * The base interface for all social providers.
  */
-trait SocialProvider extends Provider with SocialProfileBuilder {
+trait SocialProvider extends Provider with SocialProfileBuilder with ExecutionContextProvider {
 
   /**
    * The type of the concrete implementation of this abstract type.
@@ -46,6 +45,16 @@ trait SocialProvider extends Provider with SocialProfileBuilder {
    * The settings type.
    */
   type Settings
+
+  /**
+   * The HTTP layer implementation.
+   */
+  protected val httpLayer: HTTPLayer
+
+  /**
+   * The execution context to handle the asynchronous operations.
+   */
+  override implicit val executionContext = httpLayer.executionContext
 
   /**
    * Gets the provider settings.

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth1/LinkedInProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth1/LinkedInProvider.scala
@@ -24,7 +24,6 @@ import com.mohiva.play.silhouette.api.util.HTTPLayer
 import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
 import com.mohiva.play.silhouette.impl.providers._
 import com.mohiva.play.silhouette.impl.providers.oauth1.LinkedInProvider._
-import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.JsValue
 
 import scala.concurrent.Future

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth1/TwitterProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth1/TwitterProvider.scala
@@ -24,7 +24,6 @@ import com.mohiva.play.silhouette.api.util.HTTPLayer
 import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
 import com.mohiva.play.silhouette.impl.providers._
 import com.mohiva.play.silhouette.impl.providers.oauth1.TwitterProvider._
-import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.JsValue
 
 import scala.concurrent.Future

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth1/XingProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth1/XingProvider.scala
@@ -24,7 +24,6 @@ import com.mohiva.play.silhouette.api.util.HTTPLayer
 import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
 import com.mohiva.play.silhouette.impl.providers._
 import com.mohiva.play.silhouette.impl.providers.oauth1.XingProvider._
-import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.{ JsObject, JsValue }
 
 import scala.concurrent.Future

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth1/services/PlayOAuth1Service.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth1/services/PlayOAuth1Service.scala
@@ -22,11 +22,10 @@ package com.mohiva.play.silhouette.impl.providers.oauth1.services
 import com.mohiva.play.silhouette.api.Logger
 import com.mohiva.play.silhouette.impl.providers.oauth1.services.PlayOAuth1Service._
 import com.mohiva.play.silhouette.impl.providers.{ OAuth1Info, OAuth1Service, OAuth1Settings }
-import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.oauth.{ ConsumerKey, OAuth, RequestToken, ServiceInfo, _ }
 import play.api.libs.ws.WSSignatureCalculator
 
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 
 /**
  * The OAuth1 service implementation which wraps Play Framework's OAuth implementation.
@@ -59,9 +58,10 @@ class PlayOAuth1Service(service: OAuth, settings: OAuth1Settings) extends OAuth1
    * Retrieves the request info and secret.
    *
    * @param callbackURL The URL where the provider should redirect to (usually a URL on the current app).
+   * @param ec The execution context to handle the asynchronous operations.
    * @return A OAuth1Info in case of success, Exception otherwise.
    */
-  override def retrieveRequestToken(callbackURL: String): Future[OAuth1Info] = {
+  override def retrieveRequestToken(callbackURL: String)(implicit ec: ExecutionContext): Future[OAuth1Info] = {
     Future(service.retrieveRequestToken(settings.callbackURL)).map(_.fold(
       e => throw e,
       t => OAuth1Info(t.token, t.secret)))
@@ -72,9 +72,10 @@ class PlayOAuth1Service(service: OAuth, settings: OAuth1Settings) extends OAuth1
    *
    * @param oAuthInfo The info/secret pair obtained from a previous call.
    * @param verifier A string you got through your user, with redirection.
+   * @param ec The execution context to handle the asynchronous operations.
    * @return A OAuth1Info in case of success, Exception otherwise.
    */
-  override def retrieveAccessToken(oAuthInfo: OAuth1Info, verifier: String): Future[OAuth1Info] = {
+  override def retrieveAccessToken(oAuthInfo: OAuth1Info, verifier: String)(implicit ec: ExecutionContext): Future[OAuth1Info] = {
     Future(service.retrieveAccessToken(RequestToken(oAuthInfo.token, oAuthInfo.secret), verifier)).map(_.fold(
       e => throw e,
       t => OAuth1Info(t.token, t.secret)))

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/ClefProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/ClefProvider.scala
@@ -20,7 +20,6 @@ import com.mohiva.play.silhouette.api.util.HTTPLayer
 import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
 import com.mohiva.play.silhouette.impl.providers._
 import com.mohiva.play.silhouette.impl.providers.oauth2.ClefProvider._
-import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.JsValue
 
 import scala.concurrent.Future

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/DropboxProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/DropboxProvider.scala
@@ -21,7 +21,6 @@ import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
 import com.mohiva.play.silhouette.impl.providers._
 import com.mohiva.play.silhouette.impl.providers.oauth2.DropboxProvider._
 import play.api.http.HeaderNames._
-import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.JsValue
 
 import scala.concurrent.Future

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/FacebookProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/FacebookProvider.scala
@@ -25,7 +25,6 @@ import com.mohiva.play.silhouette.impl.exceptions.{ UnexpectedResponseException,
 import com.mohiva.play.silhouette.impl.providers.OAuth2Provider._
 import com.mohiva.play.silhouette.impl.providers._
 import com.mohiva.play.silhouette.impl.providers.oauth2.FacebookProvider._
-import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.{ JsObject, JsValue }
 import play.api.libs.ws.WSResponse
 

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/FoursquareProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/FoursquareProvider.scala
@@ -24,7 +24,6 @@ import com.mohiva.play.silhouette.api.util.HTTPLayer
 import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
 import com.mohiva.play.silhouette.impl.providers._
 import com.mohiva.play.silhouette.impl.providers.oauth2.FoursquareProvider._
-import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.JsValue
 
 import scala.concurrent.Future

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/GitHubProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/GitHubProvider.scala
@@ -25,7 +25,6 @@ import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
 import com.mohiva.play.silhouette.impl.providers._
 import com.mohiva.play.silhouette.impl.providers.oauth2.GitHubProvider._
 import play.api.http.HeaderNames
-import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.JsValue
 
 import scala.concurrent.Future

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/GoogleProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/GoogleProvider.scala
@@ -24,7 +24,6 @@ import com.mohiva.play.silhouette.api.util.HTTPLayer
 import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
 import com.mohiva.play.silhouette.impl.providers._
 import com.mohiva.play.silhouette.impl.providers.oauth2.GoogleProvider._
-import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.{ JsObject, JsValue }
 
 import scala.concurrent.Future

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/InstagramProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/InstagramProvider.scala
@@ -24,7 +24,6 @@ import com.mohiva.play.silhouette.api.util.HTTPLayer
 import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
 import com.mohiva.play.silhouette.impl.providers._
 import com.mohiva.play.silhouette.impl.providers.oauth2.InstagramProvider._
-import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.JsValue
 
 import scala.concurrent.Future

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/LinkedInProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/LinkedInProvider.scala
@@ -24,7 +24,6 @@ import com.mohiva.play.silhouette.api.util.HTTPLayer
 import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
 import com.mohiva.play.silhouette.impl.providers._
 import com.mohiva.play.silhouette.impl.providers.oauth2.LinkedInProvider._
-import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.JsValue
 
 import scala.concurrent.Future

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/VKProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/VKProvider.scala
@@ -25,7 +25,6 @@ import com.mohiva.play.silhouette.impl.exceptions.{ UnexpectedResponseException,
 import com.mohiva.play.silhouette.impl.providers.OAuth2Provider._
 import com.mohiva.play.silhouette.impl.providers._
 import com.mohiva.play.silhouette.impl.providers.oauth2.VKProvider._
-import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
 import play.api.libs.ws.WSResponse

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/state/DummyState.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/state/DummyState.scala
@@ -19,7 +19,7 @@ import com.mohiva.play.silhouette.api.util.ExtractableRequest
 import com.mohiva.play.silhouette.impl.providers.{ OAuth2State, OAuth2StateProvider }
 import play.api.mvc.Result
 
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 
 /**
  * A dummy state which can be used to avoid state validation. This can be useful if the state
@@ -44,19 +44,23 @@ class DummyStateProvider extends OAuth2StateProvider {
    * Builds the state.
    *
    * @param request The request.
+   * @param ec The execution context to handle the asynchronous operations.
    * @tparam B The type of the request body.
    * @return The build state.
    */
-  override def build[B](implicit request: ExtractableRequest[B]): Future[DummyState] = Future.successful(DummyState())
+  override def build[B](implicit request: ExtractableRequest[B], ec: ExecutionContext): Future[DummyState] =
+    Future.successful(DummyState())
 
   /**
    * Returns always a valid state avoid authentication errors.
    *
    * @param request The request.
+   * @param ec The execution context to handle the asynchronous operations.
    * @tparam B The type of the request body.
    * @return Always a valid state avoid authentication errors.
    */
-  override def validate[B](implicit request: ExtractableRequest[B]) = Future.successful(DummyState())
+  override def validate[B](implicit request: ExtractableRequest[B], ec: ExecutionContext) =
+    Future.successful(DummyState())
 
   /**
    * Returns the original result.

--- a/silhouette/app/com/mohiva/play/silhouette/impl/repositories/DelegableAuthInfoRepository.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/repositories/DelegableAuthInfoRepository.scala
@@ -19,9 +19,8 @@ import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
 import com.mohiva.play.silhouette.api.{ AuthInfo, LoginInfo }
 import com.mohiva.play.silhouette.impl.daos.{ AuthInfoDAO, DelegableAuthInfoDAO }
 import com.mohiva.play.silhouette.impl.repositories.DelegableAuthInfoRepository._
-import play.api.libs.concurrent.Execution.Implicits._
 
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 import scala.reflect.ClassTag
 
 /**
@@ -35,8 +34,9 @@ import scala.reflect.ClassTag
  * object.
  *
  * @param daos The auth info DAO implementations.
+ * @param ec The execution context to handle the asynchronous operations.
  */
-class DelegableAuthInfoRepository(daos: DelegableAuthInfoDAO[_]*) extends AuthInfoRepository {
+class DelegableAuthInfoRepository(daos: DelegableAuthInfoDAO[_]*)(implicit ec: ExecutionContext) extends AuthInfoRepository {
 
   /**
    * Finds the auth info which is linked with the specified login info.

--- a/silhouette/app/com/mohiva/play/silhouette/impl/services/GravatarService.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/services/GravatarService.scala
@@ -23,9 +23,8 @@ import java.security.MessageDigest
 
 import com.mohiva.play.silhouette.api.Logger
 import com.mohiva.play.silhouette.api.services.AvatarService
-import com.mohiva.play.silhouette.api.util.HTTPLayer
+import com.mohiva.play.silhouette.api.util.{ ExecutionContextProvider, HTTPLayer }
 import com.mohiva.play.silhouette.impl.services.GravatarService._
-import play.api.libs.concurrent.Execution.Implicits._
 
 import scala.concurrent.Future
 
@@ -34,7 +33,12 @@ import scala.concurrent.Future
  *
  * @param httpLayer The HTTP layer implementation.
  */
-class GravatarService(httpLayer: HTTPLayer) extends AvatarService with Logger {
+class GravatarService(httpLayer: HTTPLayer) extends AvatarService with Logger with ExecutionContextProvider {
+
+  /**
+   * The execution context to handle the asynchronous operations.
+   */
+  override implicit val executionContext = httpLayer.executionContext
 
   /**
    * Retrieves the URL for the given email address.

--- a/silhouette/app/com/mohiva/play/silhouette/impl/util/SecureRandomIDGenerator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/util/SecureRandomIDGenerator.scala
@@ -23,16 +23,16 @@ import java.security.SecureRandom
 
 import com.mohiva.play.silhouette.api.util.IDGenerator
 import play.api.libs.Codecs
-import play.api.libs.concurrent.Execution.Implicits._
 
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 
 /**
  * A generator which uses SecureRandom to generate cryptographically strong IDs.
  *
  * @param idSizeInBytes The size of the ID length in bytes.
+ * @param ec The execution context to handle the asynchronous operations.
  */
-class SecureRandomIDGenerator(idSizeInBytes: Int = 128) extends IDGenerator {
+class SecureRandomIDGenerator(idSizeInBytes: Int = 128)(implicit ec: ExecutionContext) extends IDGenerator {
 
   /**
    * Generates a new ID using SecureRandom.

--- a/silhouette/test/com/mohiva/play/silhouette/api/SilhouetteSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/api/SilhouetteSpec.scala
@@ -30,6 +30,7 @@ import play.api.i18n.{ Lang, Messages, MessagesApi }
 import play.api.inject.Module
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.concurrent.Akka
+import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.Json
 import play.api.mvc.Results._
 import play.api.mvc._
@@ -37,7 +38,6 @@ import play.api.routing.Router
 import play.api.test.{ FakeApplication, FakeRequest, PlaySpecification, WithApplication }
 import play.api.{ Configuration, OptionalSourceMapper }
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.reflect.ClassTag

--- a/silhouette/test/com/mohiva/play/silhouette/api/util/PlayHTTPLayerSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/api/util/PlayHTTPLayerSpec.scala
@@ -1,5 +1,6 @@
 package com.mohiva.play.silhouette.api.util
 
+import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.ws.WSRequest
 import play.api.test._
 

--- a/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/BearerTokenAuthenticatorSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/BearerTokenAuthenticatorSpec.scala
@@ -24,6 +24,7 @@ import com.mohiva.play.silhouette.impl.daos.AuthenticatorDAO
 import org.joda.time.DateTime
 import org.specs2.mock.Mockito
 import org.specs2.specification.Scope
+import play.api.libs.concurrent.Execution.Implicits._
 import play.api.mvc.Results
 import play.api.test.{ FakeRequest, PlaySpecification, WithApplication }
 

--- a/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticatorSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticatorSpec.scala
@@ -25,6 +25,7 @@ import org.joda.time.DateTime
 import org.specs2.matcher.MatchResult
 import org.specs2.mock.Mockito
 import org.specs2.specification.Scope
+import play.api.libs.concurrent.Execution.Implicits._
 import play.api.mvc.{ Cookie, Results }
 import play.api.test.{ FakeRequest, PlaySpecification, WithApplication }
 

--- a/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticatorSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticatorSpec.scala
@@ -19,6 +19,7 @@ import com.mohiva.play.silhouette.api.LoginInfo
 import com.mohiva.play.silhouette.api.services.AuthenticatorResult
 import org.specs2.mock.Mockito
 import org.specs2.specification.Scope
+import play.api.libs.concurrent.Execution.Implicits._
 import play.api.mvc.Results
 import play.api.test.{ FakeRequest, PlaySpecification, WithApplication }
 

--- a/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/JWTAuthenticatorSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/JWTAuthenticatorSpec.scala
@@ -29,6 +29,7 @@ import org.specs2.matcher.JsonMatchers
 import org.specs2.mock.Mockito
 import org.specs2.specification.Scope
 import play.api.libs.Crypto
+import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.{ JsNull, Json }
 import play.api.mvc.Results
 import play.api.test.{ FakeRequest, PlaySpecification, WithApplication }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticatorSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticatorSpec.scala
@@ -25,6 +25,7 @@ import org.joda.time.DateTime
 import org.specs2.mock.Mockito
 import org.specs2.specification.Scope
 import play.api.libs.Crypto
+import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.Json
 import play.api.mvc.{ Result, Results, Session }
 import play.api.test.{ FakeRequest, PlaySpecification, WithApplication }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/BasicAuthProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/BasicAuthProviderSpec.scala
@@ -19,10 +19,11 @@ import com.mohiva.play.silhouette.api.LoginInfo
 import com.mohiva.play.silhouette.api.exceptions._
 import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
 import com.mohiva.play.silhouette.api.util.{ Base64, Credentials, PasswordHasher, PasswordInfo }
-import com.mohiva.play.silhouette.impl.exceptions.{ InvalidPasswordException, IdentityNotFoundException }
+import com.mohiva.play.silhouette.impl.exceptions.{ IdentityNotFoundException, InvalidPasswordException }
 import com.mohiva.play.silhouette.impl.providers.BasicAuthProvider._
 import org.specs2.mock.Mockito
 import org.specs2.specification.Scope
+import play.api.libs.concurrent.Execution.Implicits._
 import play.api.test.{ FakeRequest, PlaySpecification, WithApplication }
 
 import scala.concurrent.Future
@@ -98,6 +99,7 @@ class BasicAuthProviderSpec extends PlaySpecification with Mockito {
       fooHasher.hash(credentials.password) returns passwordInfo
       barHasher.matches(passwordInfo, credentials.password) returns true
       authInfoRepository.find[PasswordInfo](loginInfo) returns Future.successful(Some(passwordInfo))
+      authInfoRepository.update[PasswordInfo](loginInfo, passwordInfo) returns Future.successful(passwordInfo)
 
       await(provider.authenticate(request)) must beSome(loginInfo)
       there was one(authInfoRepository).update(loginInfo, passwordInfo)

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/CredentialsProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/CredentialsProviderSpec.scala
@@ -23,6 +23,7 @@ import com.mohiva.play.silhouette.impl.exceptions.{ IdentityNotFoundException, I
 import com.mohiva.play.silhouette.impl.providers.CredentialsProvider._
 import org.specs2.mock.Mockito
 import org.specs2.specification.Scope
+import play.api.libs.concurrent.Execution.Implicits._
 import play.api.test.{ PlaySpecification, WithApplication }
 
 import scala.concurrent.Future
@@ -83,6 +84,7 @@ class CredentialsProviderSpec extends PlaySpecification with Mockito {
       fooHasher.hash(credentials.password) returns passwordInfo
       barHasher.matches(passwordInfo, credentials.password) returns true
       authInfoRepository.find[PasswordInfo](loginInfo) returns Future.successful(Some(passwordInfo))
+      authInfoRepository.update[PasswordInfo](loginInfo, passwordInfo) returns Future.successful(passwordInfo)
 
       await(provider.authenticate(credentials)) must be equalTo loginInfo
       there was one(authInfoRepository).update(loginInfo, passwordInfo)

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/OAuth1ProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/OAuth1ProviderSpec.scala
@@ -21,7 +21,8 @@ import com.mohiva.play.silhouette.impl.providers.OAuth1Provider._
 import org.specs2.matcher.ThrownExpectations
 import org.specs2.mock.Mockito
 import org.specs2.specification.Scope
-import play.api.mvc.{ Results, Result }
+import play.api.libs.concurrent.Execution.Implicits._
+import play.api.mvc.{ Result, Results }
 import play.api.test.{ FakeRequest, WithApplication }
 import play.mvc.Http.HeaderNames
 
@@ -68,7 +69,7 @@ abstract class OAuth1ProviderSpec extends SocialProviderSpec[OAuth1Info] {
 
       c.oAuthService.retrieveRequestToken(c.oAuthSettings.callbackURL) returns Future.successful(c.oAuthInfo)
       c.oAuthService.redirectUrl(any) returns c.oAuthSettings.authorizationURL
-      c.oAuthTokenSecretProvider.build(any)(any) returns Future.successful(c.oAuthTokenSecret)
+      c.oAuthTokenSecretProvider.build(any)(any, any) returns Future.successful(c.oAuthTokenSecret)
       c.oAuthTokenSecretProvider.publish(any, any)(any) answers { (a, m) =>
         a.asInstanceOf[Array[Any]](0).asInstanceOf[Result]
       }
@@ -97,9 +98,9 @@ abstract class OAuth1ProviderSpec extends SocialProviderSpec[OAuth1Info] {
       req.secure returns secure
       c.oAuthSettings.callbackURL returns callbackURL
 
-      c.oAuthService.retrieveRequestToken(any) returns Future.successful(c.oAuthInfo)
+      c.oAuthService.retrieveRequestToken(any)(any) returns Future.successful(c.oAuthInfo)
       c.oAuthService.redirectUrl(c.oAuthInfo.token) returns c.oAuthSettings.authorizationURL
-      c.oAuthTokenSecretProvider.build(any)(any) returns Future.successful(c.oAuthTokenSecret)
+      c.oAuthTokenSecretProvider.build(any)(any, any) returns Future.successful(c.oAuthTokenSecret)
       c.oAuthTokenSecretProvider.publish(any, any)(any) returns Results.Redirect(c.oAuthSettings.authorizationURL)
 
       await(c.provider.authenticate())
@@ -111,7 +112,7 @@ abstract class OAuth1ProviderSpec extends SocialProviderSpec[OAuth1Info] {
       implicit val req = FakeRequest(GET, "?" + OAuthVerifier + "=my.verifier&" + OAuthToken + "=my.token")
 
       c.oAuthTokenSecret.value returns tokenSecret
-      c.oAuthTokenSecretProvider.retrieve(any) returns Future.successful(c.oAuthTokenSecret)
+      c.oAuthTokenSecretProvider.retrieve(any, any) returns Future.successful(c.oAuthTokenSecret)
       c.oAuthService.retrieveAccessToken(c.oAuthInfo.copy(secret = tokenSecret), "my.verifier") returns Future.failed(new Exception(""))
 
       failed[UnexpectedResponseException](c.provider.authenticate()) {
@@ -124,7 +125,7 @@ abstract class OAuth1ProviderSpec extends SocialProviderSpec[OAuth1Info] {
       implicit val req = FakeRequest(GET, "?" + OAuthVerifier + "=my.verifier&" + OAuthToken + "=my.token")
 
       c.oAuthTokenSecret.value returns tokenSecret
-      c.oAuthTokenSecretProvider.retrieve(any) returns Future.successful(c.oAuthTokenSecret)
+      c.oAuthTokenSecretProvider.retrieve(any, any) returns Future.successful(c.oAuthTokenSecret)
       c.oAuthService.retrieveAccessToken(c.oAuthInfo.copy(secret = tokenSecret), "my.verifier") returns Future.successful(c.oAuthInfo)
 
       authInfo(c.provider.authenticate()) {
@@ -161,7 +162,11 @@ trait OAuth1ProviderSpecContext extends Scope with Mockito with ThrownExpectatio
   /**
    * The HTTP layer mock.
    */
-  lazy val httpLayer: HTTPLayer = mock[HTTPLayer]
+  lazy val httpLayer = {
+    val m = mock[HTTPLayer]
+    m.executionContext returns defaultContext
+    m
+  }
 
   /**
    * A OAuth1 info.

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/custom/FacebookProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/custom/FacebookProviderSpec.scala
@@ -55,7 +55,7 @@ class FacebookProviderSpec extends OAuth2ProviderSpec {
       requestHolder.withHeaders(any) returns requestHolder
       requestHolder.post[Map[String, Seq[String]]](any)(any) returns Future.successful(response)
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
-      stateProvider.validate(any) returns Future.successful(state)
+      stateProvider.validate(any, any) returns Future.successful(state)
 
       failed[UnexpectedResponseException](provider.authenticate()) {
         case e => e.getMessage must equalTo(InvalidInfoFormat.format(provider.id, ""))
@@ -70,7 +70,7 @@ class FacebookProviderSpec extends OAuth2ProviderSpec {
       requestHolder.withHeaders(any) returns requestHolder
       requestHolder.post[Map[String, Seq[String]]](any)(any) returns Future.successful(response)
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
-      stateProvider.validate(any) returns Future.successful(state)
+      stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
         case authInfo => authInfo must be equalTo OAuth2Info(

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/secrets/CookieSecretSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/secrets/CookieSecretSpec.scala
@@ -25,6 +25,7 @@ import org.specs2.matcher.JsonMatchers
 import org.specs2.mock.Mockito
 import org.specs2.specification.Scope
 import play.api.libs.Crypto
+import play.api.libs.concurrent.Execution.Implicits._
 import play.api.mvc.{ Cookie, Results }
 import play.api.test.{ FakeRequest, PlaySpecification, WithApplication }
 

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/services/PlayOAuth1ServiceSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/services/PlayOAuth1ServiceSpec.scala
@@ -19,6 +19,7 @@ import com.mohiva.play.silhouette.impl.providers.{ OAuth1Info, OAuth1Settings }
 import oauth.signpost.exception.{ OAuthException, OAuthMessageSignerException }
 import org.specs2.mock.Mockito
 import org.specs2.specification.Scope
+import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.oauth.{ OAuth, RequestToken }
 import play.api.libs.ws.WSSignatureCalculator
 import play.api.test.PlaySpecification

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/ClefProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/ClefProviderSpec.scala
@@ -52,7 +52,7 @@ class ClefProviderSpec extends OAuth2ProviderSpec {
       requestHolder.withHeaders(any) returns requestHolder
       requestHolder.post[Map[String, Seq[String]]](any)(any) returns Future.successful(response)
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
-      stateProvider.validate(any) returns Future.successful(state)
+      stateProvider.validate(any, any) returns Future.successful(state)
 
       failed[UnexpectedResponseException](provider.authenticate()) {
         case e => e.getMessage must startWith(InvalidInfoFormat.format(provider.id, ""))
@@ -67,7 +67,7 @@ class ClefProviderSpec extends OAuth2ProviderSpec {
       requestHolder.withHeaders(any) returns requestHolder
       requestHolder.post[Map[String, Seq[String]]](any)(any) returns Future.successful(response)
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
-      stateProvider.validate(any) returns Future.successful(state)
+      stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
         case authInfo => authInfo must be equalTo oAuthInfo.as[OAuth2Info]

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/DropboxProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/DropboxProviderSpec.scala
@@ -52,7 +52,7 @@ class DropboxProviderSpec extends OAuth2ProviderSpec {
       requestHolder.withHeaders(any) returns requestHolder
       requestHolder.post[Map[String, Seq[String]]](any)(any) returns Future.successful(response)
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
-      stateProvider.validate(any) returns Future.successful(state)
+      stateProvider.validate(any, any) returns Future.successful(state)
 
       failed[UnexpectedResponseException](provider.authenticate()) {
         case e => e.getMessage must startWith(InvalidInfoFormat.format(provider.id, ""))
@@ -67,7 +67,7 @@ class DropboxProviderSpec extends OAuth2ProviderSpec {
       requestHolder.withHeaders(any) returns requestHolder
       requestHolder.post[Map[String, Seq[String]]](any)(any) returns Future.successful(response)
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
-      stateProvider.validate(any) returns Future.successful(state)
+      stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
         case authInfo => authInfo must be equalTo oAuthInfo.as[OAuth2Info]

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/FacebookProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/FacebookProviderSpec.scala
@@ -51,7 +51,7 @@ class FacebookProviderSpec extends OAuth2ProviderSpec {
       requestHolder.withHeaders(any) returns requestHolder
       requestHolder.post[Map[String, Seq[String]]](any)(any) returns Future.successful(response)
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
-      stateProvider.validate(any) returns Future.successful(state)
+      stateProvider.validate(any, any) returns Future.successful(state)
 
       failed[UnexpectedResponseException](provider.authenticate()) {
         case e => e.getMessage must equalTo(InvalidInfoFormat.format(provider.id, ""))
@@ -66,7 +66,7 @@ class FacebookProviderSpec extends OAuth2ProviderSpec {
       requestHolder.withHeaders(any) returns requestHolder
       requestHolder.post[Map[String, Seq[String]]](any)(any) returns Future.successful(response)
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
-      stateProvider.validate(any) returns Future.successful(state)
+      stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
         case authInfo => authInfo must be equalTo OAuth2Info(
@@ -85,7 +85,7 @@ class FacebookProviderSpec extends OAuth2ProviderSpec {
       requestHolder.withHeaders(any) returns requestHolder
       requestHolder.post[Map[String, Seq[String]]](any)(any) returns Future.successful(response)
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
-      stateProvider.validate(any) returns Future.successful(state)
+      stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
         case authInfo => authInfo must be equalTo OAuth2Info(

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/FoursquareProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/FoursquareProviderSpec.scala
@@ -52,7 +52,7 @@ class FoursquareProviderSpec extends OAuth2ProviderSpec {
       requestHolder.withHeaders(any) returns requestHolder
       requestHolder.post[Map[String, Seq[String]]](any)(any) returns Future.successful(response)
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
-      stateProvider.validate(any) returns Future.successful(state)
+      stateProvider.validate(any, any) returns Future.successful(state)
 
       failed[UnexpectedResponseException](provider.authenticate()) {
         case e => e.getMessage must startWith(InvalidInfoFormat.format(provider.id, ""))
@@ -67,7 +67,7 @@ class FoursquareProviderSpec extends OAuth2ProviderSpec {
       requestHolder.withHeaders(any) returns requestHolder
       requestHolder.post[Map[String, Seq[String]]](any)(any) returns Future.successful(response)
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
-      stateProvider.validate(any) returns Future.successful(state)
+      stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
         case authInfo => authInfo must be equalTo oAuthInfo.as[OAuth2Info]

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/GitHubProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/GitHubProviderSpec.scala
@@ -53,7 +53,7 @@ class GitHubProviderSpec extends OAuth2ProviderSpec {
       requestHolder.withHeaders(HeaderNames.ACCEPT -> "application/json") returns requestHolder
       requestHolder.post[Map[String, Seq[String]]](any)(any) returns Future.successful(response)
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
-      stateProvider.validate(any) returns Future.successful(state)
+      stateProvider.validate(any, any) returns Future.successful(state)
 
       failed[UnexpectedResponseException](provider.authenticate()) {
         case e => e.getMessage must startWith(InvalidInfoFormat.format(provider.id, ""))
@@ -68,7 +68,7 @@ class GitHubProviderSpec extends OAuth2ProviderSpec {
       requestHolder.withHeaders(any) returns requestHolder
       requestHolder.post[Map[String, Seq[String]]](any)(any) returns Future.successful(response)
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
-      stateProvider.validate(any) returns Future.successful(state)
+      stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
         case authInfo => authInfo must be equalTo oAuthInfo.as[OAuth2Info]

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/GoogleProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/GoogleProviderSpec.scala
@@ -52,7 +52,7 @@ class GoogleProviderSpec extends OAuth2ProviderSpec {
       requestHolder.withHeaders(any) returns requestHolder
       requestHolder.post[Map[String, Seq[String]]](any)(any) returns Future.successful(response)
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
-      stateProvider.validate(any) returns Future.successful(state)
+      stateProvider.validate(any, any) returns Future.successful(state)
 
       failed[UnexpectedResponseException](provider.authenticate()) {
         case e => e.getMessage must startWith(InvalidInfoFormat.format(provider.id, ""))
@@ -67,7 +67,7 @@ class GoogleProviderSpec extends OAuth2ProviderSpec {
       requestHolder.withHeaders(any) returns requestHolder
       requestHolder.post[Map[String, Seq[String]]](any)(any) returns Future.successful(response)
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
-      stateProvider.validate(any) returns Future.successful(state)
+      stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
         case authInfo => authInfo must be equalTo oAuthInfo.as[OAuth2Info]

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/InstagramProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/InstagramProviderSpec.scala
@@ -52,7 +52,7 @@ class InstagramProviderSpec extends OAuth2ProviderSpec {
       requestHolder.withHeaders(any) returns requestHolder
       requestHolder.post[Map[String, Seq[String]]](any)(any) returns Future.successful(response)
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
-      stateProvider.validate(any) returns Future.successful(state)
+      stateProvider.validate(any, any) returns Future.successful(state)
 
       failed[UnexpectedResponseException](provider.authenticate()) {
         case e => e.getMessage must startWith(InvalidInfoFormat.format(provider.id, ""))
@@ -67,7 +67,7 @@ class InstagramProviderSpec extends OAuth2ProviderSpec {
       requestHolder.withHeaders(any) returns requestHolder
       requestHolder.post[Map[String, Seq[String]]](any)(any) returns Future.successful(response)
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
-      stateProvider.validate(any) returns Future.successful(state)
+      stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
         case authInfo => authInfo must be equalTo oAuthInfo.as[OAuth2Info]

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/LinkedInProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/LinkedInProviderSpec.scala
@@ -52,7 +52,7 @@ class LinkedInProviderSpec extends OAuth2ProviderSpec {
       requestHolder.withHeaders(any) returns requestHolder
       requestHolder.post[Map[String, Seq[String]]](any)(any) returns Future.successful(response)
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
-      stateProvider.validate(any) returns Future.successful(state)
+      stateProvider.validate(any, any) returns Future.successful(state)
 
       failed[UnexpectedResponseException](provider.authenticate()) {
         case e => e.getMessage must startWith(InvalidInfoFormat.format(provider.id, ""))
@@ -67,7 +67,7 @@ class LinkedInProviderSpec extends OAuth2ProviderSpec {
       requestHolder.withHeaders(any) returns requestHolder
       requestHolder.post[Map[String, Seq[String]]](any)(any) returns Future.successful(response)
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
-      stateProvider.validate(any) returns Future.successful(state)
+      stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
         case authInfo => authInfo must be equalTo oAuthInfo.as[OAuth2Info]

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/VKProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/VKProviderSpec.scala
@@ -52,7 +52,7 @@ class VKProviderSpec extends OAuth2ProviderSpec {
       requestHolder.withHeaders(any) returns requestHolder
       requestHolder.post[Map[String, Seq[String]]](any)(any) returns Future.successful(response)
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
-      stateProvider.validate(any) returns Future.successful(state)
+      stateProvider.validate(any, any) returns Future.successful(state)
 
       failed[UnexpectedResponseException](provider.authenticate()) {
         case e => e.getMessage must startWith(InvalidInfoFormat.format(provider.id, ""))
@@ -67,7 +67,7 @@ class VKProviderSpec extends OAuth2ProviderSpec {
       requestHolder.withHeaders(any) returns requestHolder
       requestHolder.post[Map[String, Seq[String]]](any)(any) returns Future.successful(response)
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
-      stateProvider.validate(any) returns Future.successful(state)
+      stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
         case authInfo => authInfo must be equalTo oAuthInfo.as[OAuth2Info]

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/state/CookieStateSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/state/CookieStateSpec.scala
@@ -23,6 +23,7 @@ import org.joda.time.DateTime
 import org.specs2.matcher.JsonMatchers
 import org.specs2.mock.Mockito
 import org.specs2.specification.Scope
+import play.api.libs.concurrent.Execution.Implicits._
 import play.api.mvc.{ Cookie, Results }
 import play.api.test.{ FakeRequest, PlaySpecification, WithApplication }
 

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/state/DummyStateSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/state/DummyStateSpec.scala
@@ -18,6 +18,7 @@ package com.mohiva.play.silhouette.impl.providers.oauth2.state
 import org.specs2.matcher.JsonMatchers
 import org.specs2.mock.Mockito
 import org.specs2.specification.Scope
+import play.api.libs.concurrent.Execution.Implicits._
 import play.api.mvc.Results
 import play.api.test.{ FakeRequest, PlaySpecification, WithApplication }
 

--- a/silhouette/test/com/mohiva/play/silhouette/impl/services/GravatarServiceSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/services/GravatarServiceSpec.scala
@@ -21,6 +21,7 @@ import org.specs2.mock.Mockito
 import org.specs2.specification.Scope
 import play.api.libs.ws.{ WSRequest, WSResponse }
 import play.api.test.PlaySpecification
+import play.api.libs.concurrent.Execution._
 
 import scala.concurrent.Future
 
@@ -40,6 +41,7 @@ class GravatarServiceSpec extends PlaySpecification with Mockito {
 
       response.status returns 404
       requestHolder.get() returns Future.successful(response)
+      httpLayer.executionContext returns defaultContext
       httpLayer.url(any) returns requestHolder
 
       await(service.retrieveURL(email)) should beNone
@@ -98,7 +100,11 @@ class GravatarServiceSpec extends PlaySpecification with Mockito {
     /**
      * The HTTP layer implementation.
      */
-    val httpLayer = mock[HTTPLayer]
+    val httpLayer = {
+      val m = mock[HTTPLayer]
+      m.executionContext returns defaultContext
+      m
+    }
 
     /**
      * The gravatar service implementation.

--- a/silhouette/test/com/mohiva/play/silhouette/impl/util/SecureRandomIDGeneratorSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/util/SecureRandomIDGeneratorSpec.scala
@@ -15,6 +15,7 @@
  */
 package com.mohiva.play.silhouette.impl.util
 
+import play.api.libs.concurrent.Execution.Implicits._
 import play.api.test.PlaySpecification
 
 /**


### PR DESCRIPTION
For the old discussion please see #342.

I have decided to separate the execution contexts by the relation of the single tasks. Normally you use a special execution context to separate a group of same tasks to let it run on dedicated thread pool. So for Silhouette we have the following different tasks:

* external HTTP requests (Gravatar requests, social provider requests)
* IO operations (database operations, accessing the file system (dev/random))
* internal operations (authenticator related actions or asynchronous callback execution)

All external HTTP requests can now use a single execution context which will be propagated through the `HTTPLayer` implementation. The DAO, service, repository and generator traits will not propagate an execution context through its methods. The execution context should be handled by the user through constructor injection. The `DelegableAuthInfoRepository` or the `SecureRandomIDGenerator` follows this pattern. For the Silhouette internal operations I've decided to propagate the execution context through the `Environment` as suggested by @rfranco.

What do you think @joaoraf and @rfranco?