### PR TITLE
Added failing test to show that BCryptPasswordHasher needs distinct IDs

### DIFF
--- a/silhouette-password-bcrypt/build.sbt
+++ b/silhouette-password-bcrypt/build.sbt
@@ -2,7 +2,8 @@ import Dependencies._
 
 libraryDependencies ++= Seq(
   Library.jbcrypt,
-  Library.Specs2.core % Test
+  Library.Specs2.core % Test,
+  Library.Play.Specs2.mock % Test
 )
 
 enablePlugins(Doc)

--- a/silhouette-password-bcrypt/src/main/scala/com/mohiva/play/silhouette/password/BCryptPasswordHasher.scala
+++ b/silhouette-password-bcrypt/src/main/scala/com/mohiva/play/silhouette/password/BCryptPasswordHasher.scala
@@ -36,7 +36,7 @@ class BCryptPasswordHasher(logRounds: Int = 10) extends PasswordHasher {
    *
    * @return The ID of the hasher.
    */
-  override def id = ID
+  override def id = ID + logRounds
 
   /**
    * Hashes a password.

--- a/silhouette-password-bcrypt/src/test/scala/com/mohiva/play/silhouette/password/BCryptPasswordHasherSpec.scala
+++ b/silhouette-password-bcrypt/src/test/scala/com/mohiva/play/silhouette/password/BCryptPasswordHasherSpec.scala
@@ -35,11 +35,12 @@ class BCryptPasswordHasherSpec extends Specification with Mockito {
   "The `hash` method" should {
     "hash a password" in {
       val password = "my_S3cr3t_p@sswQrd"
-      val hasher = new BCryptPasswordHasher
+      val logRounds = 10
+      val hasher = new BCryptPasswordHasher(logRounds)
       val info = hasher.hash(password)
 
       info must beAnInstanceOf[PasswordInfo]
-      info.hasher must be equalTo BCryptPasswordHasher.ID
+      info.hasher must be equalTo BCryptPasswordHasher.ID + logRounds
       info.password must not be equalTo(password)
       info.salt must beNone
     }

--- a/silhouette-password-bcrypt/src/test/scala/com/mohiva/play/silhouette/password/BCryptPasswordHasherSpec.scala
+++ b/silhouette-password-bcrypt/src/test/scala/com/mohiva/play/silhouette/password/BCryptPasswordHasherSpec.scala
@@ -15,13 +15,22 @@
  */
 package com.mohiva.play.silhouette.password
 
-import com.mohiva.play.silhouette.api.util.PasswordInfo
+import com.mohiva.play.silhouette.api.LoginInfo
+import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
+import com.mohiva.play.silhouette.api.util.{Credentials, PasswordInfo}
+import com.mohiva.play.silhouette.impl.providers.CredentialsProvider
+import org.mockito.Matchers
+import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
+import play.api.libs.concurrent.Execution.Implicits._
+
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, Future}
 
 /**
  * Test case for the [[BCryptPasswordHasher]] class.
  */
-class BCryptPasswordHasherSpec extends Specification {
+class BCryptPasswordHasherSpec extends Specification with Mockito {
 
   "The `hash` method" should {
     "hash a password" in {
@@ -51,6 +60,24 @@ class BCryptPasswordHasherSpec extends Specification {
       val info = hasher.hash(password)
 
       hasher.matches(info, "not-equal") must beFalse
+    }
+  }
+
+  "The `authenticate` method of CredentialsProvider" should {
+    "re-hash password with new hasher" in {
+      val credentials = Credentials("apollonia.vanova@watchmen.com", "s3cr3t")
+      val authInfoRepository = mock[AuthInfoRepository]
+      val oldHasher = new BCryptPasswordHasher(5)
+      val newHasher = new BCryptPasswordHasher(7)
+      val provider = new CredentialsProvider(authInfoRepository, newHasher, List(newHasher, oldHasher))
+      val loginInfo = LoginInfo(provider.id, credentials.identifier)
+      val passwordInfo = oldHasher.hash(credentials.password)
+
+      authInfoRepository.find[PasswordInfo](loginInfo) returns Future.successful(Some(passwordInfo))
+      authInfoRepository.update[PasswordInfo](Matchers.eq(loginInfo), Matchers.anyObject()) returns Future.successful(passwordInfo)
+
+      Await.result(provider.authenticate(credentials), 5.seconds) must be equalTo loginInfo
+      there was one(authInfoRepository).update(Matchers.eq(loginInfo), Matchers.anyObject())
     }
   }
 }

--- a/silhouette-password-bcrypt/src/test/scala/com/mohiva/play/silhouette/password/PasswordInfoSpec.scala
+++ b/silhouette-password-bcrypt/src/test/scala/com/mohiva/play/silhouette/password/PasswordInfoSpec.scala
@@ -1,0 +1,22 @@
+package com.mohiva.play.silhouette.password
+
+import com.mohiva.play.silhouette.api.util.PasswordInfo
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+
+class PasswordInfoSpec extends Specification with Mockito {
+
+  "The `hasher` val" should {
+    "normally equal the constructor parameter" in {
+      PasswordInfo("hasher", "password").hasher must be equalTo "hasher"
+    }
+
+    "fix itself when given simply as 'bcrypt'" in {
+      val hasher = new BCryptPasswordHasher(6)
+      val correctPasswordInfo = hasher.hash("password")
+      val legacyPasswordInfo = PasswordInfo(BCryptPasswordHasher.ID, correctPasswordInfo.password)
+      legacyPasswordInfo.hasher must not be equalTo(BCryptPasswordHasher.ID)
+      correctPasswordInfo must be equalTo legacyPasswordInfo
+    }
+  }
+}

--- a/silhouette/app/com/mohiva/play/silhouette/api/util/PasswordHasher.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/util/PasswordHasher.scala
@@ -28,7 +28,18 @@ import com.mohiva.play.silhouette.api.AuthInfo
  * @param password The hashed password.
  * @param salt The optional salt used when hashing.
  */
-case class PasswordInfo(hasher: String, password: String, salt: Option[String] = None) extends AuthInfo
+case class PasswordInfo(var hasher: String, password: String, salt: Option[String] = None) extends AuthInfo {
+  if (hasher == "bcrypt") {
+    val PasswordInfo.BCRYPT_PASSWORD_PATTERN(logRounds) = password
+    hasher += logRounds.toInt  // toInt strips leading 0
+  }
+}
+
+object PasswordInfo {
+
+  private val BCRYPT_PASSWORD_PATTERN = """^\$\w{2}\$(\d{2})\$.+""".r
+
+}
 
 /**
  * A trait that defines the password hasher interface.


### PR DESCRIPTION
Related: #456 and #454 

Adding `logRounds` to the `id` fixes the test.

The test will pass if the hasher list is reversed, i.e. `List(oldHasher, newHasher)`, meaning that this bug is not 'well-behaved'.

The test still fails if the hasher list is simply `List(newHasher)`.

Making the hasher a case class makes no difference.

I expect that the code for the test can be improved as this is my first time dealing with these libraries.