### PR TITLE
Accessing SecuredAction without authentication warns about duplicate Content-Type

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/api/ErrorHandler.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/ErrorHandler.scala
@@ -182,11 +182,11 @@ trait DefaultErrorHandler
   protected def produceResponse[S <: Status](status: S, msg: String)(implicit request: RequestHeader): Future[Result] = {
     import Codec._
     Future.successful(render {
-      case Accepts.Html() => status(toHtmlError(msg)).as(HTML).withHeaders(HeaderNames.CONTENT_TYPE -> ContentTypes.HTML)
+      case Accepts.Html() => status(toHtmlError(msg)).as(HTML)
       // This will also be the default content type if the client doesn't request a specific media type.
-      case Accepts.Json() => status(toJsonError(msg)).withHeaders(HeaderNames.CONTENT_TYPE -> ContentTypes.JSON)
-      case Accepts.Xml()  => status(toXmlError(msg)).withHeaders(HeaderNames.CONTENT_TYPE -> ContentTypes.XML)
-      case _              => status(toPlainTextError(msg)).withHeaders(HeaderNames.CONTENT_TYPE -> ContentTypes.TEXT)
+      case Accepts.Json() => status(toJsonError(msg))
+      case Accepts.Xml()  => status(toXmlError(msg))
+      case _              => status(toPlainTextError(msg))
       // The correct HTTP status code must be returned in any situation.
       // The response format will default to plain text in case the request does not specify one of known
       // media types. The user agent is responsible for inspecting the response headers as specified in

--- a/silhouette/test/com/mohiva/play/silhouette/api/ErrorHandlerSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/api/ErrorHandlerSpec.scala
@@ -16,10 +16,10 @@
 package com.mohiva.play.silhouette.api
 
 import org.specs2.matcher.Scope
-import play.api.http.ContentTypes._
+import play.api.http.MimeTypes._
 import play.api.i18n.{ I18nSupport, Messages, MessagesApi }
-import play.api.mvc.{ Result, RequestHeader }
-import play.api.test.{ FakeRequest, WithApplication, PlaySpecification }
+import play.api.mvc.{ RequestHeader, Result }
+import play.api.test.{ FakeRequest, PlaySpecification, WithApplication }
 
 import scala.concurrent.Future
 
@@ -195,7 +195,7 @@ class ErrorHandlerSpec extends PlaySpecification {
       val result = f(request)
 
       status(result) must equalTo(expectedStatus)
-      header(CONTENT_TYPE, result) must beSome(expectedContentType)
+      contentType(result) must beSome(expectedContentType)
       contentAsString(result) must contain(expectedResponseFragment)
       contentAsString(result) must contain(Messages(expectedMessage))
     }


### PR DESCRIPTION
Play: 2.5.1
Silhouette: 4.0.0-BETA4

```
def postAny() = silhouette.SecuredAction.async { request =>
  Future.successful(Ok(""))
}
```

If that action is requested without authentication headers, play 2.5 prints

`[warn] - play.core.server.netty.NettyModelConversion - Content-Type set both in header (text/html; charset=utf-8) and attached to entity (text/html; charset=utf-8), ignoring content type from entity. To remove this warning, use Result.as(...) to set the content type, rather than setting the header manually.`

Looks like `DefaultErrorHandler.produceResponse` should not use `.withHeaders(HeaderNames.CONTENT_TYPE -> ContentTypes.JSON)`