### PR TITLE
Include logRounds in BCryptPasswordHasher.id

### DIFF
--- a/silhouette-password-bcrypt/src/main/scala/com/mohiva/play/silhouette/password/BCryptPasswordHasher.scala
+++ b/silhouette-password-bcrypt/src/main/scala/com/mohiva/play/silhouette/password/BCryptPasswordHasher.scala
@@ -36,7 +36,7 @@ class BCryptPasswordHasher(logRounds: Int = 10) extends PasswordHasher {
    *
    * @return The ID of the hasher.
    */
-  override def id = ID
+  override def id = ID + logRounds
 
   /**
    * Hashes a password.

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/CredentialsProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/CredentialsProvider.scala
@@ -49,6 +49,9 @@ class CredentialsProvider @Inject() (
   passwordHasher: PasswordHasher,
   passwordHasherList: Seq[PasswordHasher])(implicit val executionContext: ExecutionContext)
   extends Provider with ExecutionContextProvider {
+    
+  require(passwordHasherList.map(_.id).toSet.size == passwordHasherList.size,
+    "Every PasswordHasher must have a unique ID")
 
   /**
    * Gets the provider ID.


### PR DESCRIPTION
My understanding of `CredentialsProvider` is that it is to be set up something like this:

```scala
val passwordHasher = new BCryptPasswordHasher(10)
new CredentialsProvider(authInfoRepository, passwordHasher, List(passwordHasher))
```

but then someday someone may want to increase the number of rounds, and so they'll do this:

```scala
val passwordHasher = new BCryptPasswordHasher(12)
new CredentialsProvider(authInfoRepository, passwordHasher, List(passwordHasher, new BCryptPasswordHasher(10)))
```

This can only work correctly if the hashers have distinct IDs, which they don't.
Perhaps https://github.com/mohiva/play-silhouette/blob/master/silhouette/test/com/mohiva/play/silhouette/impl/providers/CredentialsProviderSpec.scala should include a test with actual hashers and not just mocks to prove this.