### PR TITLE
Fix overriding settings method for Providers.

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth1Provider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth1Provider.scala
@@ -131,6 +131,11 @@ object OAuth1Provider {
 trait OAuth1Service {
 
   /**
+   * The type of the concrete implementation of this abstract type.
+   */
+  type Self <: OAuth1Service
+
+  /**
    * Indicates if the service uses the safer 1.0a specification which addresses the session fixation attack
    * identified in the OAuth Core 1.0 specification.
    *
@@ -175,6 +180,14 @@ trait OAuth1Service {
    * @return The signature calculator for the OAuth1 request.
    */
   def sign(oAuthInfo: OAuth1Info): WSSignatureCalculator
+
+  /**
+   * Gets a service initialized with a new settings object.
+   *
+   * @param f A function which gets the settings passed and returns different settings.
+   * @return An instance of the service initialized with new settings.
+   */
+  def withSettings(f: OAuth1Settings => OAuth1Settings): Self
 }
 
 /**

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/OpenIDProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/OpenIDProvider.scala
@@ -95,6 +95,11 @@ object OpenIDProvider {
 trait OpenIDService {
 
   /**
+   * The type of the concrete implementation of this abstract type.
+   */
+  type Self <: OpenIDService
+
+  /**
    * Retrieve the URL where the user should be redirected to start the OpenID authentication process.
    *
    * @param openID The OpenID to use for authentication.
@@ -113,6 +118,14 @@ trait OpenIDService {
    * @return A OpenIDInfo in case of success, Exception otherwise.
    */
   def verifiedID[B](implicit request: Request[B], ec: ExecutionContext): Future[OpenIDInfo]
+
+  /**
+   * Gets a service initialized with a new settings object.
+   *
+   * @param f A function which gets the settings passed and returns different settings.
+   * @return An instance of the service initialized with new settings.
+   */
+  def withSettings(f: OpenIDSettings => OpenIDSettings): Self
 }
 
 /**

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth1/LinkedInProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth1/LinkedInProvider.scala
@@ -115,7 +115,7 @@ class LinkedInProfileParser extends SocialProfileParser[JsValue, CommonSocialPro
  */
 class LinkedInProvider(
   protected val httpLayer: HTTPLayer,
-  protected val service: OAuth1Service,
+  val service: OAuth1Service,
   protected val tokenSecretProvider: OAuth1TokenSecretProvider,
   val settings: OAuth1Settings)
   extends BaseLinkedInProvider with CommonSocialProfileBuilder {
@@ -137,7 +137,7 @@ class LinkedInProvider(
    * @return An instance of the provider initialized with new settings.
    */
   override def withSettings(f: (Settings) => Settings) = {
-    new LinkedInProvider(httpLayer, service, tokenSecretProvider, f(settings))
+    new LinkedInProvider(httpLayer, service.withSettings(f), tokenSecretProvider, f(settings))
   }
 }
 

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth1/TwitterProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth1/TwitterProvider.scala
@@ -107,7 +107,7 @@ class TwitterProfileParser extends SocialProfileParser[JsValue, CommonSocialProf
  */
 class TwitterProvider(
   protected val httpLayer: HTTPLayer,
-  protected val service: OAuth1Service,
+  val service: OAuth1Service,
   protected val tokenSecretProvider: OAuth1TokenSecretProvider,
   val settings: OAuth1Settings)
   extends BaseTwitterProvider with CommonSocialProfileBuilder {
@@ -129,7 +129,7 @@ class TwitterProvider(
    * @return An instance of the provider initialized with new settings.
    */
   override def withSettings(f: (Settings) => Settings) = {
-    new TwitterProvider(httpLayer, service, tokenSecretProvider, f(settings))
+    new TwitterProvider(httpLayer, service.withSettings(f), tokenSecretProvider, f(settings))
   }
 }
 

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth1/XingProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth1/XingProvider.scala
@@ -112,7 +112,7 @@ class XingProfileParser extends SocialProfileParser[JsValue, CommonSocialProfile
  */
 class XingProvider(
   protected val httpLayer: HTTPLayer,
-  protected val service: OAuth1Service,
+  val service: OAuth1Service,
   protected val tokenSecretProvider: OAuth1TokenSecretProvider,
   val settings: OAuth1Settings)
   extends BaseXingProvider with CommonSocialProfileBuilder {
@@ -134,7 +134,7 @@ class XingProvider(
    * @return An instance of the provider initialized with new settings.
    */
   override def withSettings(f: (Settings) => Settings) = {
-    new XingProvider(httpLayer, service, tokenSecretProvider, f(settings))
+    new XingProvider(httpLayer, service.withSettings(f), tokenSecretProvider, f(settings))
   }
 }
 

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth1/services/PlayOAuth1Service.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth1/services/PlayOAuth1Service.scala
@@ -33,7 +33,12 @@ import scala.concurrent.{ ExecutionContext, Future }
  * @param service The Play Framework OAuth implementation.
  * @param settings The service settings.
  */
-class PlayOAuth1Service(service: OAuth, settings: OAuth1Settings) extends OAuth1Service with Logger {
+class PlayOAuth1Service(service: OAuth, val settings: OAuth1Settings) extends OAuth1Service with Logger {
+
+  /**
+   * The type of this class.
+   */
+  override type Self = PlayOAuth1Service
 
   /**
    * Constructs the default Play Framework OAuth implementation.
@@ -97,6 +102,16 @@ class PlayOAuth1Service(service: OAuth, settings: OAuth1Settings) extends OAuth1
    */
   override def sign(oAuthInfo: OAuth1Info): WSSignatureCalculator = {
     OAuthCalculator(service.info.key, RequestToken(oAuthInfo.token, oAuthInfo.secret))
+  }
+
+  /**
+   * Gets a service initialized with a new settings object.
+   *
+   * @param f A function which gets the settings passed and returns different settings.
+   * @return An instance of the service initialized with new settings.
+   */
+  override def withSettings(f: (OAuth1Settings) => OAuth1Settings) = {
+    new PlayOAuth1Service(f(settings))
   }
 }
 

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/openid/SteamProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/openid/SteamProvider.scala
@@ -82,7 +82,7 @@ class SteamProfileParser extends SocialProfileParser[Unit, CommonSocialProfile, 
  */
 class SteamProvider(
   protected val httpLayer: HTTPLayer,
-  protected val service: OpenIDService,
+  val service: OpenIDService,
   val settings: OpenIDSettings)
   extends BaseSteamProvider with CommonSocialProfileBuilder {
 
@@ -102,7 +102,9 @@ class SteamProvider(
    * @param f A function which gets the settings passed and returns different settings.
    * @return An instance of the provider initialized with new settings.
    */
-  override def withSettings(f: (Settings) => Settings) = new SteamProvider(httpLayer, service, f(settings))
+  override def withSettings(f: (Settings) => Settings) = {
+    new SteamProvider(httpLayer, service.withSettings(f), f(settings))
+  }
 }
 
 /**

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/openid/YahooProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/openid/YahooProvider.scala
@@ -87,7 +87,7 @@ class YahooProfileParser extends SocialProfileParser[Unit, CommonSocialProfile, 
  */
 class YahooProvider(
   protected val httpLayer: HTTPLayer,
-  protected val service: OpenIDService,
+  val service: OpenIDService,
   val settings: OpenIDSettings)
   extends BaseYahooProvider with CommonSocialProfileBuilder {
 
@@ -107,7 +107,9 @@ class YahooProvider(
    * @param f A function which gets the settings passed and returns different settings.
    * @return An instance of the provider initialized with new settings.
    */
-  override def withSettings(f: (Settings) => Settings) = new YahooProvider(httpLayer, service, f(settings))
+  override def withSettings(f: (Settings) => Settings) = {
+    new YahooProvider(httpLayer, service.withSettings(f), f(settings))
+  }
 }
 
 /**

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/openid/services/PlayOpenIDService.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/openid/services/PlayOpenIDService.scala
@@ -32,7 +32,12 @@ import scala.util.{ Failure, Success, Try }
  * @param client The OpenID client implementation.
  * @param settings The OpenID settings.
  */
-class PlayOpenIDService(client: OpenIdClient, settings: OpenIDSettings) extends OpenIDService {
+class PlayOpenIDService(val client: OpenIdClient, val settings: OpenIDSettings) extends OpenIDService {
+
+  /**
+   * The type of this class.
+   */
+  override type Self = PlayOpenIDService
 
   /**
    * Retrieve the URL where the user should be redirected to start the OpenID authentication process.
@@ -64,5 +69,15 @@ class PlayOpenIDService(client: OpenIdClient, settings: OpenIDSettings) extends 
   } match {
     case Success(f) => f
     case Failure(e) => Future.failed(e)
+  }
+
+  /**
+   * Gets a service initialized with a new settings object.
+   *
+   * @param f A function which gets the settings passed and returns different settings.
+   * @return An instance of the service initialized with new settings.
+   */
+  override def withSettings(f: (OpenIDSettings) => OpenIDSettings) = {
+    new PlayOpenIDService(client, f(settings))
   }
 }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/OAuth1ProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/OAuth1ProviderSpec.scala
@@ -18,6 +18,7 @@ package com.mohiva.play.silhouette.impl.providers
 import com.mohiva.play.silhouette.api.util.HTTPLayer
 import com.mohiva.play.silhouette.impl.exceptions.{ AccessDeniedException, UnexpectedResponseException }
 import com.mohiva.play.silhouette.impl.providers.OAuth1Provider._
+import com.mohiva.play.silhouette.impl.providers.oauth1.services.PlayOAuth1Service
 import org.specs2.matcher.ThrownExpectations
 import org.specs2.mock.Mockito
 import org.specs2.specification.Scope
@@ -177,8 +178,9 @@ trait OAuth1ProviderSpecContext extends Scope with Mockito with ThrownExpectatio
    * The OAuth1 service mock.
    */
   lazy val oAuthService: OAuth1Service = {
-    val s = mock[OAuth1Service]
+    val s = mock[PlayOAuth1Service]
     s.use10a returns true
+    s.withSettings(anyFunction1) returns s
     s
   }
 

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/LinkedInProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/LinkedInProviderSpec.scala
@@ -33,11 +33,13 @@ class LinkedInProviderSpec extends OAuth1ProviderSpec {
 
   "The `withSettings` method" should {
     "create a new instance with customized settings" in new WithApplication with Context {
-      val s = provider.withSettings { s =>
+      val overrideSettingsFunction: OAuth1Settings => OAuth1Settings = { s =>
         s.copy("new-request-token-url")
       }
+      val s = provider.withSettings(overrideSettingsFunction)
 
       s.settings.requestTokenURL must be equalTo "new-request-token-url"
+      there was one(oAuthService).withSettings(overrideSettingsFunction)
     }
   }
 

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/TwitterProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/TwitterProviderSpec.scala
@@ -33,11 +33,13 @@ class TwitterProviderSpec extends OAuth1ProviderSpec {
 
   "The `withSettings` method" should {
     "create a new instance with customized settings" in new WithApplication with Context {
-      val s = provider.withSettings { s =>
+      val overrideSettingsFunction: OAuth1Settings => OAuth1Settings = { s =>
         s.copy("new-request-token-url")
       }
+      val s = provider.withSettings(overrideSettingsFunction)
 
       s.settings.requestTokenURL must be equalTo "new-request-token-url"
+      there was one(oAuthService).withSettings(overrideSettingsFunction)
     }
   }
 

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/XingProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/XingProviderSpec.scala
@@ -33,11 +33,13 @@ class XingProviderSpec extends OAuth1ProviderSpec {
 
   "The `withSettings` method" should {
     "create a new instance with customized settings" in new WithApplication with Context {
-      val s = provider.withSettings { s =>
+      val overrideSettingsFunction: OAuth1Settings => OAuth1Settings = { s =>
         s.copy("new-request-token-url")
       }
+      val s = provider.withSettings(overrideSettingsFunction)
 
       s.settings.requestTokenURL must be equalTo "new-request-token-url"
+      there was one(oAuthService).withSettings(overrideSettingsFunction)
     }
   }
 

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/services/PlayOAuth1ServiceSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/services/PlayOAuth1ServiceSpec.scala
@@ -22,12 +22,22 @@ import org.specs2.specification.Scope
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.oauth.{ OAuth, RequestToken }
 import play.api.libs.ws.WSSignatureCalculator
-import play.api.test.PlaySpecification
+import play.api.test.{ WithApplication, PlaySpecification }
 
 /**
  * Test case for the [[PlayOAuth1Service]] class.
  */
 class PlayOAuth1ServiceSpec extends PlaySpecification with Mockito {
+
+  "The `withSettings` method" should {
+    "create a new instance with customized settings" in new WithApplication with Context {
+      val s = service.withSettings { s =>
+        s.copy("new-request-token-url")
+      }
+
+      s.settings.requestTokenURL must be equalTo "new-request-token-url"
+    }
+  }
 
   "The alternative constructor" should {
     "construct the service with the default Play Framework OAuth implementation" in new Context {

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/openid/SteamProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/openid/SteamProviderSpec.scala
@@ -26,11 +26,13 @@ class SteamProviderSpec extends OpenIDProviderSpec {
 
   "The `withSettings` method" should {
     "create a new instance with customized settings" in new WithApplication with Context {
-      val s = provider.withSettings { s =>
+      val overrideSettingsFunction: OpenIDSettings => OpenIDSettings = { s =>
         s.copy("new-provider-url")
       }
+      val s = provider.withSettings(overrideSettingsFunction)
 
       s.settings.providerURL must be equalTo "new-provider-url"
+      there was one(openIDService).withSettings(overrideSettingsFunction)
     }
   }
 

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/openid/YahooProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/openid/YahooProviderSpec.scala
@@ -26,11 +26,13 @@ class YahooProviderSpec extends OpenIDProviderSpec {
 
   "The `withSettings` method" should {
     "create a new instance with customized settings" in new WithApplication with Context {
-      val s = provider.withSettings { s =>
+      val overrideSettingsFunction: OpenIDSettings => OpenIDSettings = { s =>
         s.copy("new-provider-url")
       }
+      val s = provider.withSettings(overrideSettingsFunction)
 
       s.settings.providerURL must be equalTo "new-provider-url"
+      there was one(openIDService).withSettings(overrideSettingsFunction)
     }
   }
 

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/openid/service/PlayOpenIDServiceSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/openid/service/PlayOpenIDServiceSpec.scala
@@ -1,0 +1,43 @@
+package com.mohiva.play.silhouette.impl.providers.openid.service
+
+import com.mohiva.play.silhouette.impl.providers.OpenIDSettings
+import com.mohiva.play.silhouette.impl.providers.openid.services.PlayOpenIDService
+import org.specs2.mock.Mockito
+import org.specs2.specification.Scope
+import play.api.libs.openid.OpenIdClient
+import play.api.test.{ PlaySpecification, WithApplication }
+
+class PlayOpenIDServiceSpec extends PlaySpecification with Mockito {
+
+  "The `withSettings` method" should {
+    "create a new instance with customized settings" in new WithApplication with Context {
+      val s = service.withSettings { s =>
+        s.copy("new-provider-url")
+      }
+
+      s.settings.providerURL must be equalTo "new-provider-url"
+    }
+  }
+
+  /**
+   * The context.
+   */
+  trait Context extends Scope {
+    /**
+     * The OpenID settings.
+     */
+    lazy val openIDSettings = OpenIDSettings(
+      providerURL = "https://me.yahoo.com/",
+      callbackURL = "http://localhost:9000/authenticate/yahoo",
+      axRequired = Map(
+        "fullname" -> "http://axschema.org/namePerson",
+        "email" -> "http://axschema.org/contact/email",
+        "image" -> "http://axschema.org/media/image/default"
+      ),
+      realm = Some("http://localhost:9000")
+    )
+
+    val service = new PlayOpenIDService(mock[OpenIdClient], openIDSettings)
+  }
+
+}


### PR DESCRIPTION
This PR fixes #432. Some notes: 

There are three flavours of SocialProvider: OAuth1, OpenID and OAuth2. OAuth1 and OpenID related services only hold references into its respective first level settings objects (OAuth1Settings and OpenIDSettings). That makes `withSettings` API really appropriate. However OAuth2 related services (e.g CookieStateProvider) have different settings objects: CookieStateSettings vs OAuth2Settings. That means that this API could be misleading for OAuth2 scenarios, it seems that we're updating every settings value related with that OAuth2 provider but actually we're only updating OAuth2Settings instances. That's out of the scope for this fix, as it would probably involve a new API or updating the existing one, but I'd like to note it.

About OAuth1 and OpenID, one of the design decisions was exposing similar `withSettings` for their services (OAuth1Service and OpenIDService). That allow us to keep the extensibility of the current design and being able at the same time to access to internal dependencies like `client` in `PlayOpenIDService`. Unit tests for those new functionalities have been provided.

This PR breaks isolation in unit tests like `LinkedInProviderSpec`. Being able to check that some concrete setting was updated in the related services seemed more useful than verifying that some mock was called. If that's breaking the philosophy of these specs, please let me know and I'll update the PR.

