### PR TITLE
Allow to override authentication provider constants

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth1Provider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth1Provider.scala
@@ -31,7 +31,7 @@ import scala.concurrent.{ ExecutionContext, Future }
 /**
  * Base implementation for all OAuth1 providers.
  */
-trait OAuth1Provider extends SocialProvider with Logger {
+trait OAuth1Provider extends SocialProvider with OAuth1Constants with Logger {
 
   /**
    * Check if services uses 1.0a specification because it address the session fixation attack identified
@@ -108,7 +108,7 @@ trait OAuth1Provider extends SocialProvider with Logger {
 /**
  * The OAuth1Provider companion object.
  */
-object OAuth1Provider {
+object OAuth1Provider extends OAuth1Constants {
 
   /**
    * The error messages.
@@ -116,10 +116,13 @@ object OAuth1Provider {
   val AuthorizationError = "[Silhouette][%s] Authorization server returned error: %s"
   val ErrorAccessToken = "[Silhouette][%s] Error retrieving access token"
   val ErrorRequestToken = "[Silhouette][%s] Error retrieving request token"
+}
 
-  /**
-   * The OAuth1 constants.
-   */
+/**
+ * The OAuth1 constants.
+ */
+trait OAuth1Constants {
+
   val Denied = "denied"
   val OAuthVerifier = "oauth_verifier"
   val OAuthToken = "oauth_token"
@@ -141,7 +144,6 @@ trait OAuth1Service {
    *
    * @see http://oauth.net/core/1.0a/
    * @see http://oauth.net/advisories/2009-1/
-   *
    * @return True if the services uses 1.0a specification, false otherwise.
    */
   def use10a: Boolean

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth2Provider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth2Provider.scala
@@ -26,8 +26,8 @@ import com.mohiva.play.silhouette.api.exceptions._
 import com.mohiva.play.silhouette.api.util.ExtractableRequest
 import com.mohiva.play.silhouette.impl.exceptions.{ AccessDeniedException, UnexpectedResponseException }
 import com.mohiva.play.silhouette.impl.providers.OAuth2Provider._
-import play.api.libs.json._
 import play.api.libs.functional.syntax._
+import play.api.libs.json._
 import play.api.libs.ws.WSResponse
 import play.api.mvc._
 
@@ -53,7 +53,7 @@ case class OAuth2Info(
 /**
  * The Oauth2 info companion object.
  */
-object OAuth2Info {
+object OAuth2Info extends OAuth2Constants {
 
   /**
    * Converts the JSON into a [[com.mohiva.play.silhouette.impl.providers.OAuth2Info]] object.
@@ -71,7 +71,7 @@ object OAuth2Info {
 /**
  * Base implementation for all OAuth2 providers.
  */
-trait OAuth2Provider extends SocialProvider with Logger {
+trait OAuth2Provider extends SocialProvider with OAuth2Constants with Logger {
 
   /**
    * The type of the auth info.
@@ -170,7 +170,7 @@ trait OAuth2Provider extends SocialProvider with Logger {
 /**
  * The OAuth2Provider companion object.
  */
-object OAuth2Provider {
+object OAuth2Provider extends OAuth2Constants {
 
   /**
    * The error messages.
@@ -178,10 +178,13 @@ object OAuth2Provider {
   val AuthorizationURLUndefined = "[Silhouette][%s] Authorization URL is undefined"
   val AuthorizationError = "[Silhouette][%s] Authorization server returned error: %s"
   val InvalidInfoFormat = "[Silhouette][%s] Cannot build OAuth2Info because of invalid response format: %s"
+}
 
-  /**
-   * The OAuth2 constants.
-   */
+/**
+ * The OAuth2 constants.
+ */
+trait OAuth2Constants {
+
   val ClientID = "client_id"
   val ClientSecret = "client_secret"
   val RedirectURI = "redirect_uri"
@@ -204,6 +207,7 @@ object OAuth2Provider {
  * The OAuth2 state.
  *
  * This is to prevent the client for CSRF attacks as described in the OAuth2 RFC.
+ *
  * @see https://tools.ietf.org/html/rfc6749#section-10.12
  */
 trait OAuth2State {

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/OpenIDProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/OpenIDProvider.scala
@@ -26,7 +26,7 @@ import scala.concurrent.{ ExecutionContext, Future }
 /**
  * Base implementation for all OpenID providers.
  */
-trait OpenIDProvider extends SocialProvider with Logger {
+trait OpenIDProvider extends SocialProvider with OpenIDConstants with Logger {
 
   /**
    * The type of the auth info.
@@ -74,17 +74,20 @@ trait OpenIDProvider extends SocialProvider with Logger {
 /**
  * The OpenIDProvider companion object.
  */
-object OpenIDProvider {
+object OpenIDProvider extends OpenIDConstants {
 
   /**
    * The error messages.
    */
   val ErrorVerification = "[Silhouette][%s] Error verifying the ID: %s"
   val ErrorRedirectURL = "[Silhouette][%s] Error retrieving the redirect URL: %s"
+}
 
-  /**
-   * The OpenID constants.
-   */
+/**
+ * The OpenID constants.
+ */
+trait OpenIDConstants {
+
   val Mode = "openid.mode"
   val OpenID = "openID"
 }


### PR DESCRIPTION
How to override `ClientID` in `object OAuth2Provider`? See the code [here](https://github.com/mohiva/play-silhouette/blob/1efb38af36f1f590af1ca988f0e7d02793255c1a/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth2Provider.scala#L185). Some OAuth2 provider like wechat don't use `client_id` but `appid`.