### PR TITLE
Allow error format methods to be overridden

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/api/ErrorHandler.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/ErrorHandler.scala
@@ -194,14 +194,14 @@ trait DefaultErrorHandler
     })
   }
 
-  private def toHtmlError(message: String) =
+  protected def toHtmlError(message: String) =
     s"<html><head><title>$message</title></head><body>$message</body></html>"
 
-  private def toJsonError(message: String) =
+  protected def toJsonError(message: String) =
     Json.obj("success" -> false, "message" -> message)
 
-  private def toXmlError(message: String) =
+  protected def toXmlError(message: String) =
     <response><success>false</success><message>{ message }</message></response>
 
-  private def toPlainTextError(message: String) = message
+  protected def toPlainTextError(message: String) = message
 }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/mohiva/play-silhouette/blob/master/CONTRIBUTING.md)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/2.5.x/WorkingWithGit#Squashing-commits)?

## Purpose

This PR allows users to override the error format methods when extending `DefaultSecuredErrorHandler`

## References

This was discussed in the [Gitter](https://gitter.im/mohiva/play-silhouette) channel.

