### PR TITLE
Twitter Provider: add email support

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth1/TwitterProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth1/TwitterProvider.scala
@@ -85,11 +85,13 @@ class TwitterProfileParser extends SocialProfileParser[JsValue, CommonSocialProf
   override def parse(json: JsValue) = Future.successful {
     val userID = (json \ "id").as[Long]
     val fullName = (json \ "name").asOpt[String]
+    val email = (json \ "email").asOpt[String]
     val avatarURL = (json \ "profile_image_url_https").asOpt[String]
 
     CommonSocialProfile(
       loginInfo = LoginInfo(ID, userID.toString),
       fullName = fullName,
+      email = email,
       avatarURL = avatarURL)
   }
 }
@@ -144,5 +146,5 @@ object TwitterProvider {
    * The Twitter constants.
    */
   val ID = "twitter"
-  val API = "https://api.twitter.com/1.1/account/verify_credentials.json"
+  val API = "https://api.twitter.com/1.1/account/verify_credentials.json?include_email=true&skip_status=true"
 }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/TwitterProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/TwitterProviderSpec.scala
@@ -88,6 +88,25 @@ class TwitterProviderSpec extends OAuth1ProviderSpec {
           )
       }
     }
+
+    "return the social profile with email" in new WithApplication with Context {
+      val requestHolder = mock[WSRequest]
+      val response = mock[WSResponse]
+      requestHolder.sign(any) returns requestHolder
+      requestHolder.get() returns Future.successful(response)
+      response.json returns Helper.loadJson("providers/oauth1/twitter.with.email.json")
+      httpLayer.url(API) returns requestHolder
+
+      profile(provider.retrieveProfile(oAuthInfo)) {
+        case p =>
+          p must be equalTo new CommonSocialProfile(
+            loginInfo = LoginInfo(provider.id, "6253282"),
+            fullName = Some("Apollonia Vanova"),
+            email = Some("apollonia.vanova@watchmen.com"),
+            avatarURL = Some("https://pbs.twimg.com/profile_images/1209905677/appolonia_.jpg")
+          )
+      }
+    }
   }
 
   /**

--- a/silhouette/test/resources/providers/oauth1/twitter.with.email.json
+++ b/silhouette/test/resources/providers/oauth1/twitter.with.email.json
@@ -1,0 +1,11 @@
+{
+  "id": 6253282,
+  "id_str": "6253282",
+  "name": "Apollonia Vanova",
+  "email": "apollonia.vanova@watchmen.com",
+  "screen_name": "apolloniavanova",
+  "location": "Slovak",
+  "description": "A Slovakian-born actress, known for her roles as Silhouette in the film version of Watchmen.",
+  "url": "http:\/\/apolloniavanova.com",
+  "profile_image_url_https": "https://pbs.twimg.com/profile_images/1209905677/appolonia_.jpg"
+}


### PR DESCRIPTION
Earlier in 2015 twitter added the ability for applications to retrieve user emails. Applications have to be specifically whitelisted in order to do this, and an additional token has to be sent along with the request to verify_credentials in order for the email to be returned.