### PR TITLE
Fix broken tests introduced in ad7bcdc5

### DIFF
--- a/scripts/ci-build
+++ b/scripts/ci-build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 #
 # Builds the project in the continuous integration environment.
 #

--- a/silhouette-persistence-memory/src/test/scala/com/mohiva/play/silhouette/persistence/memory/daos/OAuth1InfoDAOSpec.scala
+++ b/silhouette-persistence-memory/src/test/scala/com/mohiva/play/silhouette/persistence/memory/daos/OAuth1InfoDAOSpec.scala
@@ -17,6 +17,7 @@ package com.mohiva.play.silhouette.persistence.memory.daos
 
 import com.mohiva.play.silhouette.api.LoginInfo
 import com.mohiva.play.silhouette.impl.providers.OAuth1Info
+import com.mohiva.play.silhouette.test.WaitPatience
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.control.NoLanguageFeatures
 import org.specs2.mutable.Specification
@@ -29,24 +30,24 @@ import scala.language.postfixOps
 /**
  * Test case for the [[OAuth1InfoDAO]] class.
  */
-class OAuth1InfoDAOSpec(implicit ev: ExecutionEnv) extends Specification with NoLanguageFeatures {
+class OAuth1InfoDAOSpec(implicit ev: ExecutionEnv) extends Specification with NoLanguageFeatures with WaitPatience {
 
   "The `find` method" should {
     "find an OAuth1 info for the given login info" in new Context {
       Await.result(dao.save(loginInfo, authInfo), 10 seconds)
 
-      dao.find(loginInfo) must beSome(authInfo).await
+      dao.find(loginInfo) must beSome(authInfo).awaitWithPatience
     }
 
     "return None if no OAuth1 info for the given login info exists" in new Context {
-      dao.find(loginInfo.copy(providerKey = "new.key")) should beNone.await
+      dao.find(loginInfo.copy(providerKey = "new.key")) should beNone.awaitWithPatience
     }
   }
 
   "The `add` method" should {
     "add a new OAuth1 info" in new Context {
-      dao.add(loginInfo.copy(providerKey = "new.key"), authInfo) must beEqualTo(authInfo).await
-      dao.find(loginInfo.copy(providerKey = "new.key")) must beSome(authInfo).await
+      dao.add(loginInfo.copy(providerKey = "new.key"), authInfo) must beEqualTo(authInfo).awaitWithPatience
+      dao.find(loginInfo.copy(providerKey = "new.key")) must beSome(authInfo).awaitWithPatience
     }
   }
 
@@ -54,29 +55,29 @@ class OAuth1InfoDAOSpec(implicit ev: ExecutionEnv) extends Specification with No
     "update an existing OAuth1 info" in new Context {
       val updatedInfo = authInfo.copy(secret = "updated")
 
-      dao.update(loginInfo, updatedInfo) must beEqualTo(updatedInfo).await
-      dao.find(loginInfo) must beSome(updatedInfo).await
+      dao.update(loginInfo, updatedInfo) must beEqualTo(updatedInfo).awaitWithPatience
+      dao.find(loginInfo) must beSome(updatedInfo).awaitWithPatience
     }
   }
 
   "The `save` method" should {
     "insert a new OAuth1 info" in new Context {
-      dao.save(loginInfo.copy(providerKey = "new.key"), authInfo) must beEqualTo(authInfo).await
-      dao.find(loginInfo.copy(providerKey = "new.key")) must beSome(authInfo).await
+      dao.save(loginInfo.copy(providerKey = "new.key"), authInfo) must beEqualTo(authInfo).awaitWithPatience
+      dao.find(loginInfo.copy(providerKey = "new.key")) must beSome(authInfo).awaitWithPatience
     }
 
     "update an existing OAuth1 info" in new Context {
       val updatedInfo = authInfo.copy(secret = "updated")
 
-      dao.update(loginInfo, updatedInfo) must beEqualTo(updatedInfo).await
-      dao.find(loginInfo) must beSome(updatedInfo).await
+      dao.update(loginInfo, updatedInfo) must beEqualTo(updatedInfo).awaitWithPatience
+      dao.find(loginInfo) must beSome(updatedInfo).awaitWithPatience
     }
   }
 
   "The `remove` method" should {
     "remove an OAuth1 info" in new Context {
       Await.result(dao.remove(loginInfo), 10 seconds)
-      dao.find(loginInfo) must beNone.await
+      dao.find(loginInfo) must beNone.awaitWithPatience
     }
   }
 

--- a/silhouette-persistence-memory/src/test/scala/com/mohiva/play/silhouette/persistence/memory/daos/OAuth2InfoDAOSpec.scala
+++ b/silhouette-persistence-memory/src/test/scala/com/mohiva/play/silhouette/persistence/memory/daos/OAuth2InfoDAOSpec.scala
@@ -17,6 +17,7 @@ package com.mohiva.play.silhouette.persistence.memory.daos
 
 import com.mohiva.play.silhouette.api.LoginInfo
 import com.mohiva.play.silhouette.impl.providers.OAuth2Info
+import com.mohiva.play.silhouette.test.WaitPatience
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.control.NoLanguageFeatures
 import org.specs2.mutable.Specification
@@ -29,24 +30,24 @@ import scala.language.postfixOps
 /**
  * Test case for the [[OAuth2InfoDAO]] class.
  */
-class OAuth2InfoDAOSpec(implicit ev: ExecutionEnv) extends Specification with NoLanguageFeatures {
+class OAuth2InfoDAOSpec(implicit ev: ExecutionEnv) extends Specification with NoLanguageFeatures with WaitPatience {
 
   "The `find` method" should {
     "find an OAuth2 info for the given login info" in new Context {
       Await.result(dao.save(loginInfo, authInfo), 10 seconds)
 
-      dao.find(loginInfo) must beSome(authInfo).await
+      dao.find(loginInfo) must beSome(authInfo).awaitWithPatience
     }
 
     "return None if no OAuth2 info for the given login info exists" in new Context {
-      dao.find(loginInfo.copy(providerKey = "new.key")) should beNone.await
+      dao.find(loginInfo.copy(providerKey = "new.key")) should beNone.awaitWithPatience
     }
   }
 
   "The `add` method" should {
     "add a new OAuth2 info" in new Context {
-      dao.add(loginInfo.copy(providerKey = "new.key"), authInfo) must beEqualTo(authInfo).await
-      dao.find(loginInfo.copy(providerKey = "new.key")) must beSome(authInfo).await
+      dao.add(loginInfo.copy(providerKey = "new.key"), authInfo) must beEqualTo(authInfo).awaitWithPatience
+      dao.find(loginInfo.copy(providerKey = "new.key")) must beSome(authInfo).awaitWithPatience
     }
   }
 
@@ -54,29 +55,29 @@ class OAuth2InfoDAOSpec(implicit ev: ExecutionEnv) extends Specification with No
     "update an existing OAuth2 info" in new Context {
       val updatedInfo = authInfo.copy(tokenType = Some("updated"))
 
-      dao.update(loginInfo, updatedInfo) must beEqualTo(updatedInfo).await
-      dao.find(loginInfo) must beSome(updatedInfo).await
+      dao.update(loginInfo, updatedInfo) must beEqualTo(updatedInfo).awaitWithPatience
+      dao.find(loginInfo) must beSome(updatedInfo).awaitWithPatience
     }
   }
 
   "The `save` method" should {
     "insert a new OAuth2 info" in new Context {
-      dao.save(loginInfo.copy(providerKey = "new.key"), authInfo) must beEqualTo(authInfo).await
-      dao.find(loginInfo.copy(providerKey = "new.key")) must beSome(authInfo).await
+      dao.save(loginInfo.copy(providerKey = "new.key"), authInfo) must beEqualTo(authInfo).awaitWithPatience
+      dao.find(loginInfo.copy(providerKey = "new.key")) must beSome(authInfo).awaitWithPatience
     }
 
     "update an existing OAuth2 info" in new Context {
       val updatedInfo = authInfo.copy(tokenType = Some("updated"))
 
-      dao.update(loginInfo, updatedInfo) must beEqualTo(updatedInfo).await
-      dao.find(loginInfo) must beSome(updatedInfo).await
+      dao.update(loginInfo, updatedInfo) must beEqualTo(updatedInfo).awaitWithPatience
+      dao.find(loginInfo) must beSome(updatedInfo).awaitWithPatience
     }
   }
 
   "The `remove` method" should {
     "remove an OAuth2 info" in new Context {
       Await.result(dao.remove(loginInfo), 10 seconds)
-      dao.find(loginInfo) must beNone.await
+      dao.find(loginInfo) must beNone.awaitWithPatience
     }
   }
 

--- a/silhouette-persistence-memory/src/test/scala/com/mohiva/play/silhouette/persistence/memory/daos/OpenIDInfoDAOSpec.scala
+++ b/silhouette-persistence-memory/src/test/scala/com/mohiva/play/silhouette/persistence/memory/daos/OpenIDInfoDAOSpec.scala
@@ -17,6 +17,7 @@ package com.mohiva.play.silhouette.persistence.memory.daos
 
 import com.mohiva.play.silhouette.api.LoginInfo
 import com.mohiva.play.silhouette.impl.providers.OpenIDInfo
+import com.mohiva.play.silhouette.test.WaitPatience
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.control.NoLanguageFeatures
 import org.specs2.mutable.Specification
@@ -29,24 +30,24 @@ import scala.language.postfixOps
 /**
  * Test case for the [[OpenIDInfoDAO]] class.
  */
-class OpenIDInfoDAOSpec(implicit ev: ExecutionEnv) extends Specification with NoLanguageFeatures {
+class OpenIDInfoDAOSpec(implicit ev: ExecutionEnv) extends Specification with NoLanguageFeatures with WaitPatience {
 
   "The `find` method" should {
     "find an OAuth1 info for the given login info" in new Context {
       Await.result(dao.save(loginInfo, authInfo), 10 seconds)
 
-      dao.find(loginInfo) must beSome(authInfo).await
+      dao.find(loginInfo) must beSome(authInfo).awaitWithPatience
     }
 
     "return None if no OAuth1 info for the given login info exists" in new Context {
-      dao.find(loginInfo.copy(providerKey = "new.key")) should beNone.await
+      dao.find(loginInfo.copy(providerKey = "new.key")) should beNone.awaitWithPatience
     }
   }
 
   "The `add` method" should {
     "add a new OAuth1 info" in new Context {
-      dao.add(loginInfo.copy(providerKey = "new.key"), authInfo) must beEqualTo(authInfo).await
-      dao.find(loginInfo.copy(providerKey = "new.key")) must beSome(authInfo).await
+      dao.add(loginInfo.copy(providerKey = "new.key"), authInfo) must beEqualTo(authInfo).awaitWithPatience
+      dao.find(loginInfo.copy(providerKey = "new.key")) must beSome(authInfo).awaitWithPatience
     }
   }
 
@@ -54,29 +55,29 @@ class OpenIDInfoDAOSpec(implicit ev: ExecutionEnv) extends Specification with No
     "update an existing OAuth1 info" in new Context {
       val updatedInfo = authInfo.copy(attributes = authInfo.attributes.updated("fullname", "updated"))
 
-      dao.update(loginInfo, updatedInfo) must beEqualTo(updatedInfo).await
-      dao.find(loginInfo) must beSome(updatedInfo).await
+      dao.update(loginInfo, updatedInfo) must beEqualTo(updatedInfo).awaitWithPatience
+      dao.find(loginInfo) must beSome(updatedInfo).awaitWithPatience
     }
   }
 
   "The `save` method" should {
     "insert a new OAuth1 info" in new Context {
-      dao.save(loginInfo.copy(providerKey = "new.key"), authInfo) must beEqualTo(authInfo).await
-      dao.find(loginInfo.copy(providerKey = "new.key")) must beSome(authInfo).await
+      dao.save(loginInfo.copy(providerKey = "new.key"), authInfo) must beEqualTo(authInfo).awaitWithPatience
+      dao.find(loginInfo.copy(providerKey = "new.key")) must beSome(authInfo).awaitWithPatience
     }
 
     "update an existing OAuth1 info" in new Context {
       val updatedInfo = authInfo.copy(attributes = authInfo.attributes.updated("fullname", "updated"))
 
-      dao.update(loginInfo, updatedInfo) must beEqualTo(updatedInfo).await
-      dao.find(loginInfo) must beSome(updatedInfo).await
+      dao.update(loginInfo, updatedInfo) must beEqualTo(updatedInfo).awaitWithPatience
+      dao.find(loginInfo) must beSome(updatedInfo).awaitWithPatience
     }
   }
 
   "The `remove` method" should {
     "remove an OAuth1 info" in new Context {
       Await.result(dao.remove(loginInfo), 10 seconds)
-      dao.find(loginInfo) must beNone.await
+      dao.find(loginInfo) must beNone.awaitWithPatience
     }
   }
 

--- a/silhouette-persistence-memory/src/test/scala/com/mohiva/play/silhouette/persistence/memory/daos/PasswordInfoDAOSpec.scala
+++ b/silhouette-persistence-memory/src/test/scala/com/mohiva/play/silhouette/persistence/memory/daos/PasswordInfoDAOSpec.scala
@@ -17,6 +17,7 @@ package com.mohiva.play.silhouette.persistence.memory.daos
 
 import com.mohiva.play.silhouette.api.LoginInfo
 import com.mohiva.play.silhouette.api.util.PasswordInfo
+import com.mohiva.play.silhouette.test.WaitPatience
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.control.NoLanguageFeatures
 import org.specs2.mutable.Specification
@@ -29,24 +30,24 @@ import scala.language.postfixOps
 /**
  * Test case for the [[PasswordInfoDAO]] class.
  */
-class PasswordInfoDAOSpec(implicit ev: ExecutionEnv) extends Specification with NoLanguageFeatures {
+class PasswordInfoDAOSpec(implicit ev: ExecutionEnv) extends Specification with NoLanguageFeatures with WaitPatience {
 
   "The `find` method" should {
     "find an password info for the given login info" in new Context {
       Await.result(dao.save(loginInfo, authInfo), 10 seconds)
 
-      dao.find(loginInfo) must beSome(authInfo).await
+      dao.find(loginInfo) must beSome(authInfo).awaitWithPatience
     }
 
     "return None if no password info for the given login info exists" in new Context {
-      dao.find(loginInfo.copy(providerKey = "new.key")) should beNone.await
+      dao.find(loginInfo.copy(providerKey = "new.key")) should beNone.awaitWithPatience
     }
   }
 
   "The `add` method" should {
     "add a new password info" in new Context {
-      dao.add(loginInfo.copy(providerKey = "new.key"), authInfo) must beEqualTo(authInfo).await
-      dao.find(loginInfo.copy(providerKey = "new.key")) must beSome(authInfo).await
+      dao.add(loginInfo.copy(providerKey = "new.key"), authInfo) must beEqualTo(authInfo).awaitWithPatience
+      dao.find(loginInfo.copy(providerKey = "new.key")) must beSome(authInfo).awaitWithPatience
     }
   }
 
@@ -54,29 +55,29 @@ class PasswordInfoDAOSpec(implicit ev: ExecutionEnv) extends Specification with 
     "update an existing password info" in new Context {
       val updatedInfo = authInfo.copy(password = "updated")
 
-      dao.update(loginInfo, updatedInfo) must beEqualTo(updatedInfo).await
-      dao.find(loginInfo) must beSome(updatedInfo).await
+      dao.update(loginInfo, updatedInfo) must beEqualTo(updatedInfo).awaitWithPatience
+      dao.find(loginInfo) must beSome(updatedInfo).awaitWithPatience
     }
   }
 
   "The `save` method" should {
     "insert a new password info" in new Context {
-      dao.save(loginInfo.copy(providerKey = "new.key"), authInfo) must beEqualTo(authInfo).await
-      dao.find(loginInfo.copy(providerKey = "new.key")) must beSome(authInfo).await
+      dao.save(loginInfo.copy(providerKey = "new.key"), authInfo) must beEqualTo(authInfo).awaitWithPatience
+      dao.find(loginInfo.copy(providerKey = "new.key")) must beSome(authInfo).awaitWithPatience
     }
 
     "update an existing password info" in new Context {
       val updatedInfo = authInfo.copy(password = "updated")
 
-      dao.update(loginInfo, updatedInfo) must beEqualTo(updatedInfo).await
-      dao.find(loginInfo) must beSome(updatedInfo).await
+      dao.update(loginInfo, updatedInfo) must beEqualTo(updatedInfo).awaitWithPatience
+      dao.find(loginInfo) must beSome(updatedInfo).awaitWithPatience
     }
   }
 
   "The `remove` method" should {
     "remove an password info" in new Context {
       Await.result(dao.remove(loginInfo), 10 seconds)
-      dao.find(loginInfo) must beNone.await
+      dao.find(loginInfo) must beNone.awaitWithPatience
     }
   }
 

--- a/silhouette-persistence-memory/src/test/scala/com/mohiva/play/silhouette/test/WaitPatience.scala
+++ b/silhouette-persistence-memory/src/test/scala/com/mohiva/play/silhouette/test/WaitPatience.scala
@@ -1,0 +1,23 @@
+package com.mohiva.play.silhouette.test
+
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.matcher.FutureMatchers.FutureMatchable
+import org.specs2.matcher.Matcher
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.languageFeature.implicitConversions
+
+trait WaitPatience {
+
+  def retries = 10
+
+  def timeout = 1.second
+
+  implicit class WaitWithPatienceFutureMatchable[T](m: Matcher[T])(implicit ee: ExecutionEnv) extends FutureMatchable[T](m)(ee) {
+    def awaitWithPatience: Matcher[Future[T]] = {
+      await(retries, timeout)
+    }
+  }
+
+}

--- a/silhouette-persistence/src/test/scala/com/mohiva/play/silhouette/persistence/daos/InMemoryAuthInfoDAOSpec.scala
+++ b/silhouette-persistence/src/test/scala/com/mohiva/play/silhouette/persistence/daos/InMemoryAuthInfoDAOSpec.scala
@@ -16,6 +16,7 @@
 package com.mohiva.play.silhouette.persistence.daos
 
 import com.mohiva.play.silhouette.api.{ AuthInfo, LoginInfo }
+import com.mohiva.play.silhouette.test.WaitPatience
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.control.NoLanguageFeatures
 import org.specs2.mutable.Specification
@@ -28,24 +29,24 @@ import scala.language.postfixOps
 /**
  * Test case for the [[InMemoryAuthInfoDAO]] trait.
  */
-class InMemoryAuthInfoDAOSpec(implicit ev: ExecutionEnv) extends Specification with NoLanguageFeatures {
+class InMemoryAuthInfoDAOSpec(implicit ev: ExecutionEnv) extends Specification with NoLanguageFeatures with WaitPatience {
 
   "The `find` method" should {
     "find an OAuth1 info for the given login info" in new Context {
       Await.result(dao.save(loginInfo, authInfo), 10 seconds)
 
-      dao.find(loginInfo) must beSome(authInfo).await
+      dao.find(loginInfo) must beSome(authInfo).awaitWithPatience
     }
 
     "return None if no OAuth1 info for the given login info exists" in new Context {
-      dao.find(loginInfo.copy(providerKey = "new.key")) should beNone.await
+      dao.find(loginInfo.copy(providerKey = "new.key")) should beNone.awaitWithPatience
     }
   }
 
   "The `add` method" should {
     "add a new OAuth1 info" in new Context {
-      dao.add(loginInfo.copy(providerKey = "new.key"), authInfo) must beEqualTo(authInfo).await
-      dao.find(loginInfo.copy(providerKey = "new.key")) must beSome(authInfo).await
+      dao.add(loginInfo.copy(providerKey = "new.key"), authInfo) must beEqualTo(authInfo).awaitWithPatience
+      dao.find(loginInfo.copy(providerKey = "new.key")) must beSome(authInfo).awaitWithPatience
     }
   }
 
@@ -53,29 +54,29 @@ class InMemoryAuthInfoDAOSpec(implicit ev: ExecutionEnv) extends Specification w
     "update an existing OAuth1 info" in new Context {
       val updatedInfo = authInfo.copy(data = "updated")
 
-      dao.update(loginInfo, updatedInfo) must beEqualTo(updatedInfo).await
-      dao.find(loginInfo) must beSome(updatedInfo).await
+      dao.update(loginInfo, updatedInfo) must beEqualTo(updatedInfo).awaitWithPatience
+      dao.find(loginInfo) must beSome(updatedInfo).awaitWithPatience
     }
   }
 
   "The `save` method" should {
     "insert a new OAuth1 info" in new Context {
-      dao.save(loginInfo.copy(providerKey = "new.key"), authInfo) must beEqualTo(authInfo).await
-      dao.find(loginInfo.copy(providerKey = "new.key")) must beSome(authInfo).await
+      dao.save(loginInfo.copy(providerKey = "new.key"), authInfo) must beEqualTo(authInfo).awaitWithPatience
+      dao.find(loginInfo.copy(providerKey = "new.key")) must beSome(authInfo).awaitWithPatience
     }
 
     "update an existing OAuth1 info" in new Context {
       val updatedInfo = authInfo.copy(data = "updated")
 
-      dao.update(loginInfo, updatedInfo) must beEqualTo(updatedInfo).await
-      dao.find(loginInfo) must beSome(updatedInfo).await
+      dao.update(loginInfo, updatedInfo) must beEqualTo(updatedInfo).awaitWithPatience
+      dao.find(loginInfo) must beSome(updatedInfo).awaitWithPatience
     }
   }
 
   "The `remove` method" should {
     "remove an OAuth1 info" in new Context {
       Await.result(dao.remove(loginInfo), 10 seconds)
-      dao.find(loginInfo) must beNone.await
+      dao.find(loginInfo) must beNone.awaitWithPatience
     }
   }
 

--- a/silhouette-persistence/src/test/scala/com/mohiva/play/silhouette/persistence/repositories/CacheAuthenticatorRepositorySpec.scala
+++ b/silhouette-persistence/src/test/scala/com/mohiva/play/silhouette/persistence/repositories/CacheAuthenticatorRepositorySpec.scala
@@ -17,6 +17,7 @@ package com.mohiva.play.silhouette.persistence.repositories
 
 import com.mohiva.play.silhouette.api.StorableAuthenticator
 import com.mohiva.play.silhouette.api.util.CacheLayer
+import com.mohiva.play.silhouette.test.WaitPatience
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
@@ -28,20 +29,20 @@ import scala.concurrent.duration.Duration
 /**
  * Test case for the [[CacheAuthenticatorRepository]] class.
  */
-class CacheAuthenticatorRepositorySpec(implicit ev: ExecutionEnv) extends Specification with Mockito {
+class CacheAuthenticatorRepositorySpec(implicit ev: ExecutionEnv) extends Specification with Mockito with WaitPatience {
 
   "The `find` method" should {
     "return value from cache" in new Context {
       cacheLayer.find[StorableAuthenticator]("test-id") returns Future.successful(Some(authenticator))
 
-      repository.find("test-id") must beSome(authenticator).await
+      repository.find("test-id") must beSome(authenticator).awaitWithPatience
       there was one(cacheLayer).find[StorableAuthenticator]("test-id")
     }
 
     "return None if value couldn't be found in cache" in new Context {
       cacheLayer.find[StorableAuthenticator]("test-id") returns Future.successful(None)
 
-      repository.find("test-id") must beNone.await
+      repository.find("test-id") must beNone.awaitWithPatience
       there was one(cacheLayer).find[StorableAuthenticator]("test-id")
     }
   }
@@ -51,7 +52,7 @@ class CacheAuthenticatorRepositorySpec(implicit ev: ExecutionEnv) extends Specif
       authenticator.id returns "test-id"
       cacheLayer.save("test-id", authenticator, Duration.Inf) returns Future.successful(authenticator)
 
-      repository.add(authenticator) must beEqualTo(authenticator).await
+      repository.add(authenticator) must beEqualTo(authenticator).awaitWithPatience
       there was one(cacheLayer).save("test-id", authenticator, Duration.Inf)
     }
   }
@@ -61,7 +62,7 @@ class CacheAuthenticatorRepositorySpec(implicit ev: ExecutionEnv) extends Specif
       authenticator.id returns "test-id"
       cacheLayer.save("test-id", authenticator, Duration.Inf) returns Future.successful(authenticator)
 
-      repository.update(authenticator) must beEqualTo(authenticator).await
+      repository.update(authenticator) must beEqualTo(authenticator).awaitWithPatience
       there was one(cacheLayer).save("test-id", authenticator, Duration.Inf)
     }
   }
@@ -70,7 +71,7 @@ class CacheAuthenticatorRepositorySpec(implicit ev: ExecutionEnv) extends Specif
     "remove value from cache" in new Context {
       cacheLayer.remove("test-id") returns Future.successful(())
 
-      repository.remove("test-id") must beEqualTo(()).await
+      repository.remove("test-id") must beEqualTo(()).awaitWithPatience
       there was one(cacheLayer).remove("test-id")
     }
   }

--- a/silhouette-persistence/src/test/scala/com/mohiva/play/silhouette/persistence/repositories/DelegableAuthInfoRepositorySpec.scala
+++ b/silhouette-persistence/src/test/scala/com/mohiva/play/silhouette/persistence/repositories/DelegableAuthInfoRepositorySpec.scala
@@ -23,6 +23,7 @@ import com.mohiva.play.silhouette.api.{ AuthInfo, LoginInfo }
 import com.mohiva.play.silhouette.impl.providers.{ OAuth1Info, OAuth2Info }
 import com.mohiva.play.silhouette.persistence.daos.{ DelegableAuthInfoDAO, InMemoryAuthInfoDAO }
 import com.mohiva.play.silhouette.persistence.repositories.DelegableAuthInfoRepository._
+import com.mohiva.play.silhouette.test.WaitPatience
 import net.codingwell.scalaguice.ScalaModule
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.control.NoLanguageFeatures
@@ -38,7 +39,7 @@ import scala.language.postfixOps
  * Test case for the [[DelegableAuthInfoRepository]] trait.
  */
 class DelegableAuthInfoRepositorySpec(implicit ev: ExecutionEnv)
-  extends Specification with Mockito with NoLanguageFeatures {
+  extends Specification with Mockito with NoLanguageFeatures with WaitPatience {
 
   "The `find` method" should {
     "delegate the PasswordInfo to the correct DAO" in new Context {
@@ -46,7 +47,7 @@ class DelegableAuthInfoRepositorySpec(implicit ev: ExecutionEnv)
 
       Await.result(passwordInfoDAO.add(loginInfo, passwordInfo), 10 seconds)
 
-      service.find[PasswordInfo](loginInfo) must beSome(passwordInfo).await
+      service.find[PasswordInfo](loginInfo) must beSome(passwordInfo).awaitWithPatience
       there was one(passwordInfoDAO).find(loginInfo)
     }
 
@@ -55,7 +56,7 @@ class DelegableAuthInfoRepositorySpec(implicit ev: ExecutionEnv)
 
       Await.result(oauth1InfoDAO.add(loginInfo, oauth1Info), 10 seconds)
 
-      service.find[OAuth1Info](loginInfo) must beSome(oauth1Info).await
+      service.find[OAuth1Info](loginInfo) must beSome(oauth1Info).awaitWithPatience
       there was one(oauth1InfoDAO).find(loginInfo)
     }
 
@@ -64,7 +65,7 @@ class DelegableAuthInfoRepositorySpec(implicit ev: ExecutionEnv)
 
       Await.result(oauth2InfoDAO.add(loginInfo, oauth2Info), 10 seconds)
 
-      service.find[OAuth2Info](loginInfo) must beSome(oauth2Info).await
+      service.find[OAuth2Info](loginInfo) must beSome(oauth2Info).awaitWithPatience
       there was one(oauth2InfoDAO).find(loginInfo)
     }
 
@@ -73,7 +74,7 @@ class DelegableAuthInfoRepositorySpec(implicit ev: ExecutionEnv)
 
       service.find[UnsupportedInfo](loginInfo) must throwA[ConfigurationException].like {
         case e => e.getMessage must startWith(FindError.format(classOf[UnsupportedInfo]))
-      }.await
+      }.awaitWithPatience
     }
   }
 
@@ -81,21 +82,21 @@ class DelegableAuthInfoRepositorySpec(implicit ev: ExecutionEnv)
     "delegate the PasswordInfo to the correct DAO" in new Context {
       val loginInfo = LoginInfo("credentials", "1")
 
-      service.add(loginInfo, passwordInfo) must beEqualTo(passwordInfo).await
+      service.add(loginInfo, passwordInfo) must beEqualTo(passwordInfo).awaitWithPatience
       there was one(passwordInfoDAO).add(loginInfo, passwordInfo)
     }
 
     "delegate the OAuth1Info to the correct DAO" in new Context {
       val loginInfo = LoginInfo("credentials", "1")
 
-      service.add(loginInfo, oauth1Info) must beEqualTo(oauth1Info).await
+      service.add(loginInfo, oauth1Info) must beEqualTo(oauth1Info).awaitWithPatience
       there was one(oauth1InfoDAO).add(loginInfo, oauth1Info)
     }
 
     "delegate the OAuth2Info to the correct DAO" in new Context {
       val loginInfo = LoginInfo("credentials", "1")
 
-      service.add(loginInfo, oauth2Info) must beEqualTo(oauth2Info).await
+      service.add(loginInfo, oauth2Info) must beEqualTo(oauth2Info).awaitWithPatience
       there was one(oauth2InfoDAO).add(loginInfo, oauth2Info)
     }
 
@@ -104,7 +105,7 @@ class DelegableAuthInfoRepositorySpec(implicit ev: ExecutionEnv)
 
       service.add(loginInfo, new UnsupportedInfo) must throwA[ConfigurationException].like {
         case e => e.getMessage must startWith(AddError.format(classOf[UnsupportedInfo]))
-      }.await
+      }.awaitWithPatience
     }
   }
 
@@ -112,21 +113,21 @@ class DelegableAuthInfoRepositorySpec(implicit ev: ExecutionEnv)
     "delegate the PasswordInfo to the correct DAO" in new Context {
       val loginInfo = LoginInfo("credentials", "1")
 
-      service.update(loginInfo, passwordInfo) must beEqualTo(passwordInfo).await
+      service.update(loginInfo, passwordInfo) must beEqualTo(passwordInfo).awaitWithPatience
       there was one(passwordInfoDAO).update(loginInfo, passwordInfo)
     }
 
     "delegate the OAuth1Info to the correct DAO" in new Context {
       val loginInfo = LoginInfo("credentials", "1")
 
-      service.update(loginInfo, oauth1Info) must beEqualTo(oauth1Info).await
+      service.update(loginInfo, oauth1Info) must beEqualTo(oauth1Info).awaitWithPatience
       there was one(oauth1InfoDAO).update(loginInfo, oauth1Info)
     }
 
     "delegate the OAuth2Info to the correct DAO" in new Context {
       val loginInfo = LoginInfo("credentials", "1")
 
-      service.update(loginInfo, oauth2Info) must beEqualTo(oauth2Info).await
+      service.update(loginInfo, oauth2Info) must beEqualTo(oauth2Info).awaitWithPatience
       there was one(oauth2InfoDAO).update(loginInfo, oauth2Info)
     }
 
@@ -135,7 +136,7 @@ class DelegableAuthInfoRepositorySpec(implicit ev: ExecutionEnv)
 
       service.update(loginInfo, new UnsupportedInfo) must throwA[ConfigurationException].like {
         case e => e.getMessage must startWith(UpdateError.format(classOf[UnsupportedInfo]))
-      }.await
+      }.awaitWithPatience
     }
   }
 
@@ -143,21 +144,21 @@ class DelegableAuthInfoRepositorySpec(implicit ev: ExecutionEnv)
     "delegate the PasswordInfo to the correct DAO" in new Context {
       val loginInfo = LoginInfo("credentials", "1")
 
-      service.save(loginInfo, passwordInfo) must beEqualTo(passwordInfo).await
+      service.save(loginInfo, passwordInfo) must beEqualTo(passwordInfo).awaitWithPatience
       there was one(passwordInfoDAO).save(loginInfo, passwordInfo)
     }
 
     "delegate the OAuth1Info to the correct DAO" in new Context {
       val loginInfo = LoginInfo("credentials", "1")
 
-      service.save(loginInfo, oauth1Info) must beEqualTo(oauth1Info).await
+      service.save(loginInfo, oauth1Info) must beEqualTo(oauth1Info).awaitWithPatience
       there was one(oauth1InfoDAO).save(loginInfo, oauth1Info)
     }
 
     "delegate the OAuth2Info to the correct DAO" in new Context {
       val loginInfo = LoginInfo("credentials", "1")
 
-      service.save(loginInfo, oauth2Info) must beEqualTo(oauth2Info).await
+      service.save(loginInfo, oauth2Info) must beEqualTo(oauth2Info).awaitWithPatience
       there was one(oauth2InfoDAO).save(loginInfo, oauth2Info)
     }
 
@@ -166,7 +167,7 @@ class DelegableAuthInfoRepositorySpec(implicit ev: ExecutionEnv)
 
       service.save(loginInfo, new UnsupportedInfo) must throwA[ConfigurationException].like {
         case e => e.getMessage must startWith(SaveError.format(classOf[UnsupportedInfo]))
-      }.await
+      }.awaitWithPatience
     }
   }
 
@@ -176,7 +177,7 @@ class DelegableAuthInfoRepositorySpec(implicit ev: ExecutionEnv)
 
       Await.result(passwordInfoDAO.add(loginInfo, passwordInfo), 10 seconds)
 
-      service.remove[PasswordInfo](loginInfo) must beEqualTo(()).await
+      service.remove[PasswordInfo](loginInfo) must beEqualTo(()).awaitWithPatience
       there was one(passwordInfoDAO).remove(loginInfo)
     }
 
@@ -185,7 +186,7 @@ class DelegableAuthInfoRepositorySpec(implicit ev: ExecutionEnv)
 
       Await.result(oauth1InfoDAO.add(loginInfo, oauth1Info), 10 seconds)
 
-      service.remove[OAuth1Info](loginInfo) must beEqualTo(()).await
+      service.remove[OAuth1Info](loginInfo) must beEqualTo(()).awaitWithPatience
       there was one(oauth1InfoDAO).remove(loginInfo)
     }
 
@@ -194,7 +195,7 @@ class DelegableAuthInfoRepositorySpec(implicit ev: ExecutionEnv)
 
       Await.result(oauth2InfoDAO.add(loginInfo, oauth2Info), 10 seconds)
 
-      service.remove[OAuth2Info](loginInfo) must beEqualTo(()).await
+      service.remove[OAuth2Info](loginInfo) must beEqualTo(()).awaitWithPatience
       there was one(oauth2InfoDAO).remove(loginInfo)
     }
 
@@ -203,7 +204,7 @@ class DelegableAuthInfoRepositorySpec(implicit ev: ExecutionEnv)
 
       service.remove[UnsupportedInfo](loginInfo) must throwA[ConfigurationException].like {
         case e => e.getMessage must startWith(RemoveError.format(classOf[UnsupportedInfo]))
-      }.await
+      }.awaitWithPatience
     }
   }
 

--- a/silhouette-persistence/src/test/scala/com/mohiva/play/silhouette/test/WaitPatience.scala
+++ b/silhouette-persistence/src/test/scala/com/mohiva/play/silhouette/test/WaitPatience.scala
@@ -1,0 +1,23 @@
+package com.mohiva.play.silhouette.test
+
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.matcher.FutureMatchers.FutureMatchable
+import org.specs2.matcher.Matcher
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.languageFeature.implicitConversions
+
+trait WaitPatience {
+
+  def retries = 10
+
+  def timeout = 1.second
+
+  implicit class WaitWithPatienceFutureMatchable[T](m: Matcher[T])(implicit ee: ExecutionEnv) extends FutureMatchable[T](m)(ee) {
+    def awaitWithPatience: Matcher[Future[T]] = {
+      await(retries, timeout)
+    }
+  }
+
+}

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/LinkedInProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/LinkedInProviderSpec.scala
@@ -88,7 +88,7 @@ class LinkedInProviderSpec extends OAuth1ProviderSpec {
 
       await(provider.retrieveProfile(oAuthInfo))
 
-      there was one(httpLayer.url(url))
+      there was one(httpLayer).url(url)
     }
 
     "return the social profile" in new WithApplication with Context {

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/TwitterProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/TwitterProviderSpec.scala
@@ -85,7 +85,7 @@ class TwitterProviderSpec extends OAuth1ProviderSpec {
 
       await(provider.retrieveProfile(oAuthInfo))
 
-      there was one(httpLayer.url(url))
+      there was one(httpLayer).url(url)
     }
 
     "return the social profile" in new WithApplication with Context {

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/XingProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/XingProviderSpec.scala
@@ -85,7 +85,7 @@ class XingProviderSpec extends OAuth1ProviderSpec {
 
       await(provider.retrieveProfile(oAuthInfo))
 
-      there was one(httpLayer.url(url))
+      there was one(httpLayer).url(url)
     }
 
     "return the social profile" in new WithApplication with Context {

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/ClefProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/ClefProviderSpec.scala
@@ -113,7 +113,7 @@ class ClefProviderSpec extends OAuth2ProviderSpec {
 
       await(provider.retrieveProfile(oAuthInfo.as[OAuth2Info]))
 
-      there was one(httpLayer.url(url.format("my.access.token")))
+      there was one(httpLayer).url(url.format("my.access.token"))
     }
 
     "return the social profile" in new WithApplication with Context {

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/DropboxProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/DropboxProviderSpec.scala
@@ -122,7 +122,7 @@ class DropboxProviderSpec extends OAuth2ProviderSpec {
 
       await(provider.retrieveProfile(authInfo))
 
-      there was one(httpLayer.url(url))
+      there was one(httpLayer).url(url)
     }
 
     "return the social profile" in new WithApplication with Context {

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/FacebookProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/FacebookProviderSpec.scala
@@ -115,7 +115,7 @@ class FacebookProviderSpec extends OAuth2ProviderSpec {
 
       await(provider.retrieveProfile(oAuthInfo.as[OAuth2Info]))
 
-      there was one(httpLayer.url(url.format("my.access.token")))
+      there was one(httpLayer).url(url.format("my.access.token"))
     }
 
     "return the social profile" in new WithApplication with Context {

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/FoursquareProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/FoursquareProviderSpec.scala
@@ -115,7 +115,7 @@ class FoursquareProviderSpec extends OAuth2ProviderSpec {
 
       await(provider.retrieveProfile(oAuthInfo.as[OAuth2Info]))
 
-      there was one(httpLayer.url(url.format("my.access.token")))
+      there was one(httpLayer).url(url.format("my.access.token"))
     }
 
     "return the social profile" in new WithApplication with Context {

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/GitHubProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/GitHubProviderSpec.scala
@@ -115,7 +115,7 @@ class GitHubProviderSpec extends OAuth2ProviderSpec {
 
       await(provider.retrieveProfile(oAuthInfo.as[OAuth2Info]))
 
-      there was one(httpLayer.url(url.format("my.access.token")))
+      there was one(httpLayer).url(url.format("my.access.token"))
     }
 
     "return the social profile" in new WithApplication with Context {

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/GoogleProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/GoogleProviderSpec.scala
@@ -114,7 +114,7 @@ class GoogleProviderSpec extends OAuth2ProviderSpec {
 
       await(provider.retrieveProfile(oAuthInfo.as[OAuth2Info]))
 
-      there was one(httpLayer.url(url.format("my.access.token")))
+      there was one(httpLayer).url(url.format("my.access.token"))
     }
 
     "return the social profile with an email" in new WithApplication with Context {

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/InstagramProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/InstagramProviderSpec.scala
@@ -115,7 +115,7 @@ class InstagramProviderSpec extends OAuth2ProviderSpec {
 
       await(provider.retrieveProfile(oAuthInfo.as[OAuth2Info]))
 
-      there was one(httpLayer.url(url.format("my.access.token")))
+      there was one(httpLayer).url(url.format("my.access.token"))
     }
 
     "return the social profile" in new WithApplication with Context {

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/LinkedInProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/LinkedInProviderSpec.scala
@@ -117,7 +117,7 @@ class LinkedInProviderSpec extends OAuth2ProviderSpec {
 
       await(provider.retrieveProfile(oAuthInfo.as[OAuth2Info]))
 
-      there was one(httpLayer.url(url.format("my.access.token")))
+      there was one(httpLayer).url(url.format("my.access.token"))
     }
 
     "return the social profile" in new WithApplication with Context {

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/VKProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/VKProviderSpec.scala
@@ -114,7 +114,7 @@ class VKProviderSpec extends OAuth2ProviderSpec {
 
       await(provider.retrieveProfile(oAuthInfo.as[OAuth2Info]))
 
-      there was one(httpLayer.url(url.format("my.access.token")))
+      there was one(httpLayer).url(url.format("my.access.token"))
     }
 
     "return the social profile with email" in new WithApplication with Context {


### PR DESCRIPTION
Since the introduction of API URL override in ad7bcdc5 the build was
inevitably broken because of a wrong Mockito validate statement. 
Travis did not detect the breakage because of the missing "-e" option
on the bash execution, thus the final "echo" was shallowing the exit
code of the test.

This change fixes the build ci script *AND* the Mockito validation
statement.