### PR TITLE
[WIP] Prototyped refresh for OAuth2 Bearers

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -32,7 +32,7 @@ object BasicSettings extends AutoPlugin {
 
   override def projectSettings = Seq(
     organization := "com.mohiva",
-    version := "4.0.0-BETA4",
+    version := "4.0.0-BETA5",
     resolvers ++= Dependencies.resolvers,
     scalaVersion := Dependencies.Versions.scalaVersion,
     crossScalaVersions := Dependencies.Versions.crossScala,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -57,5 +57,6 @@ object Dependencies {
     val akkaTestkit = "com.typesafe.akka" %% "akka-testkit" % "2.4.2"
     val casClient = "org.jasig.cas.client" % "cas-client-core" % "3.4.1"
     val casClientSupportSAML = "org.jasig.cas.client" % "cas-client-support-saml" % "3.4.1"
+    val jodaTime = "joda-time" % "joda-time" % "2.9.3"
   }
 }

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth2Provider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth2Provider.scala
@@ -51,7 +51,16 @@ case class OAuth2Info(
   tokenType: Option[String] = None,
   expiresIn: Option[Int] = None,
   refreshToken: Option[String] = None,
-  params: Option[Map[String, String]] = None) extends AuthInfo
+  params: Option[Map[String, String]] = None,
+  generatedAt: Instant = new Instant()
+) extends AuthInfo {
+  def expired: Boolean = {
+    expiresIn match {
+      case Some(in) => generatedAt.plus((in * 1000).toLong).isAfter(new Instant())
+      case None     => false
+    }
+  }
+}
 
 /**
  * The Oauth2 info companion object.

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth2Provider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth2Provider.scala
@@ -184,28 +184,28 @@ trait OAuth2Provider extends SocialProvider with OAuth2Constants with Logger {
   }
 
   /**
-    * Refreshes the OAuth2Info token at the refreshURL. Example code:
-    *
-    * def bearer(token: String) = req.withHeaders("Authorization" -> s"Bearer ${token}")
-    *
-    * def executeOAuth(info: OAuth2Info, provider: OAuth2Provider) = {
-    *   val again = provider.refresh(info.refreshToken).flatMap(token =>
-    *     bearer(token, request).execute().map(_ -> token)
-    *   )
-    *   val response = if (info.expired) {
-    *     again
-    *   } else {
-    *     bearer(info, request).execute().flatMap({ resp =>
-    *       resp.status match {
-    *         case 401 => again
-    *         case _   => Future.successful((resp, info))
-    *       }
-    *     })
-    *   }
-    * }
-    *
-    * @param refreshToken The refresh token, as on OAuth2Info
-    */
+   * Refreshes the OAuth2Info token at the refreshURL. Example code:
+   *
+   * def bearer(token: String) = req.withHeaders("Authorization" -> s"Bearer ${token}")
+   *
+   * def executeOAuth(info: OAuth2Info, provider: OAuth2Provider) = {
+   *   val again = provider.refresh(info.refreshToken).flatMap(token =>
+   *     bearer(token, request).execute().map(_ -> token)
+   *   )
+   *   val response = if (info.expired) {
+   *     again
+   *   } else {
+   *     bearer(info, request).execute().flatMap({ resp =>
+   *       resp.status match {
+   *         case 401 => again
+   *         case _   => Future.successful((resp, info))
+   *       }
+   *     })
+   *   }
+   * }
+   *
+   * @param refreshToken The refresh token, as on OAuth2Info
+   */
 
   def refresh(refreshToken: String): Option[Future[OAuth2Info]] = {
     settings.refreshURL.map({ url =>

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth2Provider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth2Provider.scala
@@ -62,9 +62,16 @@ case class OAuth2Info(
    *
    * @param at The Instant to check against.
    */
-  def expired(at: Instant = new Instant()): Boolean = {
+  def expired(at: Instant): Boolean = {
     expiresIn match {
       case Some(in) => at.isAfter(generatedAt.plus(Seconds.seconds(in).toStandardDuration()))
+      case None     => false
+    }
+  }
+
+  def expired(at: Clock): Boolean = {
+    expiresIn match {
+      case Some(in) => at.now.isAfter(generatedAt.plus(Seconds.seconds(in).toStandardDuration()))
       case None     => false
     }
   }

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth2Provider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth2Provider.scala
@@ -54,7 +54,7 @@ case class OAuth2Info(
   params: Option[Map[String, String]] = None,
   generatedAt: Instant = new Instant()
 ) extends AuthInfo {
-  /*
+  /**
    * Checks if the auth token is expired and needs to be refreshed.
    *
    * @param at The Instant to check against.
@@ -182,6 +182,30 @@ trait OAuth2Provider extends SocialProvider with OAuth2Constants with Logger {
       info => Success(info)
     )
   }
+
+  /**
+    * Refreshes the OAuth2Info token at the refreshURL. Example code:
+    *
+    * def bearer(token: String) = req.withHeaders("Authorization" -> s"Bearer ${token}")
+    *
+    * def executeOAuth(info: OAuth2Info, provider: OAuth2Provider) = {
+    *   val again = provider.refresh(info.refreshToken).flatMap(token =>
+    *     bearer(token, request).execute().map(_ -> token)
+    *   )
+    *   val response = if (info.expired) {
+    *     again
+    *   } else {
+    *     bearer(info, request).execute().flatMap({ resp =>
+    *       resp.status match {
+    *         case 401 => again
+    *         case _   => Future.successful((resp, info))
+    *       }
+    *     })
+    *   }
+    * }
+    *
+    * @param refreshToken The refresh token, as on OAuth2Info
+    */
 
   def refresh(refreshToken: String): Option[Future[OAuth2Info]] = {
     settings.refreshURL.map({ url =>

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth2Provider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth2Provider.scala
@@ -54,9 +54,9 @@ case class OAuth2Info(
   params: Option[Map[String, String]] = None,
   generatedAt: Instant = new Instant()
 ) extends AuthInfo {
-  def expired: Boolean = {
+  def expired(at: Instant = new Instant()): Boolean = {
     expiresIn match {
-      case Some(in) => generatedAt.plus((in * 1000).toLong).isAfter(new Instant())
+      case Some(in) => generatedAt.plus((in * 1000).toLong).isAfter(at)
       case None     => false
     }
   }

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth2Provider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/OAuth2Provider.scala
@@ -30,7 +30,7 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import play.api.libs.ws.WSResponse
 import play.api.mvc._
-import org.joda.time.Instant
+import org.joda.time.{ Instant, Seconds }
 import org.apache.commons.codec.binary.Base64
 
 import scala.concurrent.{ ExecutionContext, Future }
@@ -54,9 +54,14 @@ case class OAuth2Info(
   params: Option[Map[String, String]] = None,
   generatedAt: Instant = new Instant()
 ) extends AuthInfo {
+  /*
+   * Checks if the auth token is expired and needs to be refreshed.
+   *
+   * @param at The Instant to check against.
+   */
   def expired(at: Instant = new Instant()): Boolean = {
     expiresIn match {
-      case Some(in) => generatedAt.plus((in * 1000).toLong).isAfter(at)
+      case Some(in) => at.isAfter(generatedAt.plus(Seconds.seconds(in).toStandardDuration()))
       case None     => false
     }
   }

--- a/silhouette/build.sbt
+++ b/silhouette/build.sbt
@@ -5,6 +5,7 @@ libraryDependencies ++= Seq(
   Library.Play.ws,
   Library.jwtCore,
   Library.jwtApi,
+  Library.jodaTime,
   Library.Play.specs2 % Test,
   Library.Play.Specs2.matcherExtra % Test,
   Library.Play.Specs2.mock % Test,

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/OAuth2InfoSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/OAuth2InfoSpec.scala
@@ -1,0 +1,19 @@
+
+package com.mohiva.play.silhouette.impl.providers
+
+import org.joda.time.Instant
+import play.api.test.PlaySpecification
+
+class OAuth2InfoSpec extends PlaySpecification {
+  "The `expired` method" should {
+    val baseInstant = new Instant(0)
+    val base = OAuth2Info("", None, Some(10), None, None, baseInstant)
+    "return false before it expired" in {
+      base.expired(new Instant(5000)) should be equalTo false
+    }
+    "return true after it has expired" in {
+      base.expired(new Instant(15000)) should be equalTo true
+    }
+  }
+
+}

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/OAuth2InfoSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/OAuth2InfoSpec.scala
@@ -1,3 +1,18 @@
+/**
+  * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *     http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
 
 package com.mohiva.play.silhouette.impl.providers
 

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/OAuth2InfoSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/OAuth2InfoSpec.scala
@@ -1,18 +1,18 @@
 /**
-  * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *     http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-  */
+ * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.mohiva.play.silhouette.impl.providers
 

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/OAuth2ProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/OAuth2ProviderSpec.scala
@@ -21,6 +21,7 @@ import com.mohiva.play.silhouette.api.exceptions._
 import com.mohiva.play.silhouette.api.util.HTTPLayer
 import com.mohiva.play.silhouette.impl.exceptions.{ AccessDeniedException, UnexpectedResponseException }
 import com.mohiva.play.silhouette.impl.providers.OAuth2Provider._
+import org.joda.time.Instant
 import org.specs2.matcher.ThrownExpectations
 import org.specs2.mock.Mockito
 import org.specs2.specification.Scope
@@ -209,6 +210,8 @@ abstract class OAuth2ProviderSpec extends SocialProviderSpec[OAuth2Info] {
       c.provider.settings must be equalTo c.oAuthSettings
     }
   }
+
+  def normalizeTime(info: OAuth2Info): OAuth2Info = info.copy(generatedAt = new Instant(0))
 
   /**
    * Defines the context for the abstract OAuth2 provider spec.

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/custom/FacebookProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/custom/FacebookProviderSpec.scala
@@ -73,7 +73,7 @@ class FacebookProviderSpec extends OAuth2ProviderSpec {
       stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
-        case authInfo => authInfo must be equalTo oAuthInfo.as[OAuth2Info]
+        case authInfo => normalizeTime(authInfo) must be equalTo normalizeTime(oAuthInfo.as[OAuth2Info])
       }
     }
   }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/custom/FacebookProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/custom/FacebookProviderSpec.scala
@@ -73,7 +73,7 @@ class FacebookProviderSpec extends OAuth2ProviderSpec {
       stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
-        case authInfo => normalizeTime(authInfo) must be equalTo normalizeTime(oAuthInfo.as[OAuth2Info])
+        case authInfo => authInfo must beTypedEqualTo(oAuthInfo.as[OAuth2Info]) ^^^ normalizeTime
       }
     }
   }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/Auth0ProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/Auth0ProviderSpec.scala
@@ -76,7 +76,7 @@ class Auth0ProviderSpec extends OAuth2ProviderSpec {
       stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
-        case authInfo => authInfo must be equalTo oAuthInfo.as[OAuth2Info]
+        case authInfo => normalizeTime(authInfo) must be equalTo normalizeTime(oAuthInfo.as[OAuth2Info])
       }
     }
   }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/Auth0ProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/Auth0ProviderSpec.scala
@@ -76,7 +76,7 @@ class Auth0ProviderSpec extends OAuth2ProviderSpec {
       stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
-        case authInfo => normalizeTime(authInfo) must be equalTo normalizeTime(oAuthInfo.as[OAuth2Info])
+        case authInfo => authInfo must beTypedEqualTo(oAuthInfo.as[OAuth2Info]) ^^^ normalizeTime
       }
     }
   }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/ClefProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/ClefProviderSpec.scala
@@ -70,7 +70,7 @@ class ClefProviderSpec extends OAuth2ProviderSpec {
       stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
-        case authInfo => normalizeTime(authInfo) must be equalTo normalizeTime(oAuthInfo.as[OAuth2Info])
+        case authInfo => authInfo must beTypedEqualTo(oAuthInfo.as[OAuth2Info]) ^^^ normalizeTime
       }
     }
   }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/ClefProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/ClefProviderSpec.scala
@@ -70,7 +70,7 @@ class ClefProviderSpec extends OAuth2ProviderSpec {
       stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
-        case authInfo => authInfo must be equalTo oAuthInfo.as[OAuth2Info]
+        case authInfo => normalizeTime(authInfo) must be equalTo normalizeTime(oAuthInfo.as[OAuth2Info])
       }
     }
   }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/DropboxProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/DropboxProviderSpec.scala
@@ -70,7 +70,7 @@ class DropboxProviderSpec extends OAuth2ProviderSpec {
       stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
-        case authInfo => normalizeTime(authInfo) must be equalTo normalizeTime(oAuthInfo.as[OAuth2Info])
+        case authInfo => authInfo must beTypedEqualTo(oAuthInfo.as[OAuth2Info]) ^^^ normalizeTime
       }
     }
   }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/DropboxProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/DropboxProviderSpec.scala
@@ -70,7 +70,7 @@ class DropboxProviderSpec extends OAuth2ProviderSpec {
       stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
-        case authInfo => authInfo must be equalTo oAuthInfo.as[OAuth2Info]
+        case authInfo => normalizeTime(authInfo) must be equalTo normalizeTime(oAuthInfo.as[OAuth2Info])
       }
     }
   }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/FacebookProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/FacebookProviderSpec.scala
@@ -70,7 +70,7 @@ class FacebookProviderSpec extends OAuth2ProviderSpec {
       stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
-        case authInfo => authInfo must be equalTo oAuthInfo.as[OAuth2Info]
+        case authInfo => normalizeTime(authInfo) must be equalTo normalizeTime(oAuthInfo.as[OAuth2Info])
       }
     }
   }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/FacebookProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/FacebookProviderSpec.scala
@@ -70,7 +70,7 @@ class FacebookProviderSpec extends OAuth2ProviderSpec {
       stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
-        case authInfo => normalizeTime(authInfo) must be equalTo normalizeTime(oAuthInfo.as[OAuth2Info])
+        case authInfo => authInfo must beTypedEqualTo(oAuthInfo.as[OAuth2Info]) ^^^ normalizeTime
       }
     }
   }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/FoursquareProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/FoursquareProviderSpec.scala
@@ -70,7 +70,7 @@ class FoursquareProviderSpec extends OAuth2ProviderSpec {
       stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
-        case authInfo => normalizeTime(authInfo) must be equalTo normalizeTime(oAuthInfo.as[OAuth2Info])
+        case authInfo => authInfo must beTypedEqualTo(oAuthInfo.as[OAuth2Info]) ^^^ normalizeTime
       }
     }
   }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/FoursquareProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/FoursquareProviderSpec.scala
@@ -70,7 +70,7 @@ class FoursquareProviderSpec extends OAuth2ProviderSpec {
       stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
-        case authInfo => authInfo must be equalTo oAuthInfo.as[OAuth2Info]
+        case authInfo => normalizeTime(authInfo) must be equalTo normalizeTime(oAuthInfo.as[OAuth2Info])
       }
     }
   }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/GitHubProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/GitHubProviderSpec.scala
@@ -71,7 +71,7 @@ class GitHubProviderSpec extends OAuth2ProviderSpec {
       stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
-        case authInfo => normalizeTime(authInfo) must be equalTo normalizeTime(oAuthInfo.as[OAuth2Info])
+        case authInfo => authInfo must beTypedEqualTo(oAuthInfo.as[OAuth2Info]) ^^^ normalizeTime
       }
     }
   }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/GitHubProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/GitHubProviderSpec.scala
@@ -71,7 +71,7 @@ class GitHubProviderSpec extends OAuth2ProviderSpec {
       stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
-        case authInfo => authInfo must be equalTo oAuthInfo.as[OAuth2Info]
+        case authInfo => normalizeTime(authInfo) must be equalTo normalizeTime(oAuthInfo.as[OAuth2Info])
       }
     }
   }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/GoogleProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/GoogleProviderSpec.scala
@@ -70,7 +70,7 @@ class GoogleProviderSpec extends OAuth2ProviderSpec {
       stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
-        case authInfo => authInfo must be equalTo oAuthInfo.as[OAuth2Info]
+        case authInfo => normalizeTime(authInfo) must be equalTo normalizeTime(oAuthInfo.as[OAuth2Info])
       }
     }
   }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/GoogleProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/GoogleProviderSpec.scala
@@ -70,7 +70,7 @@ class GoogleProviderSpec extends OAuth2ProviderSpec {
       stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
-        case authInfo => normalizeTime(authInfo) must be equalTo normalizeTime(oAuthInfo.as[OAuth2Info])
+        case authInfo => authInfo must beTypedEqualTo(oAuthInfo.as[OAuth2Info]) ^^^ normalizeTime
       }
     }
   }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/InstagramProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/InstagramProviderSpec.scala
@@ -70,7 +70,7 @@ class InstagramProviderSpec extends OAuth2ProviderSpec {
       stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
-        case authInfo => normalizeTime(authInfo) must be equalTo normalizeTime(oAuthInfo.as[OAuth2Info])
+        case authInfo => authInfo must beTypedEqualTo(oAuthInfo.as[OAuth2Info]) ^^^ normalizeTime
       }
     }
   }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/InstagramProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/InstagramProviderSpec.scala
@@ -70,7 +70,7 @@ class InstagramProviderSpec extends OAuth2ProviderSpec {
       stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
-        case authInfo => authInfo must be equalTo oAuthInfo.as[OAuth2Info]
+        case authInfo => normalizeTime(authInfo) must be equalTo normalizeTime(oAuthInfo.as[OAuth2Info])
       }
     }
   }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/LinkedInProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/LinkedInProviderSpec.scala
@@ -70,7 +70,7 @@ class LinkedInProviderSpec extends OAuth2ProviderSpec {
       stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
-        case authInfo => normalizeTime(authInfo) must be equalTo normalizeTime(oAuthInfo.as[OAuth2Info])
+        case authInfo => authInfo must beTypedEqualTo(oAuthInfo.as[OAuth2Info]) ^^^ normalizeTime
       }
     }
   }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/LinkedInProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/LinkedInProviderSpec.scala
@@ -70,7 +70,7 @@ class LinkedInProviderSpec extends OAuth2ProviderSpec {
       stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
-        case authInfo => authInfo must be equalTo oAuthInfo.as[OAuth2Info]
+        case authInfo => normalizeTime(authInfo) must be equalTo normalizeTime(oAuthInfo.as[OAuth2Info])
       }
     }
   }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/VKProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/VKProviderSpec.scala
@@ -70,7 +70,7 @@ class VKProviderSpec extends OAuth2ProviderSpec {
       stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
-        case authInfo => normalizeTime(authInfo) must be equalTo normalizeTime(oAuthInfo.as[OAuth2Info])
+        case authInfo => authInfo must beTypedEqualTo(oAuthInfo.as[OAuth2Info]) ^^^ normalizeTime
       }
     }
   }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/VKProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/VKProviderSpec.scala
@@ -70,7 +70,7 @@ class VKProviderSpec extends OAuth2ProviderSpec {
       stateProvider.validate(any, any) returns Future.successful(state)
 
       authInfo(provider.authenticate()) {
-        case authInfo => authInfo must be equalTo oAuthInfo.as[OAuth2Info]
+        case authInfo => normalizeTime(authInfo) must be equalTo normalizeTime(oAuthInfo.as[OAuth2Info])
       }
     }
   }


### PR DESCRIPTION
# Pull Request Checklist
- [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
- [x] Have you read through the [contributor guidelines](https://github.com/mohiva/play-silhouette/blob/master/CONTRIBUTING.md)?
- [ ] Have you [squashed your commits](https://docs.openshift.org/origin-m4/oo_contributors_guide.html#submitting-code)?
- [x] Have you added copyright headers to new files?
- [x] Have you suggest documentation edits?
- [ ] Have you added tests for any changed functionality?

`sbt` can't find `scripts/reformat`.
## Purpose

This PR adds refresh_token functionality.
## Background

I've tried to add some type safety via `OAuth2Bearer`, It might be a good idea to subclass `OAuth2Provider` in a similar manner, maybe adding the `OAuth2Info` via generic.
## References

https://tools.ietf.org/html/rfc6749#section-6
Supposedly you can link gitter chats, but I can't get the anchor.
