### PR TITLE
Use None as default value for Option based settings values

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/BearerTokenAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/BearerTokenAuthenticator.scala
@@ -306,10 +306,10 @@ object BearerTokenAuthenticatorService {
  * The settings for the bearer token authenticator.
  *
  * @param headerName The name of the header in which the token will be transferred.
- * @param authenticatorIdleTimeout The duration an authenticator can be idle before it timed out. Defaults to 30 minutes.
- * @param authenticatorExpiry The duration an authenticator expires. Defaults to 12 hours.
+ * @param authenticatorIdleTimeout The duration an authenticator can be idle before it timed out.
+ * @param authenticatorExpiry The duration an authenticator expires after it was created.
  */
 case class BearerTokenAuthenticatorSettings(
   headerName: String = "X-Auth-Token",
-  authenticatorIdleTimeout: Option[FiniteDuration] = Some(30 minutes),
+  authenticatorIdleTimeout: Option[FiniteDuration] = None,
   authenticatorExpiry: FiniteDuration = 12 hours)

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticator.scala
@@ -444,9 +444,9 @@ object CookieAuthenticatorService {
  * @param secureCookie Whether this cookie is secured, sent only for HTTPS requests.
  * @param httpOnlyCookie Whether this cookie is HTTP only, i.e. not accessible from client-side JavaScript code.
  * @param useFingerprinting Indicates if a fingerprint of the user should be stored in the authenticator.
- * @param cookieMaxAge The duration a cookie expires. `None` for a transient cookie. Defaults to 12 hours.
- * @param authenticatorIdleTimeout The duration an authenticator can be idle before it timed out. Defaults to 30 minutes.
- * @param authenticatorExpiry The duration an authenticator expires. Defaults to 12 hours.
+ * @param cookieMaxAge The duration a cookie expires. `None` for a transient cookie..
+ * @param authenticatorIdleTimeout The duration an authenticator can be idle before it timed out.
+ * @param authenticatorExpiry The duration an authenticator expires after it was created.
  */
 case class CookieAuthenticatorSettings(
   cookieName: String = "id",
@@ -456,6 +456,6 @@ case class CookieAuthenticatorSettings(
   httpOnlyCookie: Boolean = true,
   encryptAuthenticator: Boolean = true,
   useFingerprinting: Boolean = true,
-  cookieMaxAge: Option[FiniteDuration] = Some(12 hours),
-  authenticatorIdleTimeout: Option[FiniteDuration] = Some(30 minutes),
+  cookieMaxAge: Option[FiniteDuration] = None,
+  authenticatorIdleTimeout: Option[FiniteDuration] = None,
   authenticatorExpiry: FiniteDuration = 12 hours)

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/JWTAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/JWTAuthenticator.scala
@@ -475,13 +475,13 @@ object JWTAuthenticatorService {
  * @param issuerClaim The issuer claim identifies the principal that issued the JWT.
  * @param encryptSubject Indicates if the subject should be encrypted in JWT.
  * @param authenticatorIdleTimeout The duration an authenticator can be idle before it timed out.
- * @param authenticatorExpiry The duration an authenticator expires.
+ * @param authenticatorExpiry The duration an authenticator expires after it was created.
  * @param sharedSecret The shared secret to sign the JWT.
  */
 case class JWTAuthenticatorSettings(
   headerName: String = "X-Auth-Token",
   issuerClaim: String = "play-silhouette",
   encryptSubject: Boolean = true,
-  authenticatorIdleTimeout: Option[FiniteDuration] = None, // This feature is disabled by default to prevent the generation of a new JWT on every request
+  authenticatorIdleTimeout: Option[FiniteDuration] = None,
   authenticatorExpiry: FiniteDuration = 12 hours,
   sharedSecret: String)

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticator.scala
@@ -375,12 +375,12 @@ object SessionAuthenticatorService {
  * @param sessionKey The key of the authenticator in the session.
  * @param encryptAuthenticator Indicates if the authenticator should be encrypted in session.
  * @param useFingerprinting Indicates if a fingerprint of the user should be stored in the authenticator.
- * @param authenticatorIdleTimeout The duration an authenticator can be idle before it timed out. Defaults to 30 minutes.
- * @param authenticatorExpiry The duration an authenticator expires. Defaults to 12 hours.
+ * @param authenticatorIdleTimeout The duration an authenticator can be idle before it timed out.
+ * @param authenticatorExpiry The duration an authenticator expires after it was created.
  */
 case class SessionAuthenticatorSettings(
   sessionKey: String = "authenticator",
   encryptAuthenticator: Boolean = true,
   useFingerprinting: Boolean = true,
-  authenticatorIdleTimeout: Option[FiniteDuration] = Some(30 minutes),
+  authenticatorIdleTimeout: Option[FiniteDuration] = None,
   authenticatorExpiry: FiniteDuration = 12 hours)


### PR DESCRIPTION
If we use an other default value as `None` for `Option` based setting keys, then we do not have the possibility to set `None` as value in the Play configuration. Because if we omit the config property or if we use `null` as value, then the Typesafe config implementation will use the default value for this property.