### PR TITLE
Allow to override the creation of the LoginInfo for the CredentialsProvider

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -32,7 +32,7 @@ object BasicSettings extends AutoPlugin {
 
   override def projectSettings = Seq(
     organization := "com.mohiva",
-    version := "3.0.3",
+    version := "3.0.4",
     resolvers ++= Dependencies.resolvers,
     scalaVersion := Dependencies.Versions.scalaVersion,
     crossScalaVersions := Dependencies.Versions.crossScala,


### PR DESCRIPTION
By default the credentials provider creates the login info with the identifier entered in the form. For some cases this may not be enough. It could also be possible that a login form allows a user to log in with either a username or an email address. In this case, the `loginInfo` method provided with this pull request, should be overridden to provide a unique binding, like the user ID, for the entered form values.

See: http://silhouette.mohiva.com/v3.0/discuss/56002d146932a00d00ba7bd9