### PR TITLE
Fixing issue with CAS username

### DIFF
--- a/silhouette-cas/src/main/scala/com/mohiva/play/silhouette/impl/providers/cas/CasProvider.scala
+++ b/silhouette-cas/src/main/scala/com/mohiva/play/silhouette/impl/providers/cas/CasProvider.scala
@@ -133,7 +133,7 @@ class CasProfileParser
     attr.foreach { case (key, value) => logger.debug("key: [%s], value: [%s]".format(key, value)) }
 
     CommonSocialProfile(
-      LoginInfo(ID, attr.get(UserName).asInstanceOf[String]),
+      LoginInfo(ID, principal.getName),
       firstName = Option(attr.get(FirstName).asInstanceOf[String]),
       lastName = Option(attr.get(LastName).asInstanceOf[String]),
       email = Option(attr.get(Email).asInstanceOf[String]),

--- a/silhouette-cas/src/test/scala/com/mohiva/play/silhouette/impl/providers/cas/CasProviderSpec.scala
+++ b/silhouette-cas/src/test/scala/com/mohiva/play/silhouette/impl/providers/cas/CasProviderSpec.scala
@@ -99,6 +99,7 @@ class CasProviderSpec extends SocialProviderSpec[CasAuthInfo] with Mockito with 
 
   "The `retrieveProfile` method" should {
     "return a valid profile if the CAS client validates the ticket" in new Context {
+      principal.getName returns userName
       principal.getAttributes returns attr
       client.validateServiceTicket(ticket) returns Future.successful(principal)
 


### PR DESCRIPTION
## Purpose

Fixes an issue in the CasProvider where an incorrect LoginInfo object was being constructed.

## Background Context

The unit tests pass as they are contrived. However the previous code falls over at runtime.



