### PR TITLE
Facebook provider access_token parse error

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/FacebookProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/FacebookProvider.scala
@@ -21,15 +21,12 @@ package com.mohiva.play.silhouette.impl.providers.oauth2
 
 import com.mohiva.play.silhouette.api.LoginInfo
 import com.mohiva.play.silhouette.api.util.HTTPLayer
-import com.mohiva.play.silhouette.impl.exceptions.{ UnexpectedResponseException, ProfileRetrievalException }
-import com.mohiva.play.silhouette.impl.providers.OAuth2Provider._
+import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
 import com.mohiva.play.silhouette.impl.providers._
 import com.mohiva.play.silhouette.impl.providers.oauth2.FacebookProvider._
 import play.api.libs.json.{ JsObject, JsValue }
-import play.api.libs.ws.WSResponse
 
 import scala.concurrent.Future
-import scala.util.{ Failure, Success, Try }
 
 /**
  * Base Facebook OAuth2 Provider.
@@ -73,22 +70,6 @@ trait BaseFacebookProvider extends OAuth2Provider {
           throw new ProfileRetrievalException(SpecifiedProfileError.format(id, errorMsg, errorType, errorCode))
         case _ => profileParser.parse(json)
       }
-    }
-  }
-
-  /**
-   * Builds the OAuth2 info.
-   *
-   * Facebook does not follow the OAuth2 spec :-\
-   *
-   * @param response The response from the provider.
-   * @return The OAuth2 info on success, otherwise an failure.
-   */
-  override protected def buildInfo(response: WSResponse): Try[OAuth2Info] = {
-    response.body.split("&|=") match {
-      case Array(AccessToken, token, Expires, expiresIn) => Success(OAuth2Info(token, None, Some(expiresIn.toInt)))
-      case Array(AccessToken, token) => Success(OAuth2Info(token))
-      case _ => Failure(new UnexpectedResponseException(InvalidInfoFormat.format(id, response.body)))
     }
   }
 }
@@ -168,5 +149,5 @@ object FacebookProvider {
    * The Facebook constants.
    */
   val ID = "facebook"
-  val API = "https://graph.facebook.com/me?fields=name,first_name,last_name,picture,email&return_ssl_resources=1&access_token=%s"
+  val API = "https://graph.facebook.com/v2.3/me?fields=name,first_name,last_name,picture,email&return_ssl_resources=1&access_token=%s"
 }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/custom/FacebookProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/custom/FacebookProviderSpec.scala
@@ -23,7 +23,7 @@ import com.mohiva.play.silhouette.impl.providers.SocialProfileBuilder._
 import com.mohiva.play.silhouette.impl.providers._
 import com.mohiva.play.silhouette.impl.providers.oauth2.FacebookProvider._
 import com.mohiva.play.silhouette.impl.providers.oauth2.{ BaseFacebookProvider, FacebookProfileParser, FacebookProvider }
-import play.api.libs.json.JsValue
+import play.api.libs.json.{ Json, JsValue }
 import play.api.libs.ws.{ WSRequest, WSResponse }
 import play.api.test.{ FakeRequest, WithApplication }
 import test.Helper
@@ -51,14 +51,14 @@ class FacebookProviderSpec extends OAuth2ProviderSpec {
       val requestHolder = mock[WSRequest]
       val response = mock[WSResponse]
       implicit val req = FakeRequest(GET, "?" + Code + "=my.code")
-      response.body returns ""
+      response.json returns Json.obj()
       requestHolder.withHeaders(any) returns requestHolder
       requestHolder.post[Map[String, Seq[String]]](any)(any) returns Future.successful(response)
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
       stateProvider.validate(any, any) returns Future.successful(state)
 
       failed[UnexpectedResponseException](provider.authenticate()) {
-        case e => e.getMessage must equalTo(InvalidInfoFormat.format(provider.id, ""))
+        case e => e.getMessage must startWith(InvalidInfoFormat.format(provider.id, ""))
       }
     }
 
@@ -66,18 +66,14 @@ class FacebookProviderSpec extends OAuth2ProviderSpec {
       val requestHolder = mock[WSRequest]
       val response = mock[WSResponse]
       implicit val req = FakeRequest(GET, "?" + Code + "=my.code")
-      response.body returns AccessToken + "=my.access.token&" + Expires + "=1"
+      response.json returns oAuthInfo
       requestHolder.withHeaders(any) returns requestHolder
       requestHolder.post[Map[String, Seq[String]]](any)(any) returns Future.successful(response)
       httpLayer.url(oAuthSettings.accessTokenURL) returns requestHolder
       stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
-        case authInfo => authInfo must be equalTo OAuth2Info(
-          accessToken = "my.access.token",
-          tokenType = None,
-          expiresIn = Some(1),
-          refreshToken = None)
+        case authInfo => authInfo must be equalTo oAuthInfo.as[OAuth2Info]
       }
     }
   }
@@ -111,28 +107,7 @@ class FacebookProviderSpec extends OAuth2ProviderSpec {
       }
     }
 
-    "return the social profile and the auth info with expires value" in new WithApplication with Context {
-      val requestHolder = mock[WSRequest]
-      val response = mock[WSResponse]
-      response.json returns Helper.loadJson("providers/custom/facebook.success.json")
-      requestHolder.get() returns Future.successful(response)
-      httpLayer.url(API.format("my.access.token")) returns requestHolder
-
-      profile(provider.retrieveProfile(oAuthInfo.as[OAuth2Info])) {
-        case p =>
-          p must be equalTo new CustomSocialProfile(
-            loginInfo = LoginInfo(provider.id, "134405962728980"),
-            firstName = Some("Apollonia"),
-            lastName = Some("Vanova"),
-            fullName = Some("Apollonia Vanova"),
-            email = Some("apollonia.vanova@watchmen.com"),
-            avatarURL = Some("https://fbcdn-sphotos-g-a.akamaihd.net/hphotos-ak-ash2/t1/36245_155530314499277_2350717_n.jpg?lvh=1"),
-            gender = Some("male")
-          )
-      }
-    }
-
-    "return the social profile and the auth info without expires value" in new WithApplication with Context {
+    "return the social profile" in new WithApplication with Context {
       val requestHolder = mock[WSRequest]
       val response = mock[WSResponse]
       response.json returns Helper.loadJson("providers/custom/facebook.success.json")
@@ -176,6 +151,13 @@ class FacebookProviderSpec extends OAuth2ProviderSpec {
       clientID = "my.client.id",
       clientSecret = "my.client.secret",
       scope = Some("email")))
+
+    /**
+     * The OAuth2 info returned by Facebook.
+     *
+     * @see https://developers.facebook.com/docs/facebook-login/access-tokens
+     */
+    override lazy val oAuthInfo = Helper.loadJson("providers/oauth2/facebook.access.token.json")
 
     /**
      * The provider to test.

--- a/silhouette/test/resources/providers/oauth2/clef.access.token.json
+++ b/silhouette/test/resources/providers/oauth2/clef.access.token.json
@@ -1,4 +1,4 @@
 {
-  "access_token": "token_1234567890",
+  "access_token": "my.access.token",
   "success": true
 }

--- a/silhouette/test/resources/providers/oauth2/facebook.access.token.json
+++ b/silhouette/test/resources/providers/oauth2/facebook.access.token.json
@@ -1,5 +1,5 @@
 {
   "access_token": "my.access.token",
   "token_type": "bearer",
-  "uid": "12345"
+  "expires_in": 5183836
 }


### PR DESCRIPTION
Facebook 2.3 API response with JSON, not url encoded params.