### PR TITLE
Remove default binding for persistence memory module

### DIFF
--- a/silhouette-persistence-memory/src/main/resources/reference.conf
+++ b/silhouette-persistence-memory/src/main/resources/reference.conf
@@ -1,3 +1,0 @@
-# The application DI modules
-# ~~~~~
-play.modules.enabled += "com.mohiva.play.silhouette.persistence.memory.modules.PersistenceModule"


### PR DESCRIPTION
## Fixes

Fixes #466 https://github.com/mohiva/play-silhouette-angular-seed/issues/42

## Purpose

Removes the `reference.conf` from module and therefore remove the default binding for the `PersistenceModule`.

## Background Context

Defining the default binding when the module is included isn't a good idea, because it confuses people and it makes it hard to define a custom `AuthInfoRepository` because then the module must first be disabled.
