### PR TITLE
Define meaningful interface for password re-hashing

### DIFF
--- a/silhouette-password-bcrypt/src/main/scala/com/mohiva/play/silhouette/password/BCryptPasswordHasher.scala
+++ b/silhouette-password-bcrypt/src/main/scala/com/mohiva/play/silhouette/password/BCryptPasswordHasher.scala
@@ -26,14 +26,10 @@ import org.mindrot.jbcrypt.BCrypt
 /**
  * Implementation of the password hasher based on BCrypt.
  *
- * We declare this class as case class so that the compiler can create the `equals` method for us. This
- * is needed for the credentials based providers as an indicator that a password should be re-hashed,
- * if the log rounds value was changed.
- *
  * @param logRounds The log2 of the number of rounds of hashing to apply.
  * @see [[http://www.mindrot.org/files/jBCrypt/jBCrypt-0.2-doc/BCrypt.html#gensalt(int) gensalt]]
  */
-case class BCryptPasswordHasher(logRounds: Int = 10) extends PasswordHasher {
+class BCryptPasswordHasher(logRounds: Int = 10) extends PasswordHasher {
 
   /**
    * Gets the ID of the hasher.
@@ -51,7 +47,10 @@ case class BCryptPasswordHasher(logRounds: Int = 10) extends PasswordHasher {
    * @param plainPassword The password to hash.
    * @return A PasswordInfo containing the hashed password.
    */
-  override def hash(plainPassword: String) = PasswordInfo(id, BCrypt.hashpw(plainPassword, BCrypt.gensalt(logRounds)))
+  override def hash(plainPassword: String) = PasswordInfo(
+    hasher = id,
+    password = BCrypt.hashpw(plainPassword, BCrypt.gensalt(logRounds))
+  )
 
   /**
    * Checks if a password matches the hashed version.
@@ -62,6 +61,24 @@ case class BCryptPasswordHasher(logRounds: Int = 10) extends PasswordHasher {
    */
   override def matches(passwordInfo: PasswordInfo, suppliedPassword: String) = {
     BCrypt.checkpw(suppliedPassword, passwordInfo.password)
+  }
+
+  /**
+   * Indicates if a password info hashed with this hasher is deprecated.
+   *
+   * In case of the BCrypt password hasher, a password is deprecated if the log rounds have changed.
+   *
+   * @param passwordInfo The password info to check the deprecation status for.
+   * @return True if the given password info is deprecated, false otherwise. If a hasher isn't
+   *         suitable for the given password, this method should return None.
+   */
+  override def isDeprecated(passwordInfo: PasswordInfo): Option[Boolean] = {
+    Option(isSuitable(passwordInfo)).collect {
+      case true =>
+        val LogRoundsPattern(lr) = passwordInfo.password
+        // Is deprecated if the log rounds has changed
+        lr != logRounds.toString
+    }
   }
 }
 
@@ -74,4 +91,9 @@ object BCryptPasswordHasher {
    * The ID of the hasher.
    */
   val ID = "bcrypt"
+
+  /**
+   * The pattern to extract the log rounds from the password string.
+   */
+  val LogRoundsPattern = """^\$\w{2}\$(\d{1,2})\$.+""".r
 }

--- a/silhouette-persistence/src/test/scala/com/mohiva/play/silhouette/test/WaitPatience.scala
+++ b/silhouette-persistence/src/test/scala/com/mohiva/play/silhouette/test/WaitPatience.scala
@@ -19,5 +19,4 @@ trait WaitPatience {
       await(retries, timeout)
     }
   }
-
 }

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/PasswordProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/PasswordProvider.scala
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mohiva.play.silhouette.impl.providers
+
+import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
+import com.mohiva.play.silhouette.api.util.{ ExecutionContextProvider, PasswordHasherRegistry, PasswordInfo }
+import com.mohiva.play.silhouette.api.{ LoginInfo, Provider }
+import com.mohiva.play.silhouette.impl.providers.PasswordProvider._
+
+import scala.concurrent.Future
+
+/**
+ * Base provider which provides shared functionality to authenticate with a password.
+ */
+trait PasswordProvider extends Provider with ExecutionContextProvider {
+
+  /**
+   * The authentication state.
+   */
+  sealed trait State
+
+  /**
+   * Indicates that the authentication was successful.
+   */
+  case object Authenticated extends State
+
+  /**
+   * Indicates that the entered password doesn't match with the stored one.
+   */
+  case class InvalidPassword(error: String) extends State
+
+  /**
+   * Indicates that the stored password cannot be checked with the registered hashers.
+   */
+  case class UnsupportedHasher(error: String) extends State
+
+  /**
+   * Indicates that no password info was stored for the login info.
+   */
+  case class NotFound(error: String) extends State
+
+  /**
+   * The auth info repository.
+   */
+  protected val authInfoRepository: AuthInfoRepository
+
+  /**
+   * The password hashers used by the application.
+   */
+  protected val passwordHasherRegistry: PasswordHasherRegistry
+
+  /**
+   * Authenticates a user
+   *
+   * @param loginInfo The login info to search the password info for.
+   * @param password The user password to authenticate with.
+   * @return The authentication state.
+   */
+  def authenticate(loginInfo: LoginInfo, password: String): Future[State] = {
+    authInfoRepository.find[PasswordInfo](loginInfo).flatMap {
+      case Some(passwordInfo) => passwordHasherRegistry.find(passwordInfo) match {
+        case Some(hasher) if hasher.matches(passwordInfo, password) =>
+          if (passwordHasherRegistry.isDeprecated(hasher) || hasher.isDeprecated(passwordInfo).contains(true)) {
+            authInfoRepository.update(loginInfo, passwordHasherRegistry.current.hash(password)).map { _ =>
+              Authenticated
+            }
+          } else {
+            Future.successful(Authenticated)
+          }
+        case Some(hasher) => Future.successful(InvalidPassword(PasswordDoesNotMatch.format(id)))
+        case None => Future.successful(UnsupportedHasher(HasherIsNotRegistered.format(
+          id, passwordInfo.hasher, passwordHasherRegistry.all.map(_.id).mkString(", ")
+        )))
+      }
+      case None => Future.successful(NotFound(PasswordInfoNotFound.format(id, loginInfo)))
+    }
+  }
+}
+
+/**
+ * The companion object.
+ */
+object PasswordProvider {
+
+  /**
+   * The error messages.
+   */
+  val PasswordDoesNotMatch = "[Silhouette][%s] Passwords does not match"
+  val HasherIsNotRegistered = "[Silhouette][%s] Stored hasher ID `%s` isn't registered as supported hasher: %s"
+  val PasswordInfoNotFound = "[Silhouette][%s] Could not find password info for given login info: %s"
+}

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/PasswordProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/PasswordProviderSpec.scala
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mohiva.play.silhouette.impl.providers
+
+import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
+import com.mohiva.play.silhouette.api.util._
+import org.specs2.mock.Mockito
+import org.specs2.specification.Scope
+import play.api.test.PlaySpecification
+
+/**
+ * Abstract test case for the [[com.mohiva.play.silhouette.impl.providers.PasswordProvider]] based class.
+ */
+trait PasswordProviderSpec extends PlaySpecification with Mockito {
+
+  /**
+   * The context.
+   */
+  trait BaseContext extends Scope {
+
+    /**
+     * The default password hasher.
+     */
+    lazy val fooHasher = hasher("foo")
+
+    /**
+     * A deprecated password hasher.
+     */
+    lazy val barHasher = hasher("bar")
+
+    /**
+     * The auth info repository mock.
+     */
+    lazy val authInfoRepository = mock[AuthInfoRepository]
+
+    /**
+     * The password hasher registry.
+     */
+    lazy val passwordHasherRegistry = new PasswordHasherRegistry(fooHasher, Seq(barHasher))
+
+    /**
+     * Helper method to create a hasher mock.
+     *
+     * @param id The ID of the hasher.
+     * @return A hasher mock.
+     */
+    private def hasher(id: String) = {
+      val h = mock[PasswordHasher]
+      h.id returns id
+      h.isSuitable(any) answers { p =>
+        p.asInstanceOf[PasswordInfo].hasher == h.id
+      }
+      h.isDeprecated(any) returns Some(false)
+      h
+    }
+  }
+}


### PR DESCRIPTION
WIP

In contrast to the current implementation it now defines the clear responsibility for every component. Currently this is defined squishy in the interface and therefore can lead to bugs like #454 or #459.

What are the changes for the user:
It's now unambiguous when a password hasher or a password is deprecated and when it should be updated with a newer algorithm. This is now defined through the `PasswordHasherRegistry`. It accepts two parameters. The current preferred algorithm and the list of deprecated hashers which are needed to macht the old hashes which are stored in the database.

So to instantiate the `CredentialsProvider` as example, a user must now write:
```scala
new CredentialsProvider(..., new PasswordHasherRegistry(new BCryptPassordHasher(10)))
```

instead of

```scala
new CredentialsProvider(..., new BCryptPassordHasher(10), Seq(new BCryptPassordHasher(10)))
```

I can now handle the case of a deprecated password for a not deprecated password hasher as described in #454.

The user can only increase the log rounds for a password hasher:
```scala
new CredentialsProvider(..., new PasswordHasherRegistry(new BCryptPassordHasher(20)))
```

If another password hashing algorihtm should be used, then it's now clear defined what hasher is preferred and which is deprecated.
```scala
new CredentialsProvider(..., new PasswordHasherRegistry(new SCryptPassordHasher(), Seq(new BCryptPassordHasher())))
```

instead of

```scala
new CredentialsProvider(..., new SCryptPassordHasher(), Seq(new SCryptPassordHasher(), new BCryptPassordHasher())))
```

This pull request introduces a new optional `metadata` field for the `PasswordInfo` class. so if you need a relational SQL database, then you must add this field to your database table. This additional field is needed to store additional data for a hasher which can be used to check if a password is deprecated or not. It's not needed to convert you data in the database.