### PR TITLE
Move type for the settings to authenticator

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/api/Authenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/Authenticator.scala
@@ -30,6 +30,11 @@ trait Authenticator {
   type Value
 
   /**
+   * The type of the settings an authenticator can handle.
+   */
+  type Settings
+
+  /**
    * Gets the linked login info for an identity.
    *
    * @return The linked login info for an identity.

--- a/silhouette/app/com/mohiva/play/silhouette/api/services/AuthenticatorService.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/services/AuthenticatorService.scala
@@ -89,16 +89,11 @@ trait AuthenticatorService[T <: Authenticator] extends ExecutionContextProvider 
   type Self <: AuthenticatorService[T]
 
   /**
-   * The type of the settings.
-   */
-  type Settings
-
-  /**
    * Gets the authenticator settings.
    *
    * @return The authenticator settings.
    */
-  def settings: Settings
+  def settings: T#Settings
 
   /**
    * Gets an authenticator service initialized with a new settings object.
@@ -106,7 +101,7 @@ trait AuthenticatorService[T <: Authenticator] extends ExecutionContextProvider 
    * @param f A function which gets the settings passed and returns different settings.
    * @return An instance of the authenticator service initialized with new settings.
    */
-  def withSettings(f: Settings => Settings): Self
+  def withSettings(f: T#Settings => T#Settings): Self
 
   /**
    * Creates a new authenticator for the specified login info.

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/BearerTokenAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/BearerTokenAuthenticator.scala
@@ -60,6 +60,11 @@ case class BearerTokenAuthenticator(
   override type Value = String
 
   /**
+   * The type of the settings an authenticator can handle.
+   */
+  override type Settings = BearerTokenAuthenticatorSettings
+
+  /**
    * Checks if the authenticator isn't expired and isn't timed out.
    *
    * @return True if the authenticator isn't expired and isn't timed out.
@@ -104,11 +109,6 @@ class BearerTokenAuthenticatorService(
    * The type of this class.
    */
   override type Self = BearerTokenAuthenticatorService
-
-  /**
-   * The type of the settings.
-   */
-  override type Settings = BearerTokenAuthenticatorSettings
 
   /**
    * Gets an authenticator service initialized with a new settings object.

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticator.scala
@@ -73,6 +73,11 @@ case class CookieAuthenticator(
   override type Value = Cookie
 
   /**
+   * The type of the settings an authenticator can handle.
+   */
+  override type Settings = CookieAuthenticatorSettings
+
+  /**
    * Checks if the authenticator isn't expired and isn't timed out.
    *
    * @return True if the authenticator isn't expired and isn't timed out.
@@ -175,11 +180,6 @@ class CookieAuthenticatorService(
    * The type of this class.
    */
   override type Self = CookieAuthenticatorService
-
-  /**
-   * The type of the settings.
-   */
-  override type Settings = CookieAuthenticatorSettings
 
   /**
    * Gets an authenticator service initialized with a new settings object.

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticator.scala
@@ -36,6 +36,11 @@ case class DummyAuthenticator(loginInfo: LoginInfo) extends Authenticator {
   override type Value = Unit
 
   /**
+   * The type of the settings an authenticator can handle.
+   */
+  override type Settings = Unit
+
+  /**
    * Authenticator is always valid.
    *
    * @return True because it's always valid.
@@ -55,11 +60,6 @@ class DummyAuthenticatorService(implicit val executionContext: ExecutionContext)
    * The type of this class.
    */
   override type Self = DummyAuthenticatorService
-
-  /**
-   * The type of the settings.
-   */
-  override type Settings = Unit
 
   /**
    * Gets the authenticator settings.

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/JWTAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/JWTAuthenticator.scala
@@ -74,6 +74,11 @@ case class JWTAuthenticator(
   override type Value = String
 
   /**
+   * The type of the settings an authenticator can handle.
+   */
+  override type Settings = JWTAuthenticatorSettings
+
+  /**
    * Checks if the authenticator isn't expired and isn't timed out.
    *
    * @return True if the authenticator isn't expired and isn't timed out.
@@ -252,11 +257,6 @@ class JWTAuthenticatorService(
    * The type of this class.
    */
   override type Self = JWTAuthenticatorService
-
-  /**
-   * The type of the settings.
-   */
-  override type Settings = JWTAuthenticatorSettings
 
   /**
    * Gets an authenticator service initialized with a new settings object.

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticator.scala
@@ -59,6 +59,11 @@ case class SessionAuthenticator(
   override type Value = Session
 
   /**
+   * The type of the settings an authenticator can handle.
+   */
+  override type Settings = SessionAuthenticatorSettings
+
+  /**
    * Checks if the authenticator isn't expired and isn't timed out.
    *
    * @return True if the authenticator isn't expired and isn't timed out.
@@ -157,11 +162,6 @@ class SessionAuthenticatorService(
    * The type of this class.
    */
   override type Self = SessionAuthenticatorService
-
-  /**
-   * The type of the settings.
-   */
-  override type Settings = SessionAuthenticatorSettings
 
   /**
    * Gets an authenticator service initialized with a new settings object.


### PR DESCRIPTION
 Move type for the `Settings` to `Authenticator` to allow the usage of the `withSettings` method on a `AuthenticatorService[Authenticator]` instance.