### PR TITLE
Move persistence based API into a separate project

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -24,6 +24,18 @@ object Build extends Build {
     base = file("silhouette")
   )
 
+  val silhouettePersistence = Project(
+    id = "play-silhouette-persistence",
+    base = file("silhouette-persistence"),
+    dependencies = Seq(silhouette)
+  )
+
+  val silhouettePersistenceMemory = Project(
+    id = "play-silhouette-persistence-memory",
+    base = file("silhouette-persistence-memory"),
+    dependencies = Seq(silhouettePersistence)
+  )
+
   val silhouetteTestkit = Project(
     id = "play-silhouette-testkit",
     base = file("silhouette-testkit"),
@@ -33,7 +45,12 @@ object Build extends Build {
   val root = Project(
     id = "root",
     base = file("."),
-    aggregate = Seq(silhouette, silhouetteTestkit),
+    aggregate = Seq(
+      silhouette,
+      silhouettePersistence,
+      silhouettePersistenceMemory,
+      silhouetteTestkit
+    ),
     settings = Defaults.coreDefaultSettings ++
       APIDoc.settings ++
       Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,10 +35,16 @@ object Dependencies {
       val cache = "com.typesafe.play" %% "play-cache" % version
       val test = "com.typesafe.play" %% "play-test" % version
       val specs2 = "com.typesafe.play" %% "play-specs2" % version
+      object Specs2 {
+        private val version = "3.4"
+        val matcherExtra = "org.specs2" %% "specs2-matcher-extra" % version
+        val mock = "org.specs2" %% "specs2-mock" % version
+      }
     }
 
     object Specs2 {
-      private val version = "3.4"
+      private val version = "3.6.5"
+      val core = "org.specs2" %% "specs2-core" % version
       val matcherExtra = "org.specs2" %% "specs2-matcher-extra" % version
       val mock = "org.specs2" %% "specs2-mock" % version
     }
@@ -46,7 +52,6 @@ object Dependencies {
     val jbcrypt = "org.mindrot" % "jbcrypt" % "0.3m"
     val jwtCore = "com.atlassian.jwt" % "jwt-core" % "1.2.4"
     val jwtApi = "com.atlassian.jwt" % "jwt-api" % "1.2.4"
-    val mockito = "org.mockito" % "mockito-core" % "1.10.19"
     val scalaGuice = "net.codingwell" %% "scala-guice" % "4.0.0"
     val akkaTestkit = "com.typesafe.akka" %% "akka-testkit" % "2.3.10"
   }

--- a/silhouette-persistence-memory/build.sbt
+++ b/silhouette-persistence-memory/build.sbt
@@ -1,0 +1,8 @@
+import Dependencies._
+
+libraryDependencies ++= Seq(
+  Library.scalaGuice,
+  Library.Specs2.core % Test
+)
+
+enablePlugins(Doc)

--- a/silhouette-persistence-memory/src/main/scala/com/mohiva/play/silhouette/persistence/daos/OAuth1InfoDAO.scala
+++ b/silhouette-persistence-memory/src/main/scala/com/mohiva/play/silhouette/persistence/daos/OAuth1InfoDAO.scala
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mohiva.play.silhouette.persistence.daos
+
+import com.mohiva.play.silhouette.impl.providers.OAuth1Info
+
+/**
+ * The DAO to persist the OAuth1 information.
+ *
+ * Note: Not thread safe, demo only.
+ */
+class OAuth1InfoDAO extends InMemoryAuthInfoDAO[OAuth1Info]

--- a/silhouette-persistence-memory/src/main/scala/com/mohiva/play/silhouette/persistence/daos/OAuth2InfoDAO.scala
+++ b/silhouette-persistence-memory/src/main/scala/com/mohiva/play/silhouette/persistence/daos/OAuth2InfoDAO.scala
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mohiva.play.silhouette.persistence.daos
+
+import com.mohiva.play.silhouette.impl.providers.OAuth2Info
+
+/**
+ * The DAO to persist the OAuth2 information.
+ *
+ * Note: Not thread safe, demo only.
+ */
+class OAuth2InfoDAO extends InMemoryAuthInfoDAO[OAuth2Info]

--- a/silhouette-persistence-memory/src/main/scala/com/mohiva/play/silhouette/persistence/daos/OpenIDInfoDAO.scala
+++ b/silhouette-persistence-memory/src/main/scala/com/mohiva/play/silhouette/persistence/daos/OpenIDInfoDAO.scala
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mohiva.play.silhouette.persistence.daos
+
+import com.mohiva.play.silhouette.impl.providers.OpenIDInfo
+
+/**
+ * The DAO to persist the OpenID information.
+ *
+ * Note: Not thread safe, demo only.
+ */
+class OpenIDInfoDAO extends InMemoryAuthInfoDAO[OpenIDInfo]

--- a/silhouette-persistence-memory/src/main/scala/com/mohiva/play/silhouette/persistence/daos/PasswordInfoDAO.scala
+++ b/silhouette-persistence-memory/src/main/scala/com/mohiva/play/silhouette/persistence/daos/PasswordInfoDAO.scala
@@ -13,9 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.mohiva.play.silhouette.impl
+package com.mohiva.play.silhouette.persistence.daos
+
+import com.mohiva.play.silhouette.api.util.PasswordInfo
 
 /**
- * Provides implementations of the repositories.
+ * The DAO to persist the password information.
+ *
+ * Note: Not thread safe, demo only.
  */
-package object repositories {}
+class PasswordInfoDAO extends InMemoryAuthInfoDAO[PasswordInfo]

--- a/silhouette-persistence-memory/src/main/scala/com/mohiva/play/silhouette/persistence/daos/package.scala
+++ b/silhouette-persistence-memory/src/main/scala/com/mohiva/play/silhouette/persistence/daos/package.scala
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mohiva.play.silhouette.persistence
+
+/**
+ * Provides drop-in DAO replacements for the common `AuthInfo` implementations.
+ */
+package object daos

--- a/silhouette-persistence-memory/src/main/scala/com/mohiva/play/silhouette/persistence/modules/PersistenceModule.scala
+++ b/silhouette-persistence-memory/src/main/scala/com/mohiva/play/silhouette/persistence/modules/PersistenceModule.scala
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mohiva.play.silhouette.persistence.modules
+
+import com.google.inject.{ AbstractModule, Provides }
+import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
+import com.mohiva.play.silhouette.api.util.PasswordInfo
+import com.mohiva.play.silhouette.impl.providers.{ OAuth1Info, OAuth2Info, OpenIDInfo }
+import com.mohiva.play.silhouette.persistence.daos._
+import com.mohiva.play.silhouette.persistence.repositories.DelegableAuthInfoRepository
+import net.codingwell.scalaguice.ScalaModule
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+/**
+ * Provides Guice bindings for the persistence module.
+ */
+class PersistenceModule extends AbstractModule with ScalaModule {
+
+  /**
+   * Configures the module.
+   */
+  def configure(): Unit = {
+    bind[DelegableAuthInfoDAO[PasswordInfo]].to[PasswordInfoDAO]
+    bind[DelegableAuthInfoDAO[OAuth1Info]].to[OAuth1InfoDAO]
+    bind[DelegableAuthInfoDAO[OAuth2Info]].to[OAuth2InfoDAO]
+    bind[DelegableAuthInfoDAO[OpenIDInfo]].to[OpenIDInfoDAO]
+  }
+
+  /**
+   * Provides the auth info repository.
+   *
+   * @param passwordInfoDAO The implementation of the delegable password auth info DAO.
+   * @param oauth1InfoDAO The implementation of the delegable OAuth1 auth info DAO.
+   * @param oauth2InfoDAO The implementation of the delegable OAuth2 auth info DAO.
+   * @param openIDInfoDAO The implementation of the delegable OpenID auth info DAO.
+   * @return The auth info repository instance.
+   */
+  @Provides
+  def provideAuthInfoRepository(
+    passwordInfoDAO: DelegableAuthInfoDAO[PasswordInfo],
+    oauth1InfoDAO: DelegableAuthInfoDAO[OAuth1Info],
+    oauth2InfoDAO: DelegableAuthInfoDAO[OAuth2Info],
+    openIDInfoDAO: DelegableAuthInfoDAO[OpenIDInfo]): AuthInfoRepository = {
+
+    new DelegableAuthInfoRepository(passwordInfoDAO, oauth1InfoDAO, oauth2InfoDAO, openIDInfoDAO)
+  }
+}

--- a/silhouette-persistence-memory/src/test/scala/com/mohiva/play/silhouette/persistence/daos/OAuth1InfoDAOSpec.scala
+++ b/silhouette-persistence-memory/src/test/scala/com/mohiva/play/silhouette/persistence/daos/OAuth1InfoDAOSpec.scala
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mohiva.play.silhouette.persistence.daos
+
+import com.mohiva.play.silhouette.api.LoginInfo
+import com.mohiva.play.silhouette.impl.providers.OAuth1Info
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.control.NoLanguageFeatures
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+/**
+ * Test case for the [[OAuth1InfoDAO]] class.
+ */
+class OAuth1InfoDAOSpec(implicit ev: ExecutionEnv) extends Specification with NoLanguageFeatures {
+
+  "The `find` method" should {
+    "find an OAuth1 info for the given login info" in new Context {
+      Await.result(dao.save(loginInfo, authInfo), 10 seconds)
+
+      dao.find(loginInfo) must beSome(authInfo).await
+    }
+
+    "return None if no OAuth1 info for the given login info exists" in new Context {
+      dao.find(loginInfo.copy(providerKey = "new.key")) should beNone.await
+    }
+  }
+
+  "The `add` method" should {
+    "add a new OAuth1 info" in new Context {
+      dao.add(loginInfo.copy(providerKey = "new.key"), authInfo) must beEqualTo(authInfo).await
+      dao.find(loginInfo.copy(providerKey = "new.key")) must beSome(authInfo).await
+    }
+  }
+
+  "The `update` method" should {
+    "update an existing OAuth1 info" in new Context {
+      val updatedInfo = authInfo.copy(secret = "updated")
+
+      dao.update(loginInfo, updatedInfo) must beEqualTo(updatedInfo).await
+      dao.find(loginInfo) must beSome(updatedInfo).await
+    }
+  }
+
+  "The `save` method" should {
+    "insert a new OAuth1 info" in new Context {
+      dao.save(loginInfo.copy(providerKey = "new.key"), authInfo) must beEqualTo(authInfo).await
+      dao.find(loginInfo.copy(providerKey = "new.key")) must beSome(authInfo).await
+    }
+
+    "update an existing OAuth1 info" in new Context {
+      val updatedInfo = authInfo.copy(secret = "updated")
+
+      dao.update(loginInfo, updatedInfo) must beEqualTo(updatedInfo).await
+      dao.find(loginInfo) must beSome(updatedInfo).await
+    }
+  }
+
+  "The `remove` method" should {
+    "remove an OAuth1 info" in new Context {
+      Await.result(dao.remove(loginInfo), 10 seconds)
+      dao.find(loginInfo) must beNone.await
+    }
+  }
+
+  /**
+   * The context.
+   */
+  trait Context extends Scope {
+
+    /**
+     * The OAuth1 info DAO implementation.
+     */
+    lazy val dao = new OAuth1InfoDAO
+
+    /**
+     * A login info.
+     */
+    lazy val loginInfo = LoginInfo("provider", "6253282")
+
+    /**
+     * A OAuth1 info.
+     */
+    lazy val authInfo = OAuth1Info("my.token", "my.consumer.secret")
+  }
+}

--- a/silhouette-persistence-memory/src/test/scala/com/mohiva/play/silhouette/persistence/daos/OAuth2InfoDAOSpec.scala
+++ b/silhouette-persistence-memory/src/test/scala/com/mohiva/play/silhouette/persistence/daos/OAuth2InfoDAOSpec.scala
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mohiva.play.silhouette.persistence.daos
+
+import com.mohiva.play.silhouette.api.LoginInfo
+import com.mohiva.play.silhouette.impl.providers.OAuth2Info
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.control.NoLanguageFeatures
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+/**
+ * Test case for the [[OAuth2InfoDAO]] class.
+ */
+class OAuth2InfoDAOSpec(implicit ev: ExecutionEnv) extends Specification with NoLanguageFeatures {
+
+  "The `find` method" should {
+    "find an OAuth2 info for the given login info" in new Context {
+      Await.result(dao.save(loginInfo, authInfo), 10 seconds)
+
+      dao.find(loginInfo) must beSome(authInfo).await
+    }
+
+    "return None if no OAuth2 info for the given login info exists" in new Context {
+      dao.find(loginInfo.copy(providerKey = "new.key")) should beNone.await
+    }
+  }
+
+  "The `add` method" should {
+    "add a new OAuth2 info" in new Context {
+      dao.add(loginInfo.copy(providerKey = "new.key"), authInfo) must beEqualTo(authInfo).await
+      dao.find(loginInfo.copy(providerKey = "new.key")) must beSome(authInfo).await
+    }
+  }
+
+  "The `update` method" should {
+    "update an existing OAuth2 info" in new Context {
+      val updatedInfo = authInfo.copy(tokenType = Some("updated"))
+
+      dao.update(loginInfo, updatedInfo) must beEqualTo(updatedInfo).await
+      dao.find(loginInfo) must beSome(updatedInfo).await
+    }
+  }
+
+  "The `save` method" should {
+    "insert a new OAuth2 info" in new Context {
+      dao.save(loginInfo.copy(providerKey = "new.key"), authInfo) must beEqualTo(authInfo).await
+      dao.find(loginInfo.copy(providerKey = "new.key")) must beSome(authInfo).await
+    }
+
+    "update an existing OAuth2 info" in new Context {
+      val updatedInfo = authInfo.copy(tokenType = Some("updated"))
+
+      dao.update(loginInfo, updatedInfo) must beEqualTo(updatedInfo).await
+      dao.find(loginInfo) must beSome(updatedInfo).await
+    }
+  }
+
+  "The `remove` method" should {
+    "remove an OAuth2 info" in new Context {
+      Await.result(dao.remove(loginInfo), 10 seconds)
+      dao.find(loginInfo) must beNone.await
+    }
+  }
+
+  /**
+   * The context.
+   */
+  trait Context extends Scope {
+
+    /**
+     * The OAuth2 info DAO implementation.
+     */
+    lazy val dao = new OAuth2InfoDAO
+
+    /**
+     * A login info.
+     */
+    lazy val loginInfo = LoginInfo("provider", "134405962728980")
+
+    /**
+     * A OAuth2 info.
+     */
+    lazy val authInfo = OAuth2Info(
+      accessToken = "my.access.token",
+      tokenType = Some("bearer"),
+      expiresIn = Some(5183836),
+      refreshToken = Some("my.refresh.token"),
+      params = Some(Map(
+        "param1" -> "value1",
+        "param2" -> "value2"
+      ))
+    )
+  }
+}

--- a/silhouette-persistence-memory/src/test/scala/com/mohiva/play/silhouette/persistence/daos/OpenIDInfoDAOSpec.scala
+++ b/silhouette-persistence-memory/src/test/scala/com/mohiva/play/silhouette/persistence/daos/OpenIDInfoDAOSpec.scala
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mohiva.play.silhouette.persistence.daos
+
+import com.mohiva.play.silhouette.api.LoginInfo
+import com.mohiva.play.silhouette.impl.providers.OpenIDInfo
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.control.NoLanguageFeatures
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+/**
+ * Test case for the [[OpenIDInfoDAO]] class.
+ */
+class OpenIDInfoDAOSpec(implicit ev: ExecutionEnv) extends Specification with NoLanguageFeatures {
+
+  "The `find` method" should {
+    "find an OAuth1 info for the given login info" in new Context {
+      Await.result(dao.save(loginInfo, authInfo), 10 seconds)
+
+      dao.find(loginInfo) must beSome(authInfo).await
+    }
+
+    "return None if no OAuth1 info for the given login info exists" in new Context {
+      dao.find(loginInfo.copy(providerKey = "new.key")) should beNone.await
+    }
+  }
+
+  "The `add` method" should {
+    "add a new OAuth1 info" in new Context {
+      dao.add(loginInfo.copy(providerKey = "new.key"), authInfo) must beEqualTo(authInfo).await
+      dao.find(loginInfo.copy(providerKey = "new.key")) must beSome(authInfo).await
+    }
+  }
+
+  "The `update` method" should {
+    "update an existing OAuth1 info" in new Context {
+      val updatedInfo = authInfo.copy(attributes = authInfo.attributes.updated("fullname", "updated"))
+
+      dao.update(loginInfo, updatedInfo) must beEqualTo(updatedInfo).await
+      dao.find(loginInfo) must beSome(updatedInfo).await
+    }
+  }
+
+  "The `save` method" should {
+    "insert a new OAuth1 info" in new Context {
+      dao.save(loginInfo.copy(providerKey = "new.key"), authInfo) must beEqualTo(authInfo).await
+      dao.find(loginInfo.copy(providerKey = "new.key")) must beSome(authInfo).await
+    }
+
+    "update an existing OAuth1 info" in new Context {
+      val updatedInfo = authInfo.copy(attributes = authInfo.attributes.updated("fullname", "updated"))
+
+      dao.update(loginInfo, updatedInfo) must beEqualTo(updatedInfo).await
+      dao.find(loginInfo) must beSome(updatedInfo).await
+    }
+  }
+
+  "The `remove` method" should {
+    "remove an OAuth1 info" in new Context {
+      Await.result(dao.remove(loginInfo), 10 seconds)
+      dao.find(loginInfo) must beNone.await
+    }
+  }
+
+  /**
+   * The context.
+   */
+  trait Context extends Scope {
+
+    /**
+     * The OAuth1 info DAO implementation.
+     */
+    lazy val dao = new OpenIDInfoDAO
+
+    /**
+     * A login info.
+     */
+    lazy val loginInfo = LoginInfo("provider", "https://me.yahoo.com/a/Xs6hPjazdrMvmbn4jhQjkjkhcasdGdsKajq9we")
+
+    /**
+     * A OAuth1 info.
+     */
+    lazy val authInfo = OpenIDInfo("https://me.yahoo.com/a/Xs6hPjazdrMvmbn4jhQjkjkhcasdGdsKajq9we", Map(
+      "fullname" -> "Apollonia Vanova",
+      "email" -> "apollonia.vanova@watchmen.com",
+      "image" -> "https://s.yimg.com/dh/ap/social/profile/profile_b48.png"
+    ))
+  }
+}

--- a/silhouette-persistence-memory/src/test/scala/com/mohiva/play/silhouette/persistence/daos/PasswordInfoDAOSpec.scala
+++ b/silhouette-persistence-memory/src/test/scala/com/mohiva/play/silhouette/persistence/daos/PasswordInfoDAOSpec.scala
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mohiva.play.silhouette.persistence.daos
+
+import com.mohiva.play.silhouette.api.LoginInfo
+import com.mohiva.play.silhouette.api.util.PasswordInfo
+import com.mohiva.play.silhouette.impl.util.BCryptPasswordHasher
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.control.NoLanguageFeatures
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+/**
+ * Test case for the [[PasswordInfoDAO]] class.
+ */
+class PasswordInfoDAOSpec(implicit ev: ExecutionEnv) extends Specification with NoLanguageFeatures {
+
+  "The `find` method" should {
+    "find an password info for the given login info" in new Context {
+      Await.result(dao.save(loginInfo, authInfo), 10 seconds)
+
+      dao.find(loginInfo) must beSome(authInfo).await
+    }
+
+    "return None if no password info for the given login info exists" in new Context {
+      dao.find(loginInfo.copy(providerKey = "new.key")) should beNone.await
+    }
+  }
+
+  "The `add` method" should {
+    "add a new password info" in new Context {
+      dao.add(loginInfo.copy(providerKey = "new.key"), authInfo) must beEqualTo(authInfo).await
+      dao.find(loginInfo.copy(providerKey = "new.key")) must beSome(authInfo).await
+    }
+  }
+
+  "The `update` method" should {
+    "update an existing password info" in new Context {
+      val updatedInfo = authInfo.copy(password = "updated")
+
+      dao.update(loginInfo, updatedInfo) must beEqualTo(updatedInfo).await
+      dao.find(loginInfo) must beSome(updatedInfo).await
+    }
+  }
+
+  "The `save` method" should {
+    "insert a new password info" in new Context {
+      dao.save(loginInfo.copy(providerKey = "new.key"), authInfo) must beEqualTo(authInfo).await
+      dao.find(loginInfo.copy(providerKey = "new.key")) must beSome(authInfo).await
+    }
+
+    "update an existing password info" in new Context {
+      val updatedInfo = authInfo.copy(password = "updated")
+
+      dao.update(loginInfo, updatedInfo) must beEqualTo(updatedInfo).await
+      dao.find(loginInfo) must beSome(updatedInfo).await
+    }
+  }
+
+  "The `remove` method" should {
+    "remove an password info" in new Context {
+      Await.result(dao.remove(loginInfo), 10 seconds)
+      dao.find(loginInfo) must beNone.await
+    }
+  }
+
+  /**
+   * The context.
+   */
+  trait Context extends Scope {
+
+    /**
+     * The password info DAO implementation.
+     */
+    lazy val dao = new PasswordInfoDAO
+
+    /**
+     * A login info.
+     */
+    lazy val loginInfo = LoginInfo("provider", "6253282")
+
+    /**
+     * A password info.
+     */
+    lazy val authInfo = PasswordInfo(
+      hasher = BCryptPasswordHasher.ID,
+      password = "$2a$10$bCBXbqjTaEcxXcjwc.kCXe.sI1b8.bTgV25gTD71KM00XdVd5MG6K"
+    )
+  }
+}

--- a/silhouette-persistence/build.sbt
+++ b/silhouette-persistence/build.sbt
@@ -1,0 +1,10 @@
+import Dependencies._
+
+libraryDependencies ++= Seq(
+  Library.Specs2.core % Test,
+  Library.Specs2.matcherExtra % Test,
+  Library.Specs2.mock % Test,
+  Library.scalaGuice % Test
+)
+
+enablePlugins(Doc)

--- a/silhouette-persistence/src/main/scala/com/mohiva/play/silhouette/persistence/daos/AuthInfoDAO.scala
+++ b/silhouette-persistence/src/main/scala/com/mohiva/play/silhouette/persistence/daos/AuthInfoDAO.scala
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mohiva.play.silhouette.persistence.daos
+
+import com.mohiva.play.silhouette.api.{ AuthInfo, LoginInfo }
+
+import scala.concurrent.Future
+
+/**
+ * The DAO to persist the auth info.
+ *
+ * @tparam T The type of the auth info to store.
+ */
+trait AuthInfoDAO[T <: AuthInfo] {
+
+  /**
+   * Finds the auth info which is linked to the specified login info.
+   *
+   * @param loginInfo The linked login info.
+   * @return The found auth info or None if no auth info could be found for the given login info.
+   */
+  def find(loginInfo: LoginInfo): Future[Option[T]]
+
+  /**
+   * Adds new auth info for the given login info.
+   *
+   * @param loginInfo The login info for which the auth info should be added.
+   * @param authInfo The auth info to add.
+   * @return The added auth info.
+   */
+  def add(loginInfo: LoginInfo, authInfo: T): Future[T]
+
+  /**
+   * Updates the auth info for the given login info.
+   *
+   * @param loginInfo The login info for which the auth info should be updated.
+   * @param authInfo The auth info to update.
+   * @return The updated auth info.
+   */
+  def update(loginInfo: LoginInfo, authInfo: T): Future[T]
+
+  /**
+   * Saves the auth info for the given login info.
+   *
+   * This method either adds the auth info if it doesn't exists or it updates the auth info
+   * if it already exists.
+   *
+   * @param loginInfo The login info for which the auth info should be saved.
+   * @param authInfo The auth info to save.
+   * @return The saved auth info.
+   */
+  def save(loginInfo: LoginInfo, authInfo: T): Future[T]
+
+  /**
+   * Removes the auth info for the given login info.
+   *
+   * @param loginInfo The login info for which the auth info should be removed.
+   * @return A future to wait for the process to be completed.
+   */
+  def remove(loginInfo: LoginInfo): Future[Unit]
+}

--- a/silhouette-persistence/src/main/scala/com/mohiva/play/silhouette/persistence/daos/DelegableAuthInfoDAO.scala
+++ b/silhouette-persistence/src/main/scala/com/mohiva/play/silhouette/persistence/daos/DelegableAuthInfoDAO.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.mohiva.play.silhouette.impl.daos
+package com.mohiva.play.silhouette.persistence.daos
 
 import com.mohiva.play.silhouette.api.AuthInfo
 
@@ -22,10 +22,10 @@ import scala.reflect.ClassTag
 /**
  * An implementation of the auth info DAO.
  *
- * This abstract implementation of the [[com.mohiva.play.silhouette.impl.daos.AuthInfoDAO]] trait
+ * This abstract implementation of the [[com.mohiva.play.silhouette.persistence.daos.AuthInfoDAO]] trait
  * allows us to get the class tag of the auth info it is responsible for. Based on the class tag
- * the [[com.mohiva.play.silhouette.impl.repositories.DelegableAuthInfoRepository]] class can
- * delegate operations to the DAO which is responsible for the currently handled auth info.
+ * the [[com.mohiva.play.silhouette.persistence.repositories.DelegableAuthInfoRepository]] class
+ * can delegate operations to the DAO which is responsible for the currently handled auth info.
  *
  * @param classTag The class tag for the type parameter.
  * @tparam T The type of the auth info to store.

--- a/silhouette-persistence/src/main/scala/com/mohiva/play/silhouette/persistence/daos/package.scala
+++ b/silhouette-persistence/src/main/scala/com/mohiva/play/silhouette/persistence/daos/package.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.mohiva.play.silhouette.impl
+package com.mohiva.play.silhouette.persistence
 
 /**
  * Provides DAO implementations to persist and retrieve objects.

--- a/silhouette-persistence/src/main/scala/com/mohiva/play/silhouette/persistence/repositories/CacheAuthenticatorRepository.scala
+++ b/silhouette-persistence/src/main/scala/com/mohiva/play/silhouette/persistence/repositories/CacheAuthenticatorRepository.scala
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.mohiva.play.silhouette.impl.daos
+package com.mohiva.play.silhouette.persistence.repositories
 
 import javax.inject.Inject
 
 import com.mohiva.play.silhouette.api.StorableAuthenticator
+import com.mohiva.play.silhouette.api.repositories.AuthenticatorRepository
 import com.mohiva.play.silhouette.api.util.CacheLayer
 
 import scala.concurrent.Future
@@ -25,13 +26,13 @@ import scala.concurrent.duration.Duration
 import scala.reflect.ClassTag
 
 /**
- * Implementation of the authenticator DAO which uses the cache layer to persist the authenticator.
+ * Implementation of the authenticator repository which uses the cache layer to persist the authenticator.
  *
  * @param cacheLayer The cache layer implementation.
  * @tparam T The type of the authenticator to store.
  */
-class CacheAuthenticatorDAO[T <: StorableAuthenticator: ClassTag] @Inject() (cacheLayer: CacheLayer)
-  extends AuthenticatorDAO[T] {
+class CacheAuthenticatorRepository[T <: StorableAuthenticator: ClassTag] @Inject() (cacheLayer: CacheLayer)
+  extends AuthenticatorRepository[T] {
 
   /**
    * Finds the authenticator for the given ID.

--- a/silhouette-persistence/src/main/scala/com/mohiva/play/silhouette/persistence/repositories/DelegableAuthInfoRepository.scala
+++ b/silhouette-persistence/src/main/scala/com/mohiva/play/silhouette/persistence/repositories/DelegableAuthInfoRepository.scala
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.mohiva.play.silhouette.impl.repositories
+package com.mohiva.play.silhouette.persistence.repositories
 
+import com.mohiva.play.silhouette.api.exceptions.ConfigurationException
 import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
 import com.mohiva.play.silhouette.api.{ AuthInfo, LoginInfo }
-import com.mohiva.play.silhouette.impl.daos.{ AuthInfoDAO, DelegableAuthInfoDAO }
-import com.mohiva.play.silhouette.impl.repositories.DelegableAuthInfoRepository._
+import com.mohiva.play.silhouette.persistence.daos.{ AuthInfoDAO, DelegableAuthInfoDAO }
+import com.mohiva.play.silhouette.persistence.repositories.DelegableAuthInfoRepository._
 
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.reflect.ClassTag
@@ -49,7 +50,7 @@ class DelegableAuthInfoRepository(daos: DelegableAuthInfoDAO[_]*)(implicit ec: E
   override def find[T <: AuthInfo](loginInfo: LoginInfo)(implicit tag: ClassTag[T]): Future[Option[T]] = {
     daos.find(_.classTag == tag) match {
       case Some(dao) => dao.find(loginInfo).map(_.map(_.asInstanceOf[T]))
-      case _ => throw new Exception(FindError.format(tag.runtimeClass))
+      case _ => throw new ConfigurationException(FindError.format(tag.runtimeClass))
     }
   }
 
@@ -64,7 +65,7 @@ class DelegableAuthInfoRepository(daos: DelegableAuthInfoDAO[_]*)(implicit ec: E
   override def add[T <: AuthInfo](loginInfo: LoginInfo, authInfo: T): Future[T] = {
     daos.find(_.classTag.runtimeClass == authInfo.getClass) match {
       case Some(dao) => dao.asInstanceOf[AuthInfoDAO[T]].add(loginInfo, authInfo)
-      case _ => throw new Exception(AddError.format(authInfo.getClass))
+      case _ => throw new ConfigurationException(AddError.format(authInfo.getClass))
     }
   }
 
@@ -79,7 +80,7 @@ class DelegableAuthInfoRepository(daos: DelegableAuthInfoDAO[_]*)(implicit ec: E
   override def update[T <: AuthInfo](loginInfo: LoginInfo, authInfo: T): Future[T] = {
     daos.find(_.classTag.runtimeClass == authInfo.getClass) match {
       case Some(dao) => dao.asInstanceOf[AuthInfoDAO[T]].update(loginInfo, authInfo)
-      case _ => throw new Exception(UpdateError.format(authInfo.getClass))
+      case _ => throw new ConfigurationException(UpdateError.format(authInfo.getClass))
     }
   }
 
@@ -96,7 +97,7 @@ class DelegableAuthInfoRepository(daos: DelegableAuthInfoDAO[_]*)(implicit ec: E
   override def save[T <: AuthInfo](loginInfo: LoginInfo, authInfo: T): Future[T] = {
     daos.find(_.classTag.runtimeClass == authInfo.getClass) match {
       case Some(dao) => dao.asInstanceOf[AuthInfoDAO[T]].save(loginInfo, authInfo)
-      case _ => throw new Exception(SaveError.format(authInfo.getClass))
+      case _ => throw new ConfigurationException(SaveError.format(authInfo.getClass))
     }
   }
 
@@ -111,7 +112,7 @@ class DelegableAuthInfoRepository(daos: DelegableAuthInfoDAO[_]*)(implicit ec: E
   override def remove[T <: AuthInfo](loginInfo: LoginInfo)(implicit tag: ClassTag[T]): Future[Unit] = {
     daos.find(_.classTag == tag) match {
       case Some(dao) => dao.remove(loginInfo)
-      case _ => throw new Exception(RemoveError.format(tag.runtimeClass))
+      case _ => throw new ConfigurationException(RemoveError.format(tag.runtimeClass))
     }
   }
 }
@@ -124,9 +125,9 @@ object DelegableAuthInfoRepository {
   /**
    * The error messages.
    */
-  val AddError = "Cannot add auth info of type: %s"
-  val FindError = "Cannot find auth info of type: %s"
-  val UpdateError = "Cannot update auth info of type: %s"
-  val SaveError = "Cannot save auth info of type: %s"
-  val RemoveError = "Cannot remove auth info of type: %s"
+  val AddError = "Cannot add auth info of type: %s; Please configure the DAO for this type"
+  val FindError = "Cannot find auth info of type: %s; Please configure the DAO for this type"
+  val UpdateError = "Cannot update auth info of type: %s; Please configure the DAO for this type"
+  val SaveError = "Cannot save auth info of type: %s; Please configure the DAO for this type"
+  val RemoveError = "Cannot remove auth info of type: %s; Please configure the DAO for this type"
 }

--- a/silhouette-persistence/src/main/scala/com/mohiva/play/silhouette/persistence/repositories/package.scala
+++ b/silhouette-persistence/src/main/scala/com/mohiva/play/silhouette/persistence/repositories/package.scala
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mohiva.play.silhouette.persistence
+
+/**
+ * Provides implementations of the repositories.
+ */
+package object repositories {}

--- a/silhouette-persistence/src/test/scala/com/mohiva/play/silhouette/persistence/daos/InMemoryAuthInfoDAOSpec.scala
+++ b/silhouette-persistence/src/test/scala/com/mohiva/play/silhouette/persistence/daos/InMemoryAuthInfoDAOSpec.scala
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mohiva.play.silhouette.persistence.daos
+
+import com.mohiva.play.silhouette.api.{ AuthInfo, LoginInfo }
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.control.NoLanguageFeatures
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+/**
+ * Test case for the [[InMemoryAuthInfoDAO]] trait.
+ */
+class InMemoryAuthInfoDAOSpec(implicit ev: ExecutionEnv) extends Specification with NoLanguageFeatures {
+
+  "The `find` method" should {
+    "find an OAuth1 info for the given login info" in new Context {
+      Await.result(dao.save(loginInfo, authInfo), 10 seconds)
+
+      dao.find(loginInfo) must beSome(authInfo).await
+    }
+
+    "return None if no OAuth1 info for the given login info exists" in new Context {
+      dao.find(loginInfo.copy(providerKey = "new.key")) should beNone.await
+    }
+  }
+
+  "The `add` method" should {
+    "add a new OAuth1 info" in new Context {
+      dao.add(loginInfo.copy(providerKey = "new.key"), authInfo) must beEqualTo(authInfo).await
+      dao.find(loginInfo.copy(providerKey = "new.key")) must beSome(authInfo).await
+    }
+  }
+
+  "The `update` method" should {
+    "update an existing OAuth1 info" in new Context {
+      val updatedInfo = authInfo.copy(data = "updated")
+
+      dao.update(loginInfo, updatedInfo) must beEqualTo(updatedInfo).await
+      dao.find(loginInfo) must beSome(updatedInfo).await
+    }
+  }
+
+  "The `save` method" should {
+    "insert a new OAuth1 info" in new Context {
+      dao.save(loginInfo.copy(providerKey = "new.key"), authInfo) must beEqualTo(authInfo).await
+      dao.find(loginInfo.copy(providerKey = "new.key")) must beSome(authInfo).await
+    }
+
+    "update an existing OAuth1 info" in new Context {
+      val updatedInfo = authInfo.copy(data = "updated")
+
+      dao.update(loginInfo, updatedInfo) must beEqualTo(updatedInfo).await
+      dao.find(loginInfo) must beSome(updatedInfo).await
+    }
+  }
+
+  "The `remove` method" should {
+    "remove an OAuth1 info" in new Context {
+      Await.result(dao.remove(loginInfo), 10 seconds)
+      dao.find(loginInfo) must beNone.await
+    }
+  }
+
+  /**
+   * The context.
+   */
+  trait Context extends Scope {
+
+    /**
+     * A test auth info implementation.
+     */
+    case class TestInfo(data: String) extends AuthInfo
+
+    /**
+     * The OAuth1 info DAO implementation.
+     */
+    lazy val dao = new InMemoryAuthInfoDAO[TestInfo] {}
+
+    /**
+     * A login info.
+     */
+    lazy val loginInfo = LoginInfo("provider", "6253282")
+
+    /**
+     * A OAuth1 info.
+     */
+    lazy val authInfo = TestInfo("my.data")
+  }
+}

--- a/silhouette-persistence/src/test/scala/com/mohiva/play/silhouette/persistence/repositories/CacheAuthenticatorRepositorySpec.scala
+++ b/silhouette-persistence/src/test/scala/com/mohiva/play/silhouette/persistence/repositories/CacheAuthenticatorRepositorySpec.scala
@@ -13,34 +13,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.mohiva.play.silhouette.impl.daos
+package com.mohiva.play.silhouette.persistence.repositories
 
 import com.mohiva.play.silhouette.api.StorableAuthenticator
 import com.mohiva.play.silhouette.api.util.CacheLayer
+import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
-import play.api.test.PlaySpecification
 
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 
 /**
- * Test case for the [[com.mohiva.play.silhouette.impl.daos.CacheAuthenticatorDAO]] class.
+ * Test case for the [[CacheAuthenticatorRepository]] class.
  */
-class CacheAuthenticatorDAOSpec extends PlaySpecification with Mockito {
+class CacheAuthenticatorRepositorySpec(implicit ev: ExecutionEnv) extends Specification with Mockito {
 
   "The `find` method" should {
     "return value from cache" in new Context {
       cacheLayer.find[StorableAuthenticator]("test-id") returns Future.successful(Some(authenticator))
 
-      await(dao.find("test-id")) must beSome(authenticator)
+      repository.find("test-id") must beSome(authenticator).await
       there was one(cacheLayer).find[StorableAuthenticator]("test-id")
     }
 
     "return None if value couldn't be found in cache" in new Context {
       cacheLayer.find[StorableAuthenticator]("test-id") returns Future.successful(None)
 
-      await(dao.find("test-id")) must beNone
+      repository.find("test-id") must beNone.await
       there was one(cacheLayer).find[StorableAuthenticator]("test-id")
     }
   }
@@ -50,7 +51,7 @@ class CacheAuthenticatorDAOSpec extends PlaySpecification with Mockito {
       authenticator.id returns "test-id"
       cacheLayer.save("test-id", authenticator, Duration.Inf) returns Future.successful(authenticator)
 
-      await(dao.add(authenticator)) must be equalTo authenticator
+      repository.add(authenticator) must beEqualTo(authenticator).await
       there was one(cacheLayer).save("test-id", authenticator, Duration.Inf)
     }
   }
@@ -60,7 +61,7 @@ class CacheAuthenticatorDAOSpec extends PlaySpecification with Mockito {
       authenticator.id returns "test-id"
       cacheLayer.save("test-id", authenticator, Duration.Inf) returns Future.successful(authenticator)
 
-      await(dao.update(authenticator)) must be equalTo authenticator
+      repository.update(authenticator) must beEqualTo(authenticator).await
       there was one(cacheLayer).save("test-id", authenticator, Duration.Inf)
     }
   }
@@ -69,7 +70,7 @@ class CacheAuthenticatorDAOSpec extends PlaySpecification with Mockito {
     "remove value from cache" in new Context {
       cacheLayer.remove("test-id") returns Future.successful(())
 
-      await(dao.remove("test-id")) must be equalTo (())
+      repository.remove("test-id") must beEqualTo(()).await
       there was one(cacheLayer).remove("test-id")
     }
   }
@@ -90,8 +91,8 @@ class CacheAuthenticatorDAOSpec extends PlaySpecification with Mockito {
     lazy val cacheLayer = mock[CacheLayer]
 
     /**
-     * The dAO to test.
+     * The repository to test.
      */
-    lazy val dao = new CacheAuthenticatorDAO[StorableAuthenticator](cacheLayer)
+    lazy val repository = new CacheAuthenticatorRepository[StorableAuthenticator](cacheLayer)
   }
 }

--- a/silhouette-testkit/app/com/mohiva/play/silhouette/test/Fakes.scala
+++ b/silhouette-testkit/app/com/mohiva/play/silhouette/test/Fakes.scala
@@ -18,10 +18,10 @@ package com.mohiva.play.silhouette.test
 import java.util.UUID
 
 import com.mohiva.play.silhouette.api._
+import com.mohiva.play.silhouette.api.repositories.AuthenticatorRepository
 import com.mohiva.play.silhouette.api.services.{ AuthenticatorService, IdentityService }
 import com.mohiva.play.silhouette.api.util.Clock
 import com.mohiva.play.silhouette.impl.authenticators._
-import com.mohiva.play.silhouette.impl.daos.AuthenticatorDAO
 import com.mohiva.play.silhouette.impl.util.{ DefaultFingerprintGenerator, SecureRandomIDGenerator }
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.mvc.RequestHeader
@@ -57,11 +57,11 @@ class FakeIdentityService[I <: Identity](identities: (LoginInfo, I)*) extends Id
 }
 
 /**
- * A fake authenticator DAO which stores authenticators in memory.
+ * A fake authenticator repository which persists authenticators in memory.
  *
  * @tparam T The type of the authenticator to handle.
  */
-class FakeAuthenticatorDAO[T <: StorableAuthenticator] extends AuthenticatorDAO[T] {
+class FakeAuthenticatorRepository[T <: StorableAuthenticator] extends AuthenticatorRepository[T] {
 
   /**
    * The data store for the OAuth1 info.
@@ -135,7 +135,7 @@ case class FakeCookieAuthenticatorService() extends CookieAuthenticatorService(
  */
 case class FakeBearerTokenAuthenticatorService() extends BearerTokenAuthenticatorService(
   new BearerTokenAuthenticatorSettings(),
-  new FakeAuthenticatorDAO[BearerTokenAuthenticator],
+  new FakeAuthenticatorRepository[BearerTokenAuthenticator],
   new SecureRandomIDGenerator(),
   Clock())
 

--- a/silhouette-testkit/build.sbt
+++ b/silhouette-testkit/build.sbt
@@ -3,8 +3,8 @@ import Dependencies._
 libraryDependencies ++= Seq(
   Library.Play.test,
   Library.Play.specs2 % Test,
-  Library.Specs2.matcherExtra % Test,
-  Library.mockito % Test,
+  Library.Play.Specs2.matcherExtra % Test,
+  Library.Play.Specs2.mock % Test,
   Library.scalaGuice % Test,
   Library.akkaTestkit % Test
 )

--- a/silhouette-testkit/test/com/mohiva/play/silhouette/test/FakesSpec.scala
+++ b/silhouette-testkit/test/com/mohiva/play/silhouette/test/FakesSpec.scala
@@ -52,11 +52,11 @@ class FakesSpec extends PlaySpecification with JsonMatchers {
     }
   }
 
-  "The `find` method of the `FakeAuthenticatorDAO`" should {
+  "The `find` method of the `FakeAuthenticatorRepository`" should {
     "return an authenticator for the given ID" in {
       val loginInfo = LoginInfo("test", "test")
       val authenticator = new FakeAuthenticator(loginInfo, "test")
-      val dao = new FakeAuthenticatorDAO[FakeAuthenticator]()
+      val dao = new FakeAuthenticatorRepository[FakeAuthenticator]()
 
       await(dao.add(authenticator))
 
@@ -64,37 +64,37 @@ class FakesSpec extends PlaySpecification with JsonMatchers {
     }
 
     "return None if no authenticator could be found for the given ID" in {
-      val dao = new FakeAuthenticatorDAO[FakeAuthenticator]()
+      val dao = new FakeAuthenticatorRepository[FakeAuthenticator]()
 
       await(dao.find("test")) must beNone
     }
   }
 
-  "The `add` method of the `FakeAuthenticatorDAO`" should {
+  "The `add` method of the `FakeAuthenticatorRepository`" should {
     "add an authenticator" in {
       val loginInfo = LoginInfo("test", "test")
       val authenticator = new FakeAuthenticator(loginInfo)
-      val dao = new FakeAuthenticatorDAO[FakeAuthenticator]()
+      val dao = new FakeAuthenticatorRepository[FakeAuthenticator]()
 
       await(dao.add(authenticator)) must be equalTo authenticator
     }
   }
 
-  "The `update` method of the `FakeAuthenticatorDAO`" should {
+  "The `update` method of the `FakeAuthenticatorRepository`" should {
     "update an authenticator" in {
       val loginInfo = LoginInfo("test", "test")
       val authenticator = new FakeAuthenticator(loginInfo)
-      val dao = new FakeAuthenticatorDAO[FakeAuthenticator]()
+      val dao = new FakeAuthenticatorRepository[FakeAuthenticator]()
 
       await(dao.update(authenticator)) must be equalTo authenticator
     }
   }
 
-  "The `remove` method of the `FakeAuthenticatorDAO`" should {
+  "The `remove` method of the `FakeAuthenticatorRepository`" should {
     "remove an authenticator" in {
       val loginInfo = LoginInfo("test", "test")
       val authenticator = new FakeAuthenticator(loginInfo, "test")
-      val dao = new FakeAuthenticatorDAO[FakeAuthenticator]()
+      val dao = new FakeAuthenticatorRepository[FakeAuthenticator]()
 
       await(dao.add(authenticator))
       await(dao.find("test")) must beSome(authenticator)

--- a/silhouette/app/com/mohiva/play/silhouette/api/repositories/AuthenticatorRepository.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/repositories/AuthenticatorRepository.scala
@@ -13,18 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.mohiva.play.silhouette.impl.daos
+package com.mohiva.play.silhouette.api.repositories
 
 import com.mohiva.play.silhouette.api.StorableAuthenticator
 
 import scala.concurrent.Future
 
 /**
- * The DAO to persist the authenticator.
+ * A trait that provides the means to persist authenticator information for the Silhouette module.
  *
  * @tparam T The type of the authenticator to store.
  */
-trait AuthenticatorDAO[T <: StorableAuthenticator] {
+trait AuthenticatorRepository[T <: StorableAuthenticator] {
 
   /**
    * Finds the authenticator for the given ID.

--- a/silhouette/build.sbt
+++ b/silhouette/build.sbt
@@ -7,8 +7,8 @@ libraryDependencies ++= Seq(
   Library.jwtCore,
   Library.jwtApi,
   Library.Play.specs2 % Test,
-  Library.Specs2.matcherExtra % Test,
-  Library.mockito % Test,
+  Library.Play.Specs2.matcherExtra % Test,
+  Library.Play.Specs2.mock % Test,
   Library.scalaGuice % Test,
   Library.akkaTestkit % Test
 )


### PR DESCRIPTION
It's often misleading that the persistence based API is integrated into the core project, because it's not really required by the core. The provides API is only one possible implementation which helps to start a new application quicker. Therefore this pull request moves the persistence based API into a separate project and provides a in-memory implementation for the auth info implementations. It's now also possible to provide different drop-in replacements for the persistence layer instead of creating a separate seed template for every persistence type(reactivemongo, slick, ...).