### PR TITLE
BasicAuthProvider should not throw exception for user errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
+sudo: false
 language: scala
 scala:
 - 2.10.5
-- 2.11.6
+- 2.11.7
 jdk:
 - oraclejdk8
 env:

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -32,7 +32,7 @@ object BasicSettings extends AutoPlugin {
 
   override def projectSettings = Seq(
     organization := "com.mohiva",
-    version := "3.0.0",
+    version := "3.0.1",
     resolvers ++= Dependencies.resolvers,
     scalaVersion := Dependencies.Versions.scalaVersion,
     crossScalaVersions := Dependencies.Versions.crossScala,

--- a/scripts/sbt-runner
+++ b/scripts/sbt-runner
@@ -4,8 +4,8 @@
 # Author: Paul Phillips <paulp@improving.org>
 
 # todo - make this dynamic
-declare -r sbt_release_version="0.13.8"
-declare -r sbt_unreleased_version="0.13.8"
+declare -r sbt_release_version="0.13.9"
+declare -r sbt_unreleased_version="0.13.9"
 declare -r buildProps="project/build.properties"
 
 declare sbt_jar sbt_dir sbt_create sbt_version
@@ -106,7 +106,7 @@ declare -r noshare_opts="-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory
 declare -r latest_28="2.8.2"
 declare -r latest_29="2.9.3"
 declare -r latest_210="2.10.5"
-declare -r latest_211="2.11.6"
+declare -r latest_211="2.11.7"
 
 declare -r script_path="$(get_script_path "$BASH_SOURCE")"
 declare -r script_name="${script_path##*/}"
@@ -115,7 +115,7 @@ declare -r script_name="${script_path##*/}"
 declare java_cmd="java"
 declare sbt_opts_file="$(init_default_option_file SBT_OPTS .sbtopts)"
 declare jvm_opts_file="$(init_default_option_file JVM_OPTS .jvmopts)"
-declare sbt_launch_repo="http://typesafe.artifactoryonline.com/typesafe/ivy-releases"
+declare sbt_launch_repo="http://repo.typesafe.com/typesafe/ivy-releases"
 
 # pull -J and -D options to give to java.
 declare -a residual_args
@@ -128,11 +128,11 @@ declare -a extra_jvm_opts extra_sbt_opts
 
 addJava () {
   vlog "[addJava] arg = '$1'"
-  java_args=( "${java_args[@]}" "$1" )
+  java_args+=("$1")
 }
 addSbt () {
   vlog "[addSbt] arg = '$1'"
-  sbt_commands=( "${sbt_commands[@]}" "$1" )
+  sbt_commands+=("$1")
 }
 setThisBuild () {
   vlog "[addBuild] args = '$@'"
@@ -141,11 +141,11 @@ setThisBuild () {
 }
 addScalac () {
   vlog "[addScalac] arg = '$1'"
-  scalac_args=( "${scalac_args[@]}" "$1" )
+  scalac_args+=("$1")
 }
 addResidual () {
   vlog "[residual] arg = '$1'"
-  residual_args=( "${residual_args[@]}" "$1" )
+  residual_args+=("$1")
 }
 addResolver () {
   addSbt "set resolvers += $1"
@@ -166,11 +166,9 @@ setJavaHome () {
   export PATH="$JAVA_HOME/bin:$PATH"
 }
 setJavaHomeQuietly () {
-  java_cmd="$1/bin/java"
-  addSbt ";warn ;set javaHome in ThisBuild := Some(file(\"$1\")) ;info"
-  export JAVA_HOME="$1"
-  export JDK_HOME="$1"
-  export PATH="$JAVA_HOME/bin:$PATH"
+  addSbt warn
+  setJavaHome "$1"
+  addSbt info
 }
 
 # if set, use JDK_HOME/JAVA_HOME over java found in path
@@ -246,7 +244,7 @@ download_url () {
 
   mkdir -p "${jar%/*}" && {
     if which curl >/dev/null; then
-      curl --fail --silent "$url" --output "$jar"
+      curl --fail --silent --location "$url" --output "$jar"
     elif which wget >/dev/null; then
       wget --quiet -O "$jar" "$url"
     fi


### PR DESCRIPTION
Currently the `BasicAuthProvider` throws an exception if the identity was not found or if the password does not match. For request providers there is no change for the developer to react to these errors. Furthermore it breaks the request provider chain.