### PR TITLE
Use request extractors to find authenticator values in other parts of the request

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/api/services/AuthenticatorService.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/services/AuthenticatorService.scala
@@ -19,7 +19,7 @@
  */
 package com.mohiva.play.silhouette.api.services
 
-import com.mohiva.play.silhouette.api.util.ExecutionContextProvider
+import com.mohiva.play.silhouette.api.util.{ ExtractableRequest, ExecutionContextProvider }
 import com.mohiva.play.silhouette.api.{ Authenticator, LoginInfo }
 import play.api.libs.iteratee.Enumerator
 import play.api.mvc._
@@ -95,10 +95,11 @@ trait AuthenticatorService[T <: Authenticator] extends ExecutionContextProvider 
   /**
    * Retrieves the authenticator from request.
    *
-   * @param request The request header.
+   * @param request The request to retrieve the authenticator from.
+   * @tparam B The type of the request body.
    * @return Some authenticator or None if no authenticator could be found in request.
    */
-  def retrieve(implicit request: RequestHeader): Future[Option[T]]
+  def retrieve[B](implicit request: ExtractableRequest[B]): Future[Option[T]]
 
   /**
    * Initializes an authenticator and instead of embedding into the the request or result, it returns

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticator.scala
@@ -182,10 +182,11 @@ class CookieAuthenticatorService(
   /**
    * Retrieves the authenticator from request.
    *
-   * @param request The request header.
+   * @param request The request to retrieve the authenticator from.
+   * @tparam B The type of the request body.
    * @return Some authenticator or None if no authenticator could be found in request.
    */
-  override def retrieve(implicit request: RequestHeader): Future[Option[CookieAuthenticator]] = {
+  override def retrieve[B](implicit request: ExtractableRequest[B]): Future[Option[CookieAuthenticator]] = {
     Future.fromTry(Try {
       if (settings.useFingerprinting) Some(fingerprintGenerator.generate) else None
     }).flatMap { fingerprint =>

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/DummyAuthenticator.scala
@@ -16,6 +16,7 @@
 package com.mohiva.play.silhouette.impl.authenticators
 
 import com.mohiva.play.silhouette.api.services.{ AuthenticatorResult, AuthenticatorService }
+import com.mohiva.play.silhouette.api.util.ExtractableRequest
 import com.mohiva.play.silhouette.api.{ Authenticator, LoginInfo }
 import play.api.mvc.{ RequestHeader, Result }
 
@@ -69,10 +70,11 @@ class DummyAuthenticatorService(implicit val executionContext: ExecutionContext)
    * a request provider grants access. If the authentication with a request provider has failed,
    * then this method must return None to not grant access to the resource.
    *
-   * @param request The request header.
+   * @param request The request to retrieve the authenticator from.
+   * @tparam B The type of the request body.
    * @return Always None because .
    */
-  override def retrieve(implicit request: RequestHeader): Future[Option[DummyAuthenticator]] = {
+  override def retrieve[B](implicit request: ExtractableRequest[B]): Future[Option[DummyAuthenticator]] = {
     Future.successful(None)
   }
 

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticator.scala
@@ -19,7 +19,7 @@ import com.mohiva.play.silhouette.api.Authenticator.Implicits._
 import com.mohiva.play.silhouette.api.exceptions._
 import com.mohiva.play.silhouette.api.services.AuthenticatorService._
 import com.mohiva.play.silhouette.api.services.{ AuthenticatorResult, AuthenticatorService }
-import com.mohiva.play.silhouette.api.util.{ Base64, Clock, FingerprintGenerator }
+import com.mohiva.play.silhouette.api.util.{ ExtractableRequest, Base64, Clock, FingerprintGenerator }
 import com.mohiva.play.silhouette.api.util.JsonFormats._
 import com.mohiva.play.silhouette.api.{ Authenticator, ExpirableAuthenticator, Logger, LoginInfo }
 import com.mohiva.play.silhouette.impl.authenticators.SessionAuthenticatorService._
@@ -158,10 +158,11 @@ class SessionAuthenticatorService(
   /**
    * Retrieves the authenticator from request.
    *
-   * @param request The request header.
+   * @param request The request to retrieve the authenticator from.
+   * @tparam B The type of the request body.
    * @return Some authenticator or None if no authenticator could be found in request.
    */
-  override def retrieve(implicit request: RequestHeader): Future[Option[SessionAuthenticator]] = {
+  override def retrieve[B](implicit request: ExtractableRequest[B]): Future[Option[SessionAuthenticator]] = {
     Future.fromTry(Try {
       if (settings.useFingerprinting) Some(fingerprintGenerator.generate) else None
     }).map { fingerprint =>

--- a/silhouette/test/com/mohiva/play/silhouette/api/util/Base64Spec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/api/util/Base64Spec.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mohiva.play.silhouette.api.util
 
 import play.api.libs.json.Json

--- a/silhouette/test/com/mohiva/play/silhouette/api/util/ClockSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/api/util/ClockSpec.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mohiva.play.silhouette.api.util
 
 import org.joda.time.DateTime

--- a/silhouette/test/com/mohiva/play/silhouette/api/util/PlayHTTPLayerSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/api/util/PlayHTTPLayerSpec.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mohiva.play.silhouette.api.util
 
 import play.api.libs.concurrent.Execution.Implicits._

--- a/silhouette/test/com/mohiva/play/silhouette/api/util/RequestExtractorSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/api/util/RequestExtractorSpec.scala
@@ -1,8 +1,23 @@
+/**
+ * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mohiva.play.silhouette.api.util
 
 import org.specs2.specification.Scope
 import play.api.libs.json.{ JsValue, Json }
-import play.api.mvc.Request
+import play.api.mvc.{ AnyContentAsEmpty, Request }
 import play.api.test._
 
 /**
@@ -19,127 +34,272 @@ class RequestExtractorSpec extends PlaySpecification {
      * Tries to extract the value from Json body.
      */
     implicit val jsonExtractor = new RequestExtractor[JsValue] {
-      def extractString(name: String)(implicit request: Request[JsValue]) = {
+      def extractString(name: String, parts: Option[Parts] = None)(implicit request: Request[JsValue]) = {
         request.body.\("test").\(name).asOpt[String]
       }
     }
   }
 
   "The `anyContent`" should {
-    "extract a value from query string" in new Context {
+    "extract a value from query string if all parts are allowed" in new Context {
       implicit val request = FakeRequest("GET", "?code=value")
 
       extract("code") must beSome("value")
     }
 
-    "return None if no value could be found in query string" in new Context {
-      implicit val request = FakeRequest()
+    "extract a value from query string if part is allowed" in new Context {
+      implicit val request = FakeRequest("GET", "?code=value")
+
+      extract("code", Some(Seq(RequestPart.QueryString))) must beSome("value")
+    }
+
+    "do not extract a value from query string if part isn't allowed" in new Context {
+      implicit val request = FakeRequest("GET", "?code=value")
+
+      extract("code", Some(Seq())) must beNone
+    }
+
+    "extract a value from headers if all parts are allowed" in new Context {
+      implicit val request = FakeRequest().withHeaders("code" -> "value")
+
+      extract("code") must beSome("value")
+    }
+
+    "extract a value from headers if part is allowed" in new Context {
+      implicit val request = FakeRequest().withHeaders("code" -> "value")
+
+      extract("code", Some(Seq(RequestPart.Headers))) must beSome("value")
+    }
+
+    "do not extract a value from headers if part isn't allowed" in new Context {
+      implicit val request = FakeRequest().withHeaders("code" -> "value")
+
+      extract("code", Some(Seq())) must beNone
+    }
+
+    "extract a value from tags if all parts are allowed" in new Context {
+      implicit val request = FakeRequest.apply(Map("code" -> "value"))
+
+      extract("code") must beSome("value")
+    }
+
+    "extract a value from tags if part is allowed" in new Context {
+      implicit val request = FakeRequest.apply(Map("code" -> "value"))
+
+      extract("code", Some(Seq(RequestPart.Tags))) must beSome("value")
+    }
+
+    "do not extract a value from tags if part isn't allowed" in new Context {
+      implicit val request = FakeRequest.apply(Map("code" -> "value"))
+
+      extract("code", Some(Seq())) must beNone
+    }
+
+    "return None if no value could be found in default parts" in new Context {
+      implicit val request = FakeRequest.apply("GET", "?none=value", Map("none" -> "value"))
+        .withHeaders("none" -> "value")
 
       extract("code") must beNone
     }
 
-    "extract a value from URL encoded body" in new Context {
+    "extract a value from URL encoded body if all parts are allowed" in new Context {
       implicit val request = FakeRequest().withFormUrlEncodedBody(("code", "value"))
 
       extract("code") must beSome("value")
     }
 
-    "return None if no value could be found in query string or URL encoded body" in new Context {
-      implicit val request = FakeRequest().withFormUrlEncodedBody(("none", "value"))
+    "extract a value from URL encoded body if part is allowed" in new Context {
+      implicit val request = FakeRequest().withFormUrlEncodedBody(("code", "value"))
+
+      extract("code", Some(Seq(RequestPart.FormUrlEncodedBody))) must beSome("value")
+    }
+
+    "do not extract a value from URL encoded body if part isn't allowed" in new Context {
+      implicit val request = FakeRequest().withFormUrlEncodedBody(("code", "value"))
+
+      extract("code", Some(Seq())) must beNone
+    }
+
+    "return None if no value could be found in default parts or URL encoded body" in new Context {
+      implicit val request = FakeRequest.apply("GET", "?none=value", Map("none" -> "value"))
+        .withHeaders("none" -> "value")
+        .withFormUrlEncodedBody(("none", "value"))
 
       extract("code") must beNone
     }
 
-    "extract a value from Json body" in new Context {
+    "extract a value from Json body if all parts are allowed" in new Context {
       implicit val request = FakeRequest().withJsonBody(Json.obj("code" -> "value"))
 
       extract("code") must beSome("value")
     }
 
-    "return None if no value could be found in query string or Json body" in new Context {
-      implicit val request = FakeRequest().withJsonBody(Json.obj("none" -> "value"))
+    "extract a value from Json body if part is allowed" in new Context {
+      implicit val request = FakeRequest().withJsonBody(Json.obj("code" -> "value"))
+
+      extract("code", Some(Seq(RequestPart.JsonBody))) must beSome("value")
+    }
+
+    "do not extract a value from Json body if part isn't allowed" in new Context {
+      implicit val request = FakeRequest().withJsonBody(Json.obj("code" -> "value"))
+
+      extract("code", Some(Seq())) must beNone
+    }
+
+    "return None if no value could be found in default parts or Json body" in new Context {
+      implicit val request = FakeRequest.apply("GET", "?none=value", Map("none" -> "value"))
+        .withHeaders("none" -> "value")
+        .withJsonBody(Json.obj("none" -> "value"))
 
       extract("code") must beNone
     }
 
-    "extract a value from XML body" in new Context {
+    "extract a value from XML body if all parts are allowed" in new Context {
       implicit val request = FakeRequest().withXmlBody(<code>value</code>)
 
       extract("code") must beSome("value")
     }
 
-    "return None if no value could be found in query string or XML body" in new Context {
-      implicit val request = FakeRequest().withXmlBody(<none>value</none>)
+    "extract a value from XML body if part is allowed" in new Context {
+      implicit val request = FakeRequest().withXmlBody(<code>value</code>)
+
+      extract("code", Some(Seq(RequestPart.XMLBody))) must beSome("value")
+    }
+
+    "do not extract a value from XML body if part isn't allowed" in new Context {
+      implicit val request = FakeRequest().withXmlBody(<code>value</code>)
+
+      extract("code", Some(Seq())) must beNone
+    }
+
+    "return None if no value could be found in default parts or XML body" in new Context {
+      implicit val request = FakeRequest.apply("GET", "?none=value", Map("none" -> "value"))
+        .withHeaders("none" -> "value")
+        .withXmlBody(<none>value</none>)
 
       extract("code") must beNone
     }
   }
 
   "The `formUrlEncodedExtractor`" should {
-    "extract a value from query string" in new Context {
+    "extract a value from query string if all parts are allowed" in new Context {
       implicit val request = FakeRequest("GET", "?code=value").withBody(Map("none" -> Seq("value")))
 
       extract("code") must beSome("value")
     }
 
-    "extract a value from body" in new Context {
+    "extract a value from headers if all parts are allowed" in new Context {
+      implicit val request = FakeRequest().withHeaders("code" -> "value").withBody(Map("none" -> Seq("value")))
+
+      extract("code") must beSome("value")
+    }
+
+    "extract a value from tags if all parts are allowed" in new Context {
+      implicit val request = FakeRequest.apply(Map("code" -> "value")).withBody(Map("none" -> Seq("value")))
+
+      extract("code") must beSome("value")
+    }
+
+    "extract a value from body if all parts are allowed" in new Context {
       implicit val request = FakeRequest().withBody(Map("code" -> Seq("value")))
 
       extract("code") must beSome("value")
     }
 
-    "return None if no value could be found in query string or body" in new Context {
-      implicit val request = FakeRequest().withBody(Map("none" -> Seq("value")))
+    "return None if no value could be found in default parts or body" in new Context {
+      implicit val request = FakeRequest.apply("GET", "?none=value", Map("none" -> "value"))
+        .withHeaders("none" -> "value")
+        .withBody(Map("none" -> Seq("value")))
 
       extract("code") must beNone
     }
   }
 
   "The `jsonExtractor`" should {
-    "extract a value from query string" in new Context {
+    "extract a value from query string if all parts are allowed" in new Context {
       implicit val request = FakeRequest("GET", "?code=value").withBody(Json.obj("none" -> "value"))
 
       extract("code") must beSome("value")
     }
 
-    "extract a value from body" in new Context {
+    "extract a value from headers if all parts are allowed" in new Context {
+      implicit val request = FakeRequest().withHeaders("code" -> "value").withBody(Json.obj("none" -> "value"))
+
+      extract("code") must beSome("value")
+    }
+
+    "extract a value from tags if all parts are allowed" in new Context {
+      implicit val request = FakeRequest.apply(Map("code" -> "value")).withBody(Json.obj("none" -> "value"))
+
+      extract("code") must beSome("value")
+    }
+
+    "extract a value from body if all parts are allowed" in new Context {
       implicit val request = FakeRequest().withBody(Json.obj("code" -> "value"))
 
       extract("code") must beSome("value")
     }
 
-    "return None if no value could be found in query string or body" in new Context {
-      implicit val request = FakeRequest().withBody(Json.obj("none" -> "value"))
+    "return None if no value could be found in default parts or body" in new Context {
+      implicit val request = FakeRequest.apply("GET", "?none=value", Map("none" -> "value"))
+        .withHeaders("none" -> "value")
+        .withBody(Json.obj("none" -> "value"))
 
       extract("code") must beNone
     }
   }
 
   "The `xmlExtractor`" should {
-    "extract a value from query string" in new Context {
+    "extract a value from query string if all parts are allowed" in new Context {
       implicit val request = FakeRequest("GET", "?code=value").withBody(<none>value</none>)
 
       extract("code") must beSome("value")
     }
 
-    "extract a value from body" in new Context {
+    "extract a value from headers if all parts are allowed" in new Context {
+      implicit val request = FakeRequest().withHeaders("code" -> "value").withBody(<none>value</none>)
+
+      extract("code") must beSome("value")
+    }
+
+    "extract a value from tags if all parts are allowed" in new Context {
+      implicit val request = FakeRequest.apply(Map("code" -> "value")).withBody(<none>value</none>)
+
+      extract("code") must beSome("value")
+    }
+
+    "extract a value from body if all parts are allowed" in new Context {
       implicit val request = FakeRequest().withBody(<code>value</code>)
 
       extract("code") must beSome("value")
     }
 
-    "return None if no value could be found in query string or body" in new Context {
-      implicit val request = FakeRequest().withBody(<none>value</none>)
+    "return None if no value could be found in default parts or body" in new Context {
+      implicit val request = FakeRequest.apply("GET", "?none=value", Map("none" -> "value"))
+        .withHeaders("none" -> "value")
+        .withBody(<none>value</none>)
 
       extract("code") must beNone
     }
   }
 
   "The `anyExtractor`" should {
-    "be executed for not supported body types" in new Context {
-      implicit val request = FakeRequest().withBody("text")
+    "extract a value from query string if all parts are allowed" in new Context {
+      implicit val request = FakeRequest("GET", "?code=value").withBody("text")
 
-      extract("code") must beNone
+      extract("code") must beSome("value")
+    }
+
+    "extract a value from headers if all parts are allowed" in new Context {
+      implicit val request = FakeRequest().withHeaders("code" -> "value").withBody("text")
+
+      extract("code") must beSome("value")
+    }
+
+    "extract a value from tags if all parts are allowed" in new Context {
+      implicit val request = FakeRequest.apply(Map("code" -> "value")).withBody("text")
+
+      extract("code") must beSome("value")
     }
   }
 
@@ -180,12 +340,30 @@ class RequestExtractorSpec extends PlaySpecification {
      * Extracts a value from request.
      *
      * @param name The name of the value to extract.
+     * @param parts The request parts from which a value can be extracted.
      * @param request The request from which the value should be extracted.
      * @tparam B The type of the request body.
      * @return The extracted value or None if the value couldn't be extracted.
      */
-    def extract[B](name: String)(implicit request: ExtractableRequest[B]): Option[String] = {
-      request.extractString(name)
+    def extract[B](name: String, parts: Option[Seq[RequestPart.Value]] = None)(
+      implicit request: ExtractableRequest[B]): Option[String] = {
+
+      request.extractString(name, parts)
+    }
+
+    /**
+     * Provides some additional helper utilities to build FakeRequest values.
+     *
+     * @param r The request to adds the helpers to.
+     */
+    implicit class RichFakeRequest(r: FakeRequest.type) {
+      def apply(method: String, path: String, tags: Map[String, String]): FakeRequest[AnyContentAsEmpty.type] = {
+        FakeRequest(method, path, FakeHeaders(), AnyContentAsEmpty, tags = tags)
+      }
+
+      def apply(tags: Map[String, String]): FakeRequest[AnyContentAsEmpty.type] = {
+        FakeRequest("GET", "/", FakeHeaders(), AnyContentAsEmpty, tags = tags)
+      }
     }
   }
 }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticatorSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticatorSpec.scala
@@ -261,7 +261,7 @@ class CookieAuthenticatorSpec extends PlaySpecification with Mockito with NoLang
     "throws an AuthenticatorRetrievalException exception if an error occurred during retrieval" in new Context {
       implicit val request = FakeRequest().withCookies(Cookie(settings.cookieName, authenticator.id))
 
-      fingerprintGenerator.generate throws new RuntimeException("Could not generate fingerprint")
+      fingerprintGenerator.generate(any) throws new RuntimeException("Could not generate fingerprint")
       settings.useFingerprinting returns true
       repository.find(authenticator.id) returns Future.successful(Some(authenticator))
 

--- a/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticatorSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticatorSpec.scala
@@ -226,7 +226,7 @@ class SessionAuthenticatorSpec extends PlaySpecification with Mockito with NoLan
     "throws an AuthenticatorRetrievalException exception if an error occurred during retrieval" in new WithApplication with Context {
       implicit val request = FakeRequest().withSession(settings.sessionKey -> Base64.encode(Json.toJson(authenticator)))
 
-      fingerprintGenerator.generate throws new RuntimeException("Could not generate fingerprint")
+      fingerprintGenerator.generate(any) throws new RuntimeException("Could not generate fingerprint")
       settings.useFingerprinting returns true
       settings.encryptAuthenticator returns false
 


### PR DESCRIPTION
Sometimes it may be necessary to send the authenticator specific values in other parts of the request. If we use a request extractor in the `retrieve` method of the authenticator service, then it may be possible to send a bearer token as example in the query string instead of the header.

See: http://silhouette.mohiva.com/v3.0/discuss/55950f4935f567170094304c