### PR TITLE
Start the Authorization after body parsing?

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/api/Authorization.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/Authorization.scala
@@ -20,7 +20,7 @@
 package com.mohiva.play.silhouette.api
 
 import play.api.i18n.Messages
-import play.api.mvc.RequestHeader
+import play.api.mvc.Request
 import scala.concurrent.{ ExecutionContext, Future }
 
 /**
@@ -35,11 +35,12 @@ trait Authorization[I <: Identity] {
    * Checks whether the user is authorized to execute an endpoint or not.
    *
    * @param identity The identity to check for.
-   * @param request The current request header.
+   * @param request The current request.
    * @param messages The messages for the current language.
+   * @tparam B The type of the request body.
    * @return True if the user is authorized, false otherwise.
    */
-  def isAuthorized(identity: I)(implicit request: RequestHeader, messages: Messages): Future[Boolean]
+  def isAuthorized[B](identity: I)(implicit request: Request[B], messages: Messages): Future[Boolean]
 }
 
 /**
@@ -61,8 +62,7 @@ object Authorization {
      * @return An `Authorization` which performs a logical negation on an `Authorization` result.
      */
     def unary_! : Authorization[I] = new Authorization[I] {
-      def isAuthorized(identity: I)(
-        implicit request: RequestHeader, messages: Messages): Future[Boolean] = {
+      def isAuthorized[B](identity: I)(implicit request: Request[B], messages: Messages): Future[Boolean] = {
         self.isAuthorized(identity).map(x => !x)
       }
     }
@@ -74,7 +74,7 @@ object Authorization {
      * @return An authorization which performs a logical AND operation with two `Authorization` instances.
      */
     def &&(authorization: Authorization[I]): Authorization[I] = new Authorization[I] {
-      def isAuthorized(identity: I)(implicit request: RequestHeader, messages: Messages): Future[Boolean] = {
+      def isAuthorized[B](identity: I)(implicit request: Request[B], messages: Messages): Future[Boolean] = {
         val leftF = self.isAuthorized(identity)
         val rightF = authorization.isAuthorized(identity)
         for {
@@ -91,7 +91,7 @@ object Authorization {
      * @return An authorization which performs a logical OR operation with two `Authorization` instances.
      */
     def ||(authorization: Authorization[I]): Authorization[I] = new Authorization[I] {
-      def isAuthorized(identity: I)(implicit request: RequestHeader, messages: Messages): Future[Boolean] = {
+      def isAuthorized[B](identity: I)(implicit request: Request[B], messages: Messages): Future[Boolean] = {
         val leftF = self.isAuthorized(identity)
         val rightF = authorization.isAuthorized(identity)
         for {

--- a/silhouette/app/com/mohiva/play/silhouette/api/Silhouette.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/Silhouette.scala
@@ -390,9 +390,10 @@ trait Silhouette[I <: Identity, A <: Authenticator] extends Controller with Logg
      *
      * @param result The authentication result.
      * @param request The current request header.
+     * @tparam B The type of the request body.
      * @return The authentication result with the additional authorization status.
      */
-    private def withAuthorization(result: Future[(Option[Either[A, A]], Option[I])])(implicit request: RequestHeader) = {
+    private def withAuthorization[B](result: Future[(Option[Either[A, A]], Option[I])])(implicit request: Request[B]) = {
       result.flatMap {
         case (a, Some(i)) =>
           authorize.map(_.isAuthorized(i)).getOrElse(Future.successful(true)).map(b => (a, Some(i), Some(b)))

--- a/silhouette/test/com/mohiva/play/silhouette/api/SilhouetteSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/api/SilhouetteSpec.scala
@@ -1045,9 +1045,10 @@ class SilhouetteSpec extends PlaySpecification with Mockito with JsonMatchers {
      * @param identity The identity to check for.
      * @param request The current request header.
      * @param messages The messages for the current language.
+     * @tparam B The type of the request body.
      * @return True if the user is authorized, false otherwise.
      */
-    def isAuthorized(identity: FakeIdentity)(implicit request: RequestHeader, messages: Messages): Future[Boolean] = {
+    def isAuthorized[B](identity: FakeIdentity)(implicit request: Request[B], messages: Messages): Future[Boolean] = {
       Future.successful(isAuthorized)
     }
   }


### PR DESCRIPTION
The Authorization object can be injected into `SecuredAction` within `SecureAction.apply` method like this:

`SecuredAction(myAuthorization(carID)).async(parse.json) {}`

However, sometimes, the authorization object `myAuthorization(carID)` is unknown until the HTTP body is parsed.  For example, there is a field called `carID` in the POST body, and the constructor for authorization is `myAuthorization(carID)`.  However, `carID` is unknown before the body is parsed, but it seems that the authorization has to be binded and done before body parsing..

Is there a way to set the authorzation outside of SecureAction.apply? 
In other words,  is there a way to start the authorization after body parsing?

