### PR TITLE
Sign cookies with HMAC

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -32,7 +32,7 @@ object BasicSettings extends AutoPlugin {
 
   override def projectSettings = Seq(
     organization := "com.mohiva",
-    version := "2.0.1",
+    version := "2.0.2",
     resolvers ++= Dependencies.resolvers,
     scalaVersion := Dependencies.Versions.scalaVersion,
     crossScalaVersions := Dependencies.Versions.crossScala,

--- a/silhouette/app/com/mohiva/play/silhouette/api/exceptions/CryptoException.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/exceptions/CryptoException.scala
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mohiva.play.silhouette.api.exceptions
+
+/**
+ * Indicates that a crypto operation error occurred.
+ *
+ * @param msg The exception message.
+ * @param cause The exception cause.
+ */
+class CryptoException(msg: String, cause: Throwable = null)
+  extends SilhouetteException(msg, cause)

--- a/silhouette/app/com/mohiva/play/silhouette/impl/util/CookieSigner.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/util/CookieSigner.scala
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mohiva.play.silhouette.impl.util
+
+import com.mohiva.play.silhouette.api.exceptions.CryptoException
+import com.mohiva.play.silhouette.impl.util.CookieSigner._
+import play.api.libs.Crypto
+
+import scala.util.{ Failure, Success, Try }
+
+/**
+ * Cookie signer implementation based on the Play cryptography functionality.
+ *
+ * This cookie signer signs the data with the specified key or with the Play application secret. If the
+ * signature verification fails, the signer does not try to decode the cookie data in any way in order
+ * to prevent various types of attacks.
+ *
+ * @param keyOption Key for signing. When None is supplied, application.secret is used. Note that using
+ *                  application.secret is discouraged (because it might cause using one key for multiple purposes) and
+ *                  should be used when required by backward compatibility.
+ * @param pepper Constant prepended and appended to the data before signing. When using one key for multiple purposes,
+ *               using a specific pepper reduces some risks arising from this.
+ */
+class CookieSigner(keyOption: Option[Array[Byte]], pepper: String = "-mohiva-silhouette-cookie-signer-") {
+
+  /**
+   * Signs (MAC) the given data using the given secret key.
+   *
+   * @param data The data to sign.
+   * @return A message authentication code.
+   */
+  def sign(data: String): String = {
+    val message = pepper + data + pepper
+    val signature = keyOption match {
+      case None => Crypto.sign(message)
+      case Some(key) => Crypto.sign(message, key)
+    }
+
+    val version = 1
+    s"$version-$signature-$data"
+  }
+
+  /**
+   * Extracts a message that was signed by [[CookieSigner.sign]].
+   *
+   * @param message The signed message to extract.
+   * @return The verified raw data, or an error if the message isn't valid.
+   */
+  def extract(message: String): Try[String] = {
+    for {
+      (_, actualSignature, actualData) <- fragment(message)
+      (_, expectedSignature, _) <- fragment(sign(actualData))
+    } yield {
+      if (Crypto.constantTimeEquals(expectedSignature, actualSignature)) {
+        actualData
+      } else {
+        throw new CryptoException(BadSignature)
+      }
+    }
+  }
+
+  /**
+   * Fragments the message into its parts.
+   *
+   * @param message The message to fragment.
+   * @return The message parts.
+   */
+  private def fragment(message: String): Try[(String, String, String)] = {
+    message.split("-", 3) match {
+      case Array(version, signature, data) if version == "1" => Success((version, signature, data))
+      case Array(version, _, _) => Failure(new CryptoException(UnknownVersion.format(version)))
+      case _ => Failure(new CryptoException(InvalidMessageFormat))
+    }
+  }
+}
+
+/**
+ * The companion object.
+ */
+object CookieSigner {
+
+  val BadSignature = "[Silhouette][CookieSigner] Bad signature"
+  val UnknownVersion = "[Silhouette][CookieSigner] Unknown version: %s"
+  val InvalidMessageFormat = "[Silhouette][CookieSigner] Invalid message format; Expected [VERSION]-[SIGNATURE]-[DATA]"
+}

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/secrets/CookieSecretSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth1/secrets/CookieSecretSpec.scala
@@ -15,15 +15,19 @@
  */
 package com.mohiva.play.silhouette.impl.providers.oauth1.secrets
 
+import java.util.regex.Pattern
+
 import com.mohiva.play.silhouette.api.util.Clock
 import com.mohiva.play.silhouette.impl.exceptions.OAuth1TokenSecretException
 import com.mohiva.play.silhouette.impl.providers.OAuth1Info
+import com.mohiva.play.silhouette.impl.providers.oauth1.secrets.CookieSecret._
 import com.mohiva.play.silhouette.impl.providers.oauth1.secrets.CookieSecretProvider._
 import org.joda.time.DateTime
 import org.specs2.matcher.JsonMatchers
 import org.specs2.mock.Mockito
 import org.specs2.specification.Scope
 import play.api.libs.Crypto
+import play.api.libs.concurrent.Execution.Implicits._
 import play.api.mvc.{ Cookie, Results }
 import play.api.test.{ FakeRequest, PlaySpecification, WithApplication }
 
@@ -44,13 +48,34 @@ class CookieSecretSpec extends PlaySpecification with Mockito with JsonMatchers 
     }
   }
 
-  "The `serialize` method of the secret" should {
-    "serialize the JSON as encrypted string" in new WithApplication with Context {
-      val dateTime = new DateTime(2014, 8, 8, 0, 0, 0)
-      val decoded = Crypto.decryptAES(secret.copy(expirationDate = dateTime).serialize)
+  "The `unserialize` method of the secret" should {
+    "throw an OAuth1TokenSecretException if a secret contains invalid json" in new WithApplication with Context {
+      val value = "invalid"
+      val msg = Pattern.quote(InvalidJson.format("test", value))
 
-      decoded must /("expirationDate" -> dateTime.getMillis)
-      decoded must /("value" -> "value")
+      unserialize(cookieSigner.sign(Crypto.encryptAES(value)), "test") must beFailedTry.withThrowable[OAuth1TokenSecretException](msg)
+    }
+
+    "throw an OAuth1TokenSecretException if a secret contains valid json but invalid secret" in new WithApplication with Context {
+      val value = "{ \"test\": \"test\" }"
+      val msg = "^" + Pattern.quote(InvalidSecretFormat.format("test", "")) + ".*"
+
+      unserialize(cookieSigner.sign(Crypto.encryptAES(value)), "test") must beFailedTry.withThrowable[OAuth1TokenSecretException](msg)
+    }
+
+    "throw an OAuth1TokenSecretException if a secret is badly signed" in new WithApplication with Context {
+      val value = "invalid"
+      val msg = Pattern.quote(InvalidCookieSignature.format("test"))
+
+      unserialize(value, "test") must beFailedTry.withThrowable[OAuth1TokenSecretException](msg)
+    }
+  }
+
+  "The `serialize/unserialize` method of the secret" should {
+    "serialize/unserialize a secret" in new WithApplication with Context {
+      val serialized = serialize(secret)
+
+      unserialize(serialized, "test") must beSuccessfulTry.withValue(secret)
     }
   }
 
@@ -69,7 +94,7 @@ class CookieSecretSpec extends PlaySpecification with Mockito with JsonMatchers 
   }
 
   "The `retrieve` method of the provider" should {
-    "throw an TokenSecretException if client secret doesn't exists" in new Context {
+    "throw an OAuth1TokenSecretException if client secret doesn't exists" in new Context {
       implicit val req = FakeRequest()
 
       await(provider.retrieve("test")) must throwA[OAuth1TokenSecretException].like {
@@ -77,8 +102,18 @@ class CookieSecretSpec extends PlaySpecification with Mockito with JsonMatchers 
       }
     }
 
-    "throw an TokenSecretException if client secret contains invalid json" in new WithApplication with Context {
-      val invalidSecret = Crypto.encryptAES("{")
+    "throw an OAuth1TokenSecretException if client secret contains invalid json" in new WithApplication with Context {
+      val invalidSecret = cookieSigner.sign(Crypto.encryptAES("{"))
+
+      implicit val req = FakeRequest().withCookies(Cookie(settings.cookieName, invalidSecret))
+
+      await(provider.retrieve("test")) must throwA[OAuth1TokenSecretException].like {
+        case e => e.getMessage must startWith(InvalidJson.format("test", ""))
+      }
+    }
+
+    "throw an OAuth1TokenSecretException if client secret contains valid json but invalid secret" in new WithApplication with Context {
+      val invalidSecret = cookieSigner.sign(Crypto.encryptAES("{ \"test\": \"test\" }"))
 
       implicit val req = FakeRequest().withCookies(Cookie(settings.cookieName, invalidSecret))
 
@@ -87,23 +122,21 @@ class CookieSecretSpec extends PlaySpecification with Mockito with JsonMatchers 
       }
     }
 
-    "throw an TokenSecretException if client secret contains valid json but invalid secret" in new WithApplication with Context {
-      val invalidSecret = Crypto.encryptAES("{ \"test\": \"test\" }")
-
-      implicit val req = FakeRequest().withCookies(Cookie(settings.cookieName, invalidSecret))
-
-      await(provider.retrieve("test")) must throwA[OAuth1TokenSecretException].like {
-        case e => e.getMessage must startWith(InvalidSecretFormat.format("test", ""))
-      }
-    }
-
-    "throw an TokenSecretException if secret is expired" in new WithApplication with Context {
+    "throw an OAuth1TokenSecretException if secret is expired" in new WithApplication with Context {
       val expiredSecret = secret.copy(expirationDate = DateTime.now.minusHours(1))
 
       implicit val req = FakeRequest().withCookies(Cookie(settings.cookieName, expiredSecret.serialize))
 
       await(provider.retrieve("test")) must throwA[OAuth1TokenSecretException].like {
         case e => e.getMessage must startWith(SecretIsExpired.format("test"))
+      }
+    }
+
+    "throw an OAuth1TokenSecretException if client secret is badly signed" in new WithApplication with Context {
+      implicit val req = FakeRequest().withCookies(Cookie(settings.cookieName, "invalid"))
+
+      await(provider.retrieve("test")) must throwA[OAuth1TokenSecretException].like {
+        case e => e.getMessage must startWith(InvalidCookieSignature.format("test"))
       }
     }
 
@@ -121,7 +154,7 @@ class CookieSecretSpec extends PlaySpecification with Mockito with JsonMatchers 
 
       cookies(result).get(settings.cookieName) should beSome[Cookie].which { c =>
         c.name must be equalTo settings.cookieName
-        c.value must be equalTo secret.serialize
+        unserialize(c.value, "test").get must be equalTo secret
         c.maxAge must beSome(settings.expirationTime)
         c.path must be equalTo settings.cookiePath
         c.domain must be equalTo settings.cookieDomain

--- a/silhouette/test/com/mohiva/play/silhouette/impl/util/CookieSignerSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/util/CookieSignerSpec.scala
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2015 Mohiva Organisation (license at mohiva dot com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mohiva.play.silhouette.impl.util
+
+import java.util.regex.Pattern
+
+import com.mohiva.play.silhouette.api.exceptions.CryptoException
+import com.mohiva.play.silhouette.impl.util.CookieSigner._
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+import play.api.test.WithApplication
+
+/**
+ * Test case for the [[CookieSigner]] class.
+ */
+class CookieSignerSpec extends Specification {
+
+  "The `sign` method" should {
+    "return a signed message in the form [VERSION]-[SIGNATURE]-[DATA]" in new WithApplication with Context {
+      val data = "some-data"
+
+      signer.sign(data) must beMatching(s"1-[^-]+-$data")
+    }
+  }
+
+  "The `extract` method" should {
+    "throw a `CryptoException` if the message format is invalid" in new Context {
+      val msg = "^" + Pattern.quote(InvalidMessageFormat) + ".*"
+
+      signer.extract("invalid") must beFailedTry.withThrowable[CryptoException](msg)
+    }
+
+    "throw a `CryptoException` if the version is unknown" in new Context {
+      val msg = "^" + Pattern.quote(UnknownVersion.format(2)) + ".*"
+
+      signer.extract("2-signature-data") must beFailedTry.withThrowable[CryptoException](msg)
+    }
+
+    "throw a `CryptoException` if the signature is invalid" in new WithApplication with Context {
+      val msg = "^" + Pattern.quote(BadSignature) + ".*"
+
+      signer.extract("1-signature-data") must beFailedTry.withThrowable[CryptoException](msg)
+    }
+
+    "extract a previously signed message" in new WithApplication with Context {
+      val data = "some-data"
+      val message = signer.sign(data)
+
+      signer.extract(message) must beSuccessfulTry.withValue(data)
+    }
+  }
+
+  /**
+   * The context.
+   */
+  trait Context extends Scope {
+
+    /**
+     * The encryption key.
+     */
+    val key = "s3cr3t_k3y"
+
+    /**
+     * The cookie signer to test.
+     */
+    val signer = new CookieSigner(Some(key.getBytes("UTF-8")))
+  }
+}


### PR DESCRIPTION
Cookies are currently not signed, which allows an attacker arbitrarily modifying the cookie value.