### PR TITLE
Big authenticator refactoring

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/api/services/AuthenticatorService.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/services/AuthenticatorService.scala
@@ -84,26 +84,6 @@ object AuthenticatorResult {
 trait AuthenticatorService[T <: Authenticator] extends ExecutionContextProvider {
 
   /**
-   * The type of the concrete implementation of this abstract type.
-   */
-  type Self <: AuthenticatorService[T]
-
-  /**
-   * Gets the authenticator settings.
-   *
-   * @return The authenticator settings.
-   */
-  def settings: T#Settings
-
-  /**
-   * Gets an authenticator service initialized with a new settings object.
-   *
-   * @param f A function which gets the settings passed and returns different settings.
-   * @return An instance of the authenticator service initialized with new settings.
-   */
-  def withSettings(f: T#Settings => T#Settings): Self
-
-  /**
    * Creates a new authenticator for the specified login info.
    *
    * @param loginInfo The login info for which the authenticator should be created.

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticator.scala
@@ -36,11 +36,6 @@ case class DummyAuthenticator(loginInfo: LoginInfo) extends Authenticator {
   override type Value = Unit
 
   /**
-   * The type of the settings an authenticator can handle.
-   */
-  override type Settings = Unit
-
-  /**
    * Authenticator is always valid.
    *
    * @return True because it's always valid.
@@ -55,26 +50,6 @@ case class DummyAuthenticator(loginInfo: LoginInfo) extends Authenticator {
  */
 class DummyAuthenticatorService(implicit val executionContext: ExecutionContext)
   extends AuthenticatorService[DummyAuthenticator] {
-
-  /**
-   * The type of this class.
-   */
-  override type Self = DummyAuthenticatorService
-
-  /**
-   * Gets the authenticator settings.
-   *
-   * @return The authenticator settings.
-   */
-  override def settings = ()
-
-  /**
-   * Gets an authenticator service initialized with a new settings object.
-   *
-   * @param f A function which gets the settings passed and returns different settings.
-   * @return An instance of the authenticator service initialized with new settings.
-   */
-  override def withSettings(f: Unit => Unit) = new DummyAuthenticatorService()
 
   /**
    * Creates a new authenticator for the specified login info.

--- a/silhouette/test/com/mohiva/play/silhouette/api/AuthenticatorSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/api/AuthenticatorSpec.scala
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mohiva.play.silhouette.api
+
+import com.mohiva.play.silhouette.api.Authenticator.Implicits._
+import org.joda.time.DateTime
+import play.api.test.PlaySpecification
+
+import scala.concurrent.duration._
+
+/**
+ * Test case for the [[com.mohiva.play.silhouette.api.Authenticator]] class.
+ */
+class AuthenticatorSpec extends PlaySpecification {
+
+  "The + method of the RichDateTime class" should {
+    "add a second to a DateTime instance" in {
+      new DateTime(2015, 6, 16, 19, 46, 0) + 1.second must be equalTo new DateTime(2015, 6, 16, 19, 46, 1)
+    }
+
+    "add a minute to a DateTime instance" in {
+      new DateTime(2015, 6, 16, 19, 46, 0) + 1.minute must be equalTo new DateTime(2015, 6, 16, 19, 47, 0)
+    }
+
+    "add an hour to a DateTime instance" in {
+      new DateTime(2015, 6, 16, 19, 46, 0) + 1.hour must be equalTo new DateTime(2015, 6, 16, 20, 46, 0)
+    }
+
+    "subtract a second from a DateTime instance" in {
+      new DateTime(2015, 6, 16, 19, 46, 0) - 1.second must be equalTo new DateTime(2015, 6, 16, 19, 45, 59)
+    }
+
+    "subtract a minute from a DateTime instance" in {
+      new DateTime(2015, 6, 16, 19, 46, 0) - 1.minute must be equalTo new DateTime(2015, 6, 16, 19, 45, 0)
+    }
+
+    "subtract an hour from a DateTime instance" in {
+      new DateTime(2015, 6, 16, 19, 46, 0) - 1.hour must be equalTo new DateTime(2015, 6, 16, 18, 46, 0)
+    }
+  }
+}

--- a/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticatorSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticatorSpec.scala
@@ -34,12 +34,6 @@ class DummyAuthenticatorSpec extends PlaySpecification with Mockito {
     }
   }
 
-  "The `withSettings` method of the service" should {
-    "create a new instance with customized settings" in new Context {
-      service.withSettings(identity) must beAnInstanceOf[DummyAuthenticatorService]
-    }
-  }
-
   "The `create` method of the service" should {
     "return an authenticator containing the given login info" in new Context {
       implicit val request = FakeRequest()


### PR DESCRIPTION
* Add explicit "Remember Me" functionality to the CookieAuthenticator
* Remove the `withSettings` method from the `AuthenticatorService` because it doesn't work as expected
* Rename the `DateTime` based variable names to `dateTime` instead of `date` to better signalize the associated type of the variable
* Encapsulate functionality for expiring authenticators into the `ExpirableAuthenticator` trait