### PR TITLE
Add a new action type that restricts access for authenticated users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - A controller is not bound to a single Authenticator anymore
 - Remove SecuredErrorHandler in favour of injectable error handler
 - Pass the auth info to the profile parsers to easier query additional data from the provider API
+- Add UnsecuredRequestHandler and UnsecuredAction
 
 ## 3.0 (2015-07-14)
 

--- a/silhouette/app/com/mohiva/play/silhouette/api/RequestHandler.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/RequestHandler.scala
@@ -48,6 +48,13 @@ case class HandlerResult[+T](result: Result, data: Option[T] = None)
 trait RequestHandlerBuilder[E <: Env, +R[_]] extends ExecutionContextProvider {
 
   /**
+   * Provides an `extract` method on an `Either` which contains the same types.
+   */
+  protected implicit class ExtractEither[T](r: Either[T, T]) {
+    def extract: T = r.fold(identity, identity)
+  }
+
+  /**
    * The execution context to handle the asynchronous operations.
    */
   implicit lazy val executionContext = environment.executionContext

--- a/silhouette/app/com/mohiva/play/silhouette/api/Silhouette.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/Silhouette.scala
@@ -1,4 +1,18 @@
-
+/**
+ * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mohiva.play.silhouette.api
 
 import javax.inject.Inject
@@ -25,6 +39,11 @@ trait Silhouette[E <: Env] {
   val securedAction: SecuredAction
 
   /**
+   * The unsecured action stack.
+   */
+  val unsecuredAction: UnsecuredAction
+
+  /**
    * The user aware action stack.
    */
   val userAwareAction: UserAwareAction
@@ -42,6 +61,20 @@ trait Silhouette[E <: Env] {
    * @return The secured request handler implementation.
    */
   def SecuredRequestHandler: SecuredRequestHandlerBuilder[E] = securedAction.requestHandler(env)
+
+  /**
+   * Provides the unsecured action implementation.
+   *
+   * @return The unsecured action implementation.
+   */
+  def UnsecuredAction: UnsecuredActionBuilder[E] = unsecuredAction(env)
+
+  /**
+   * Provides the unsecured request handler implementation.
+   *
+   * @return The unsecured request handler implementation.
+   */
+  def UnsecuredRequestHandler: UnsecuredRequestHandlerBuilder[E] = unsecuredAction.requestHandler(env)
 
   /**
    * Provides the user-aware action implementation.
@@ -69,5 +102,6 @@ trait Silhouette[E <: Env] {
 class SilhouetteProvider[E <: Env] @Inject() (
   val env: Environment[E],
   val securedAction: SecuredAction,
+  val unsecuredAction: UnsecuredAction,
   val userAwareAction: UserAwareAction)
   extends Silhouette[E]

--- a/silhouette/app/com/mohiva/play/silhouette/api/actions/SecuredAction.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/actions/SecuredAction.scala
@@ -56,13 +56,6 @@ case class SecuredRequestHandlerBuilder[E <: Env](
   extends RequestHandlerBuilder[E, ({ type R[B] = SecuredRequest[E, B] })#R] {
 
   /**
-   * Provides an `extract` method on an `Either` which contains the same types.
-   */
-  private implicit class ExtractEither[T](r: Either[T, T]) {
-    def extract: T = r.fold(identity, identity)
-  }
-
-  /**
    * Creates a secured action handler builder with a new error handler in place.
    *
    * @param errorHandler An error handler instance.

--- a/silhouette/app/com/mohiva/play/silhouette/api/actions/UnsecuredAction.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/actions/UnsecuredAction.scala
@@ -1,0 +1,253 @@
+/**
+ * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mohiva.play.silhouette.api.actions
+
+import javax.inject.Inject
+
+import com.mohiva.play.silhouette.api._
+import play.api.i18n.MessagesApi
+import play.api.inject.Module
+import play.api.mvc.{ ActionBuilder, Request, Result }
+import play.api.{ Configuration, Environment => PlayEnv }
+
+import scala.concurrent.Future
+
+/**
+ * Request handler builder implementation to provide the foundation for unsecured request handlers.
+ *
+ * @param environment The environment instance to handle the request.
+ * @param errorHandler The instance of the unsecured error handler.
+ * @tparam E The type of the environment.
+ */
+case class UnsecuredRequestHandlerBuilder[E <: Env](
+  environment: Environment[E],
+  errorHandler: UnsecuredErrorHandler)
+  extends RequestHandlerBuilder[E, Request] {
+
+  /**
+   * Creates an unsecured action handler builder with a new error handler in place.
+   *
+   * @param errorHandler An error handler instance.
+   * @return An unsecured action handler builder with a new error handler in place.
+   */
+  def apply(errorHandler: UnsecuredErrorHandler) = UnsecuredRequestHandlerBuilder[E](environment, errorHandler)
+
+  /**
+   * Invokes the block.
+   *
+   * @param block The block of code to invoke.
+   * @param request The current request.
+   * @tparam B The type of the request body.
+   * @tparam T The type of the data included in the handler result.
+   * @return A handler result.
+   */
+  override def invokeBlock[B, T](block: Request[B] => Future[HandlerResult[T]])(implicit request: Request[B]) = {
+    handleAuthentication.flatMap {
+      // A user is authenticated. The request will be forbidden
+      case (Some(authenticator), Some(identity)) =>
+        environment.eventBus.publish(NotAuthorizedEvent(identity, request))
+        handleBlock(authenticator, _ => errorHandler.onNotAuthorized.map(r => HandlerResult(r)))
+      // An authenticator but no user was found. The request will be granted and the authenticator will be discarded
+      case (Some(authenticator), None) =>
+        block(request).flatMap {
+          case hr @ HandlerResult(pr, d) =>
+            environment.authenticatorService.discard(authenticator.extract, pr).map(r => hr.copy(r))
+        }
+      // No authenticator and no user was found. The request will be granted
+      case _ => block(request)
+    }
+  }
+}
+
+/**
+ * An unsecured request handler.
+ *
+ * A handler which intercepts requests and checks if there is no authenticated user.
+ * If there is none, the execution continues and the enclosed code is invoked.
+ *
+ * If the user is authenticated, the request is forwarded to
+ * the [[com.mohiva.play.silhouette.api.actions.UnsecuredErrorHandler.onNotAuthorized]] method.
+ */
+trait UnsecuredRequestHandler {
+
+  /**
+   * The instance of the unsecured error handler.
+   */
+  val errorHandler: UnsecuredErrorHandler
+
+  /**
+   * Applies the environment to the request handler stack.
+   *
+   * @param environment The environment instance to handle the request.
+   * @tparam E The type of the environment.
+   * @return An unsecured request handler builder.
+   */
+  def apply[E <: Env](environment: Environment[E]): UnsecuredRequestHandlerBuilder[E]
+}
+
+/**
+ * Default implementation of the [[UnsecuredRequestHandler]].
+ *
+ * @param errorHandler The instance of the unsecured error handler.
+ */
+class DefaultUnsecuredRequestHandler @Inject() (val errorHandler: UnsecuredErrorHandler)
+  extends UnsecuredRequestHandler {
+
+  /**
+   * Applies the environment to the request handler stack.
+   *
+   * @param environment The environment instance to handle the request.
+   * @tparam E The type of the environment.
+   * @return A unsecured request handler builder.
+   */
+  override def apply[E <: Env](environment: Environment[E]) =
+    UnsecuredRequestHandlerBuilder[E](environment, errorHandler)
+}
+
+/**
+ * Action builder implementation to provide the foundation for unsecured actions.
+ *
+ * @param requestHandler The request handler instance.
+ * @tparam E The type of the environment.
+ */
+case class UnsecuredActionBuilder[E <: Env](requestHandler: UnsecuredRequestHandlerBuilder[E])
+  extends ActionBuilder[Request] {
+
+  /**
+   * Creates a unsecured action builder with a new error handler in place.
+   *
+   * @param errorHandler An error handler instance.
+   * @return A unsecured action builder.
+   */
+  def apply(errorHandler: UnsecuredErrorHandler) = UnsecuredActionBuilder[E](requestHandler(errorHandler))
+
+  /**
+   * Invokes the block.
+   *
+   * @param request The current request.
+   * @param block The block of code to invoke.
+   * @tparam B The type of the request body.
+   * @return A handler result.
+   */
+  override def invokeBlock[B](request: Request[B], block: Request[B] => Future[Result]) = {
+    implicit val ec = executionContext
+    implicit val req = request
+    val b = (r: Request[B]) => block(r).map(r => HandlerResult(r))
+
+    requestHandler(request)(b).map(_.result).recoverWith(requestHandler.errorHandler.exceptionHandler)
+  }
+}
+
+/**
+ * An action based on the [[UnsecuredRequestHandler]].
+ */
+trait UnsecuredAction {
+
+  /**
+   * The instance of the unsecured request handler.
+   */
+  val requestHandler: UnsecuredRequestHandler
+
+  /**
+   * Applies the environment to the action stack.
+   *
+   * @param environment The environment instance to handle the request.
+   * @tparam E The type of the environment.
+   * @return An unsecured action builder.
+   */
+  def apply[E <: Env](environment: Environment[E]): UnsecuredActionBuilder[E]
+}
+
+/**
+ * Default implementation of the [[UnsecuredAction]].
+ *
+ * @param requestHandler The instance of the unsecured request handler.
+ */
+class DefaultUnsecuredAction @Inject() (val requestHandler: UnsecuredRequestHandler) extends UnsecuredAction {
+
+  /**
+   * Applies the environment to the action stack.
+   *
+   * @param environment The environment instance to handle the request.
+   * @tparam E The type of the environment.
+   * @return An unsecured action builder.
+   */
+  override def apply[E <: Env](environment: Environment[E]) = UnsecuredActionBuilder[E](requestHandler[E](environment))
+}
+
+/**
+ * Error handler for unsecured actions.
+ */
+trait UnsecuredErrorHandler extends NotAuthorizedErrorHandler
+
+/**
+ * Default implementation of the [[UnsecuredErrorHandler]].
+ *
+ * @param messagesApi The Play messages API.
+ */
+class DefaultUnsecuredErrorHandler @Inject() (val messagesApi: MessagesApi)
+  extends UnsecuredErrorHandler
+  with DefaultNotAuthorizedErrorHandler
+
+/**
+ * Play module for providing the unsecured action components.
+ */
+class UnsecuredActionModule extends Module {
+  def bindings(environment: PlayEnv, configuration: Configuration) = {
+    Seq(
+      bind[UnsecuredAction].to[DefaultUnsecuredAction],
+      bind[UnsecuredRequestHandler].to[DefaultUnsecuredRequestHandler]
+    )
+  }
+}
+
+/**
+ * Play module to provide the unsecured error handler component.
+ *
+ * We provide an extra module so that it can be easily replaced with a custom implementation
+ * without to declare bindings for the other unsecured action module.
+ */
+class UnsecuredErrorHandlerModule extends Module {
+  def bindings(environment: PlayEnv, configuration: Configuration) = {
+    Seq(
+      bind[UnsecuredErrorHandler].to[DefaultUnsecuredErrorHandler]
+    )
+  }
+}
+
+/**
+ * Injection helper for unsecured action components
+ */
+trait UnsecuredActionComponents {
+
+  def unsecuredErrorHandler: UnsecuredErrorHandler
+
+  lazy val unsecuredRequestHandler: UnsecuredRequestHandler = new DefaultUnsecuredRequestHandler(unsecuredErrorHandler)
+  lazy val unsecuredAction: UnsecuredAction = new DefaultUnsecuredAction(unsecuredRequestHandler)
+}
+
+/**
+ * Injection helper for unsecured error handler component.
+ *
+ * We provide an extra component so that it can be easily replaced with a custom implementation
+ * without to declare bindings for the other secured action component.
+ */
+trait UnsecuredErrorHandlerComponents {
+
+  def messagesApi: MessagesApi
+
+  lazy val unsecuredErrorHandler: UnsecuredErrorHandler = new DefaultUnsecuredErrorHandler(messagesApi)
+}

--- a/silhouette/app/com/mohiva/play/silhouette/api/actions/UserAwareAction.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/actions/UserAwareAction.scala
@@ -51,13 +51,6 @@ case class UserAwareRequestHandlerBuilder[E <: Env](environment: Environment[E])
   extends RequestHandlerBuilder[E, ({ type R[B] = UserAwareRequest[E, B] })#R] {
 
   /**
-   * Provides an `extract` method on an `Either` which contains the same types.
-   */
-  private implicit class ExtractEither[T](r: Either[T, T]) {
-    def extract: T = r.fold(identity, identity)
-  }
-
-  /**
    * Invokes the block.
    *
    * @param block The block of code to invoke.

--- a/silhouette/conf/reference.conf
+++ b/silhouette/conf/reference.conf
@@ -8,4 +8,6 @@ play.crypto.secret="1s`20s2deE$r;Io]w^fpx:x^HEQ9eyeF7H:MS10iGOxdh1GH5p/hDw=Sq[ie
 # ~~~~~
 play.modules.enabled += "com.mohiva.play.silhouette.api.actions.SecuredActionModule"
 play.modules.enabled += "com.mohiva.play.silhouette.api.actions.SecuredErrorHandlerModule"
+play.modules.enabled += "com.mohiva.play.silhouette.api.actions.UnsecuredActionModule"
+play.modules.enabled += "com.mohiva.play.silhouette.api.actions.UnsecuredErrorHandlerModule"
 play.modules.enabled += "com.mohiva.play.silhouette.api.actions.UserAwareActionModule"

--- a/silhouette/test/com/mohiva/play/silhouette/api/actions/SecuredActionSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/api/actions/SecuredActionSpec.scala
@@ -444,7 +444,7 @@ class SecuredActionSpec extends PlaySpecification with Mockito with JsonMatchers
     }
   }
 
-  "The `SecureRequestHandler`" should {
+  "The `SecuredRequestHandler`" should {
     "return status 401 if authentication was not successful" in new InjectorContext {
       new WithApplication(app) with Context {
         env.authenticatorService.retrieve(any) returns Future.successful(None)

--- a/silhouette/test/com/mohiva/play/silhouette/api/actions/UnsecuredActionSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/api/actions/UnsecuredActionSpec.scala
@@ -1,0 +1,414 @@
+/**
+ * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mohiva.play.silhouette.api.actions
+
+import javax.inject.Inject
+
+import akka.actor.{ Actor, Props }
+import akka.testkit.TestProbe
+import com.mohiva.play.silhouette.api._
+import com.mohiva.play.silhouette.api.actions.UnsecuredActionSpec._
+import com.mohiva.play.silhouette.api.exceptions.NotAuthorizedException
+import com.mohiva.play.silhouette.api.services.{ AuthenticatorResult, AuthenticatorService, IdentityService }
+import net.codingwell.scalaguice.ScalaModule
+import org.specs2.control.NoLanguageFeatures
+import org.specs2.matcher.JsonMatchers
+import org.specs2.mock.Mockito
+import org.specs2.specification.Scope
+import play.api.i18n.{ Lang, Messages, MessagesApi }
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.concurrent.Akka
+import play.api.libs.concurrent.Execution.Implicits._
+import play.api.mvc.Results._
+import play.api.mvc._
+import play.api.test.{ FakeRequest, PlaySpecification, WithApplication }
+
+import scala.concurrent.Future
+import scala.language.postfixOps
+import scala.reflect.ClassTag
+
+/**
+ * Test case for the [[com.mohiva.play.silhouette.api.actions.UnsecuredActionSpec]].
+ */
+class UnsecuredActionSpec extends PlaySpecification with Mockito with JsonMatchers with NoLanguageFeatures {
+
+  "The `UnsecuredAction` action" should {
+    "grant access if no valid authenticator can be retrieved" in new InjectorContext {
+      new WithApplication(app) with Context {
+        env.authenticatorService.retrieve(any) returns Future.successful(None)
+
+        val result = controller.defaultAction(request)
+
+        status(result) must equalTo(OK)
+        contentAsString(result) must contain("full.access")
+      }
+    }
+
+    "grant access and discard authenticator if an invalid authenticator can be retrieved" in new InjectorContext {
+      new WithApplication(app) with Context {
+        env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator.copy(isValid = false)))
+        env.authenticatorService.discard(any, any)(any) answers { (a, m) =>
+          Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
+        }
+
+        val result = controller.defaultAction(request)
+
+        status(result) must equalTo(OK)
+        contentAsString(result) must contain("full.access")
+        there was one(env.authenticatorService).discard(any, any)(any)
+      }
+    }
+
+    "grant access and discard authenticator if no identity could be found for an authenticator" in new InjectorContext {
+      new WithApplication(app) with Context {
+        env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
+        env.authenticatorService.discard(any, any)(any) answers { (a, m) =>
+          Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
+        }
+        env.identityService.retrieve(identity.loginInfo) returns Future.successful(None)
+
+        val result = controller.defaultAction(request)
+
+        status(result) must equalTo(OK)
+        contentAsString(result) must contain("full.access")
+        there was one(env.authenticatorService).discard(any, any)(any)
+      }
+    }
+
+    "display local not-authorized result if user is authenticated" in new InjectorContext {
+      new WithApplication(app) with Context {
+        env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
+        env.authenticatorService.touch(any) returns Left(authenticator)
+        env.authenticatorService.update(any, any)(any) answers { (a, m) =>
+          Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
+        }
+        env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
+
+        val result = controller.actionWithErrorHandler(request)
+
+        status(result) must equalTo(FORBIDDEN)
+        contentAsString(result) must contain("local.not.authorized")
+      }
+    }
+
+    "display global not-authorized result if user is authenticated" in new InjectorContext {
+      new WithApplication(app) with Context {
+        env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
+        env.authenticatorService.touch(any) returns Left(authenticator)
+        env.authenticatorService.update(any, any)(any) answers { (a, m) =>
+          Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
+        }
+        env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
+
+        val result = controller.defaultAction(request)
+
+        status(result) must equalTo(FORBIDDEN)
+        contentAsString(result) must contain("global.not.authorized")
+      }
+    }
+  }
+
+  "The `UnsecuredRequestHandler`" should {
+    "return status 403 if user is authenticated" in new InjectorContext {
+      new WithApplication(app) with Context {
+        env.authenticatorService.retrieve(any) returns Future.successful(Some(authenticator))
+        env.authenticatorService.touch(any) returns Left(authenticator)
+        env.authenticatorService.update(any, any)(any) answers { (a, m) =>
+          Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
+        }
+        env.identityService.retrieve(identity.loginInfo) returns Future.successful(Some(identity))
+
+        val result = controller.defaultHandler(request)
+
+        status(result) must equalTo(FORBIDDEN)
+        there was one(env.authenticatorService).touch(any)
+        there was one(env.authenticatorService).update(any, any)(any)
+      }
+    }
+
+    "return the data if user is not authenticated" in new InjectorContext {
+      new WithApplication(app) with Context {
+        env.authenticatorService.retrieve(any) returns Future.successful(None)
+
+        val result = controller.defaultHandler(request)
+
+        status(result) must equalTo(OK)
+        contentAsString(result) must be equalTo "data"
+        there was no(env.authenticatorService).touch(any)
+        there was no(env.authenticatorService).update(any, any)(any)
+      }
+    }
+  }
+
+  "The `exceptionHandler` method of the UnsecuredErrorHandler" should {
+    "translate an ForbiddenException into a 403 Forbidden result" in new InjectorContext {
+      new WithApplication(app) with Context {
+        env.authenticatorService.retrieve(any) returns Future.successful(None)
+        env.authenticatorService.discard(any, any)(any) answers { (a, m) =>
+          Future.successful(AuthenticatorResult(a.asInstanceOf[Array[Any]](1).asInstanceOf[Result]))
+        }
+
+        val failed = Future.failed(new NotAuthorizedException("Access denied"))
+        val result = controller.recover(failed)
+
+        status(result) must equalTo(FORBIDDEN)
+      }
+    }
+  }
+
+  /**
+   * The injector context.
+   */
+  trait InjectorContext extends Scope {
+
+    /**
+     * The Silhouette environment.
+     */
+    lazy val env = Environment[UnsecuredEnv](
+      mock[IdentityService[UnsecuredEnv#I]],
+      mock[AuthenticatorService[UnsecuredEnv#A]],
+      Seq(),
+      new EventBus
+    )
+
+    /**
+     * The guice application builder.
+     */
+    lazy val app = new GuiceApplicationBuilder()
+      .bindings(new GuiceModule)
+      .overrides(bind[UnsecuredErrorHandler].to[GlobalUnsecuredErrorHandler])
+      .build()
+
+    /**
+     * The guice module.
+     */
+    class GuiceModule extends ScalaModule {
+      def configure(): Unit = {
+        bind[Environment[UnsecuredEnv]].toInstance(env)
+        bind[Silhouette[UnsecuredEnv]].to[SilhouetteProvider[UnsecuredEnv]]
+        bind[UnsecuredController]
+      }
+    }
+
+    /**
+     * The context.
+     */
+    trait Context {
+      self: WithApplication =>
+
+      /**
+       * An identity.
+       */
+      lazy val identity = new FakeIdentity(LoginInfo("test", "1"))
+
+      /**
+       * An authenticator.
+       */
+      lazy val authenticator = new FakeAuthenticator(LoginInfo("test", "1"))
+
+      /**
+       * A fake request.
+       */
+      lazy implicit val request = FakeRequest()
+
+      /**
+       * The messages API.
+       */
+      lazy implicit val messagesApi = app.injector.instanceOf[MessagesApi]
+
+      /**
+       * The unsecured controller.
+       */
+      lazy implicit val controller = app.injector.instanceOf[UnsecuredController]
+
+      /**
+       * The messages for the current language.
+       */
+      lazy implicit val messages = Messages(Lang.defaultLang, messagesApi)
+
+      /**
+       * The Play actor system.
+       */
+      lazy implicit val system = Akka.system
+
+      /**
+       * The test probe.
+       */
+      lazy val theProbe = TestProbe()
+
+      /**
+       * Executes a block after event bus initialization, so that the event can be handled inside the given block.
+       *
+       * @param ct The class tag of the event.
+       * @tparam T The type of the event to handle.
+       * @return The result of the block.
+       */
+      def withEvent[T <: SilhouetteEvent](block: => Any)(implicit ct: ClassTag[T]) = {
+        val listener = system.actorOf(Props(new Actor {
+          def receive = {
+            case e: T => theProbe.ref ! e
+          }
+        }))
+
+        env.eventBus.subscribe(listener, ct.runtimeClass.asInstanceOf[Class[T]])
+
+        block
+      }
+    }
+  }
+
+  /**
+   * Adds some request providers in scope.
+   *
+   * We add two providers in scope to test the chaining of this providers.
+   */
+  trait WithRequestProvider {
+    self: InjectorContext =>
+
+    /**
+     * A mock that simulates a token request provider.
+     */
+    lazy val tokenRequestProvider = mock[RequestProvider]
+
+    /**
+     * A mock that simulates a basic auth request provider.
+     */
+    lazy val basicAuthRequestProvider = mock[RequestProvider]
+
+    /**
+     * A non request provider.
+     */
+    lazy val nonRequestProvider = mock[RequestProvider]
+
+    /**
+     * The Silhouette environment.
+     */
+    override lazy val env = Environment[UnsecuredEnv](
+      mock[IdentityService[FakeIdentity]],
+      mock[AuthenticatorService[FakeAuthenticator]],
+      Seq(
+        tokenRequestProvider,
+        basicAuthRequestProvider,
+        nonRequestProvider
+      ),
+      new EventBus
+    )
+  }
+}
+
+/**
+ * The companion object.
+ */
+object UnsecuredActionSpec {
+
+  /**
+   * The environment type.
+   */
+  trait UnsecuredEnv extends Env {
+    type I = FakeIdentity
+    type A = FakeAuthenticator
+  }
+
+  /**
+   * A test identity.
+   *
+   * @param loginInfo The linked login info.
+   */
+  case class FakeIdentity(loginInfo: LoginInfo) extends Identity
+
+  /**
+   * A test authenticator.
+   *
+   * @param loginInfo The linked login info.
+   */
+  case class FakeAuthenticator(loginInfo: LoginInfo, isValid: Boolean = true) extends Authenticator
+
+  /**
+   * The global unsecured error handler.
+   */
+  class GlobalUnsecuredErrorHandler extends UnsecuredErrorHandler {
+
+    /**
+     * Called when a user is authenticated but not authorized.
+     *
+     * As defined by RFC 2616, the status code of the response should be 403 Forbidden.
+     *
+     * @param request The request header.
+     * @return The result to send to the client.
+     */
+    def onNotAuthorized(implicit request: RequestHeader) = {
+      Future.successful(Forbidden("global.not.authorized"))
+    }
+  }
+
+  /**
+   * An unsecured controller.
+   *
+   * @param silhouette The Silhouette stack.
+   */
+  class UnsecuredController @Inject() (silhouette: Silhouette[UnsecuredEnv])
+    extends Controller {
+
+    /**
+     * A local error handler.
+     */
+    lazy val errorHandler = new UnsecuredErrorHandler {
+      override def onNotAuthorized(implicit request: RequestHeader) = {
+        Future.successful(Forbidden("local.not.authorized"))
+      }
+    }
+
+    /**
+     * An unsecured action.
+     *
+     * @return The result to send to the client.
+     */
+    def defaultAction = silhouette.UnsecuredAction { implicit request =>
+      Ok("full.access")
+    }
+
+    /**
+     * An unsecured action with a custom error handler.
+     *
+     * @return The result to send to the client.
+     */
+    def actionWithErrorHandler = silhouette.UnsecuredAction(errorHandler) { Ok("full.access") }
+
+    /**
+     * An unsecured request handler.
+     */
+    def defaultHandler = Action.async { implicit request =>
+      silhouette.UnsecuredRequestHandler { _ =>
+        Future.successful(HandlerResult(Ok, Some("data")))
+      }.map {
+        case HandlerResult(r, Some(data)) => Ok(data)
+        case HandlerResult(r, None) => Forbidden
+      }
+    }
+
+    /**
+     * Method to test the `exceptionHandler` method of the [[UnsecuredErrorHandler]].
+     *
+     * @param f The future to recover from.
+     * @param request The request header.
+     * @return The result to send to the client.
+     */
+    def recover(f: Future[Result])(implicit request: RequestHeader): Future[Result] = {
+      f.recoverWith(silhouette.UnsecuredAction.requestHandler.errorHandler.exceptionHandler)
+    }
+  }
+}


### PR DESCRIPTION
It should be possible for an application to restrict access to an action for already authenticated users. If a user is already signed-in then it shouldn't possible for the user to access the sign-in or sign-up page. Instead he should be redirected to another page.