### PR TITLE
Adds Cookie encoding to DefaultSocialStateHandler

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/SocialStateProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/SocialStateProvider.scala
@@ -246,7 +246,7 @@ class DefaultSocialStateHandler(val handlers: Set[SocialStateItemHandler], cooki
    * @return The serialized state as string.
    */
   override def serialize(state: SocialState): String = {
-    cookieSigner.sign(state.items.flatMap(i => handlers.flatMap(h => h.canHandle(i).map(h.serialize))).mkString("."))
+    cookieSigner.sign(state.items.flatMap(i => handlers.flatMap(h => h.canHandle(i).map(h.serialize))).map(_.asString).mkString("."))
   }
 
   /**


### PR DESCRIPTION
Disclaimer: I'm new to Scala, to Silhouette and I don't actually have a fully functional app yet so I have no way of knowing if this is the right way to fix this potential bug, let a lone whether or not it creates other bugs.

While trying to get the 2.6 snapshot working with `DefaultSocialStateHandler` and a `CsrfStateItemHandler` I was getting encoding exceptions when Silhouette was attempting to deserialize the csrf cookie post Oauth2 handshake, which lead me to the line above.  Looking at the changelog for 2.6 I noticed that `ItemStructure.asString` was renamed `ItemStructure.asString`.  I'm not sure if this was an accident or not so I opted to submit a fix that attempts to use the new method name.

I've submitted Issue #512 to track this.