### PR TITLE
JWT Authenticator - accept different signing algorithms for JWT

### DIFF
--- a/silhouette-testkit/app/com/mohiva/play/silhouette/test/Fakes.scala
+++ b/silhouette-testkit/app/com/mohiva/play/silhouette/test/Fakes.scala
@@ -23,6 +23,7 @@ import com.mohiva.play.silhouette.api.repositories.AuthenticatorRepository
 import com.mohiva.play.silhouette.api.services.{ AuthenticatorService, IdentityService }
 import com.mohiva.play.silhouette.api.util.Clock
 import com.mohiva.play.silhouette.impl.authenticators._
+import com.mohiva.play.silhouette.impl.authenticators.jwt.{JWTAuthenticator, JWTAuthenticatorService, JWTAuthenticatorSettings}
 import com.mohiva.play.silhouette.impl.util.{ DefaultFingerprintGenerator, SecureRandomIDGenerator }
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.mvc.RequestHeader

--- a/silhouette-testkit/app/com/mohiva/play/silhouette/test/Fakes.scala
+++ b/silhouette-testkit/app/com/mohiva/play/silhouette/test/Fakes.scala
@@ -23,7 +23,7 @@ import com.mohiva.play.silhouette.api.repositories.AuthenticatorRepository
 import com.mohiva.play.silhouette.api.services.{ AuthenticatorService, IdentityService }
 import com.mohiva.play.silhouette.api.util.Clock
 import com.mohiva.play.silhouette.impl.authenticators._
-import com.mohiva.play.silhouette.impl.authenticators.jwt.{JWTAuthenticator, JWTAuthenticatorService, JWTAuthenticatorSettings}
+import com.mohiva.play.silhouette.impl.authenticators.jwt.{ JWTAuthenticator, JWTAuthenticatorService, JWTAuthenticatorSettings }
 import com.mohiva.play.silhouette.impl.util.{ DefaultFingerprintGenerator, SecureRandomIDGenerator }
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.mvc.RequestHeader

--- a/silhouette-testkit/test/com/mohiva/play/silhouette/test/FakesSpec.scala
+++ b/silhouette-testkit/test/com/mohiva/play/silhouette/test/FakesSpec.scala
@@ -19,7 +19,7 @@ import javax.inject.Inject
 
 import com.mohiva.play.silhouette.api._
 import com.mohiva.play.silhouette.impl.authenticators._
-import com.mohiva.play.silhouette.impl.authenticators.jwt.{JWTAuthenticator, JWTAuthenticatorService}
+import com.mohiva.play.silhouette.impl.authenticators.jwt.{ JWTAuthenticator, JWTAuthenticatorService }
 import com.mohiva.play.silhouette.test.FakesSpec._
 import net.codingwell.scalaguice.ScalaModule
 import org.specs2.matcher.JsonMatchers

--- a/silhouette-testkit/test/com/mohiva/play/silhouette/test/FakesSpec.scala
+++ b/silhouette-testkit/test/com/mohiva/play/silhouette/test/FakesSpec.scala
@@ -19,6 +19,7 @@ import javax.inject.Inject
 
 import com.mohiva.play.silhouette.api._
 import com.mohiva.play.silhouette.impl.authenticators._
+import com.mohiva.play.silhouette.impl.authenticators.jwt.{JWTAuthenticator, JWTAuthenticatorService}
 import com.mohiva.play.silhouette.test.FakesSpec._
 import net.codingwell.scalaguice.ScalaModule
 import org.specs2.matcher.JsonMatchers

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/jwt/JWTAlgorithmFactory.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/jwt/JWTAlgorithmFactory.scala
@@ -1,7 +1,7 @@
 package com.mohiva.play.silhouette.impl.authenticators.jwt
 
 import java.security.interfaces.{ ECPrivateKey, ECPublicKey }
-import java.security.spec.X509EncodedKeySpec
+import java.security.spec.{ PKCS8EncodedKeySpec, X509EncodedKeySpec }
 import java.security.{ KeyFactory, PrivateKey, PublicKey }
 
 import com.nimbusds.jose.crypto.{ ECDSASigner, ECDSAVerifier, MACSigner, MACVerifier }
@@ -28,7 +28,7 @@ class ECDSAAlgorithmFactory(val jwsAlgorithm: JWSAlgorithm) extends JWTAlgorithm
   }
 
   override def createSigner(key: String): JWSSigner = {
-    val privateKey: PrivateKey = KeyFactory.getInstance("EC").generatePrivate(new X509EncodedKeySpec(Base64.decodeBase64(key.getBytes(Encoding))))
+    val privateKey: PrivateKey = KeyFactory.getInstance("EC").generatePrivate(new PKCS8EncodedKeySpec(Base64.decodeBase64(key.getBytes(Encoding))))
     val eCPrivateKey: ECPrivateKey = privateKey.asInstanceOf[ECPrivateKey]
     new ECDSASigner(eCPrivateKey.getS)
   }

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/jwt/JWTAlgorithmFactory.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/jwt/JWTAlgorithmFactory.scala
@@ -1,0 +1,40 @@
+package com.mohiva.play.silhouette.impl.authenticators.jwt
+
+import java.security.interfaces.{ ECPrivateKey, ECPublicKey }
+import java.security.spec.X509EncodedKeySpec
+import java.security.{ KeyFactory, PrivateKey, PublicKey }
+
+import com.nimbusds.jose.crypto.{ ECDSASigner, ECDSAVerifier, MACSigner, MACVerifier }
+import com.nimbusds.jose.{ JWSAlgorithm, JWSSigner, JWSVerifier }
+import org.apache.commons.codec.binary.Base64
+
+trait JWTAlgorithmFactory extends JWTAlgorithmVerifierFactory with JWTAlgorithmSignerFactory
+
+trait JWTAlgorithmVerifierFactory {
+  def createVerifier(key: String): JWSVerifier
+}
+
+trait JWTAlgorithmSignerFactory {
+  def createSigner(key: String): JWSSigner
+  val jwsAlgorithm: JWSAlgorithm
+}
+
+class ECDSAAlgorithmFactory(val jwsAlgorithm: JWSAlgorithm) extends JWTAlgorithmFactory {
+
+  override def createVerifier(key: String): JWSVerifier = {
+    val publicKey: PublicKey = KeyFactory.getInstance("EC").generatePublic(new X509EncodedKeySpec(Base64.decodeBase64(key.getBytes("UTF-8"))))
+    val eCPublicKey: ECPublicKey = publicKey.asInstanceOf[ECPublicKey]
+    new ECDSAVerifier(eCPublicKey.getW.getAffineX, eCPublicKey.getW.getAffineY)
+  }
+
+  override def createSigner(key: String): JWSSigner = {
+    val privateKey: PrivateKey = KeyFactory.getInstance("EC").generatePrivate(new X509EncodedKeySpec(Base64.decodeBase64(key.getBytes("UTF-8"))))
+    val eCPrivateKey: ECPrivateKey = privateKey.asInstanceOf[ECPrivateKey]
+    new ECDSASigner(eCPrivateKey.getS)
+  }
+}
+
+class MACAlgorithmFactory(val jwsAlgorithm: JWSAlgorithm) extends JWTAlgorithmFactory {
+  override def createVerifier(key: String): JWSVerifier = new MACVerifier(key)
+  override def createSigner(key: String): JWSSigner = new MACSigner(key)
+}

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/jwt/JWTAlgorithmFactory.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/jwt/JWTAlgorithmFactory.scala
@@ -20,15 +20,15 @@ trait JWTAlgorithmSignerFactory {
 }
 
 class ECDSAAlgorithmFactory(val jwsAlgorithm: JWSAlgorithm) extends JWTAlgorithmFactory {
-
+  val Encoding: String = "UTF-8"
   override def createVerifier(key: String): JWSVerifier = {
-    val publicKey: PublicKey = KeyFactory.getInstance("EC").generatePublic(new X509EncodedKeySpec(Base64.decodeBase64(key.getBytes("UTF-8"))))
+    val publicKey: PublicKey = KeyFactory.getInstance("EC").generatePublic(new X509EncodedKeySpec(Base64.decodeBase64(key.getBytes(Encoding))))
     val eCPublicKey: ECPublicKey = publicKey.asInstanceOf[ECPublicKey]
     new ECDSAVerifier(eCPublicKey.getW.getAffineX, eCPublicKey.getW.getAffineY)
   }
 
   override def createSigner(key: String): JWSSigner = {
-    val privateKey: PrivateKey = KeyFactory.getInstance("EC").generatePrivate(new X509EncodedKeySpec(Base64.decodeBase64(key.getBytes("UTF-8"))))
+    val privateKey: PrivateKey = KeyFactory.getInstance("EC").generatePrivate(new X509EncodedKeySpec(Base64.decodeBase64(key.getBytes(Encoding))))
     val eCPrivateKey: ECPrivateKey = privateKey.asInstanceOf[ECPrivateKey]
     new ECDSASigner(eCPrivateKey.getS)
   }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/jwt/ECDSAAlgorithmFactorySpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/jwt/ECDSAAlgorithmFactorySpec.scala
@@ -1,0 +1,26 @@
+package com.mohiva.play.silhouette.impl.authenticators.jwt
+
+import com.nimbusds.jose.{ JWSAlgorithm, JWSSigner, JWSVerifier }
+import org.specs2.control.NoLanguageFeatures
+import org.specs2.matcher.JsonMatchers
+import org.specs2.mock.Mockito
+import play.api.test.PlaySpecification
+
+class ECDSAAlgorithmFactorySpec extends PlaySpecification with Mockito with JsonMatchers with NoLanguageFeatures {
+
+  "ECDSAAlgorithmFactorySpec" should {
+    "createVerifier" in {
+      val verifier: JWSVerifier = new ECDSAAlgorithmFactory(JWSAlgorithm.ES256).createVerifier("MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEW1rprhka9kZ8oGB8e90VOFHyltmuJwYyUtcut8EWr9agJaCMH7f+GvTQyhKnMJmEBMReS5FIS/eeTJz3NuiGyQ==")
+      verifier.supportedAlgorithms().contains(JWSAlgorithm.ES256) === true
+
+    }
+    "createSigner" in {
+      val signer: JWSSigner = new ECDSAAlgorithmFactory(JWSAlgorithm.ES256).createSigner("MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgHUW9ZGv4tn4h7V6wgDSNPRP4XkE5LO78XMd4isiJQGagCgYIKoZIzj0DAQehRANCAARbWumuGRr2RnygYHx73RU4UfKW2a4nBjJS1y63wRav1qAloIwft/4a9NDKEqcwmYQExF5LkUhL955MnPc26IbJ")
+      signer.supportedAlgorithms().contains(JWSAlgorithm.ES256) === true
+    }
+
+    "use algorithm instantiated with" in {
+      new ECDSAAlgorithmFactory(JWSAlgorithm.ES256).jwsAlgorithm === JWSAlgorithm.ES256
+    }
+  }
+}


### PR DESCRIPTION
Refactored _JWTAuthenticator_ to accept different signing/verifying algorithms.
Added an optional implementation of ECDSA algorithm - _ECDSAAlgorithmFactory_

*Will add UT's for _ECDSAAlgorithmFactory_ is there's an interest
