### PR TITLE
Rename cookie signer to signer

### DIFF
--- a/silhouette-crypto-jca/src/main/scala/com/mohiva/play/silhouette/crypto/JcaSigner.scala
+++ b/silhouette-crypto-jca/src/main/scala/com/mohiva/play/silhouette/crypto/JcaSigner.scala
@@ -18,22 +18,21 @@ package com.mohiva.play.silhouette.crypto
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 
-import com.mohiva.play.silhouette.api.crypto.CookieSigner
+import com.mohiva.play.silhouette.api.crypto.Signer
 import com.mohiva.play.silhouette.api.exceptions.CryptoException
 import org.apache.commons.codec.binary.Hex
-import JcaCookieSigner._
+import JcaSigner._
 import scala.util.{ Failure, Success, Try }
 
 /**
- * Cookie signer implementation based on JCA (Java Cryptography Architecture).
+ * Signer implementation based on JCA (Java Cryptography Architecture).
  *
- * This cookie signer signs the data with the specified key. If the signature verification fails,
- * the signer does not try to decode the cookie data in any way in order to prevent various types
- * of attacks.
+ * This signer signs the data with the specified key. If the signature verification fails, the signer
+ * does not try to decode the data in any way in order to prevent various types of attacks.
  *
  * @param settings The settings instance.
  */
-class JcaCookieSigner(settings: JcaCookieSignerSettings) extends CookieSigner {
+class JcaSigner(settings: JcaSignerSettings) extends Signer {
 
   /**
    * Signs (MAC) the given data using the given secret key.
@@ -105,18 +104,18 @@ class JcaCookieSigner(settings: JcaCookieSignerSettings) extends CookieSigner {
 /**
  * The companion object.
  */
-object JcaCookieSigner {
+object JcaSigner {
 
-  val BadSignature = "[Silhouette][JcaCookieSigner] Bad signature"
-  val UnknownVersion = "[Silhouette][JcaCookieSigner] Unknown version: %s"
-  val InvalidMessageFormat = "[Silhouette][JcaCookieSigner] Invalid message format; Expected [VERSION]-[SIGNATURE]-[DATA]"
+  val BadSignature = "[Silhouette][JcaSigner] Bad signature"
+  val UnknownVersion = "[Silhouette][JcaSigner] Unknown version: %s"
+  val InvalidMessageFormat = "[Silhouette][JcaSigner] Invalid message format; Expected [VERSION]-[SIGNATURE]-[DATA]"
 }
 
 /**
- * The settings for the JCA cookie signer.
+ * The settings for the JCA signer.
  *
  * @param key    Key for signing.
  * @param pepper Constant prepended and appended to the data before signing. When using one key for multiple purposes,
  *               using a specific pepper reduces some risks arising from this.
  */
-case class JcaCookieSignerSettings(key: String, pepper: String = "-mohiva-silhouette-cookie-signer-")
+case class JcaSignerSettings(key: String, pepper: String = "-mohiva-silhouette-signer-")

--- a/silhouette-crypto-jca/src/test/scala/com/mohiva/play/silhouette/crypto/JcaSignerSpec.scala
+++ b/silhouette-crypto-jca/src/test/scala/com/mohiva/play/silhouette/crypto/JcaSignerSpec.scala
@@ -19,13 +19,13 @@ import java.util.regex.Pattern
 
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
-import JcaCookieSigner._
+import JcaSigner._
 import com.mohiva.play.silhouette.api.exceptions.CryptoException
 
 /**
- * Test case for the [[JcaCookieSigner]] class.
+ * Test case for the [[JcaSigner]] class.
  */
-class JcaCookieSignerSpec extends Specification {
+class JcaSignerSpec extends Specification {
 
   "The `sign` method" should {
     "return a signed message in the form [VERSION]-[SIGNATURE]-[DATA]" in new Context {
@@ -75,11 +75,11 @@ class JcaCookieSignerSpec extends Specification {
     /**
      * The settings instance.
      */
-    val settings = new JcaCookieSignerSettings(key)
+    val settings = JcaSignerSettings(key)
 
     /**
      * The cookie signer to test.
      */
-    val signer = new JcaCookieSigner(settings)
+    val signer = new JcaSigner(settings)
   }
 }

--- a/silhouette-testkit/app/com/mohiva/play/silhouette/test/Fakes.scala
+++ b/silhouette-testkit/app/com/mohiva/play/silhouette/test/Fakes.scala
@@ -18,7 +18,7 @@ package com.mohiva.play.silhouette.test
 import java.util.UUID
 
 import com.mohiva.play.silhouette.api._
-import com.mohiva.play.silhouette.api.crypto.{ Base64AuthenticatorEncoder, CookieSigner }
+import com.mohiva.play.silhouette.api.crypto.{ Base64AuthenticatorEncoder, Signer }
 import com.mohiva.play.silhouette.api.repositories.AuthenticatorRepository
 import com.mohiva.play.silhouette.api.services.{ AuthenticatorService, IdentityService }
 import com.mohiva.play.silhouette.api.util.Clock
@@ -130,7 +130,7 @@ case class FakeSessionAuthenticatorService() extends SessionAuthenticatorService
 case class FakeCookieAuthenticatorService() extends CookieAuthenticatorService(
   CookieAuthenticatorSettings(),
   None,
-  new CookieSigner {
+  new Signer {
     def sign(data: String) = data
     def extract(message: String) = Success(message)
   },

--- a/silhouette/app/com/mohiva/play/silhouette/api/crypto/Signer.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/crypto/Signer.scala
@@ -18,12 +18,12 @@ package com.mohiva.play.silhouette.api.crypto
 import scala.util.Try
 
 /**
- * Specifies a strategy how cookies should be signed with a MAC.
+ * Specifies a strategy how data can be signed.
  */
-trait CookieSigner {
+trait Signer {
 
   /**
-   * Signs (MAC) the given data using the given secret key.
+   * Signs the given data using the given secret key.
    *
    * @param data The data to sign.
    * @return A message authentication code.
@@ -31,7 +31,7 @@ trait CookieSigner {
   def sign(data: String): String
 
   /**
-   * Extracts a message that was signed by [[CookieSigner.sign]].
+   * Extracts a message that was signed by [[Signer.sign]].
    *
    * @param message The signed message to extract.
    * @return The verified raw data, or an error if the message isn't valid.

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/DefaultSocialStateHandlerSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/DefaultSocialStateHandlerSpec.scala
@@ -15,7 +15,7 @@
  */
 package com.mohiva.play.silhouette.impl.providers
 
-import com.mohiva.play.silhouette.api.crypto.CookieSigner
+import com.mohiva.play.silhouette.api.crypto.Signer
 import com.mohiva.play.silhouette.api.exceptions.ProviderException
 import com.mohiva.play.silhouette.api.util.ExtractableRequest
 import com.mohiva.play.silhouette.impl.providers.DefaultSocialStateHandler._
@@ -170,12 +170,12 @@ class DefaultSocialStateHandlerSpec extends PlaySpecification with Mockito with 
     }
 
     /**
-     * The cookie signer implementation.
+     * The signer implementation.
      *
-     * The cookie signer returns the same value as passed to the methods. This is enough for testing.
+     * The signer returns the same value as passed to the methods. This is enough for testing.
      */
-    val cookieSigner = {
-      val c = mock[CookieSigner].smart
+    val signer = {
+      val c = mock[Signer].smart
       c.sign(any) answers { p => p.asInstanceOf[String] }
       c.extract(any) answers { p => Success(p.asInstanceOf[String]) }
       c
@@ -189,6 +189,6 @@ class DefaultSocialStateHandlerSpec extends PlaySpecification with Mockito with 
     /**
      * The state handler to test.
      */
-    val stateHandler = new DefaultSocialStateHandler(Set(Default.itemHandler, Publishable.itemHandler), cookieSigner)
+    val stateHandler = new DefaultSocialStateHandler(Set(Default.itemHandler, Publishable.itemHandler), signer)
   }
 }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/state/CsrfStateItemHandlerSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/state/CsrfStateItemHandlerSpec.scala
@@ -15,7 +15,7 @@
  */
 package com.mohiva.play.silhouette.impl.providers.state
 
-import com.mohiva.play.silhouette.api.crypto.CookieSigner
+import com.mohiva.play.silhouette.api.crypto.Signer
 import com.mohiva.play.silhouette.api.util.IDGenerator
 import com.mohiva.play.silhouette.impl.providers.SocialStateItem
 import com.mohiva.play.silhouette.impl.providers.SocialStateItem.ItemStructure
@@ -115,12 +115,12 @@ class CsrfStateItemHandlerSpec extends PlaySpecification with Mockito with JsonM
     val settings = CsrfStateSettings()
 
     /**
-     * The cookie signer implementation.
+     * The signer implementation.
      *
-     * The cookie signer returns the same value as passed to the methods. This is enough for testing.
+     * The signer returns the same value as passed to the methods. This is enough for testing.
      */
-    val cookieSigner = {
-      val c = mock[CookieSigner].smart
+    val signer = {
+      val c = mock[Signer].smart
       c.sign(any) answers { p => p.asInstanceOf[String] }
       c.extract(any) answers { p => Success(p.asInstanceOf[String]) }
       c
@@ -144,7 +144,7 @@ class CsrfStateItemHandlerSpec extends PlaySpecification with Mockito with JsonM
     /**
      * An instance of the CSRF state item handler.
      */
-    val csrfStateItemHandler = new CsrfStateItemHandler(settings, idGenerator, cookieSigner)
+    val csrfStateItemHandler = new CsrfStateItemHandler(settings, idGenerator, signer)
 
     /**
      * A helper method to create a cookie.
@@ -154,11 +154,12 @@ class CsrfStateItemHandlerSpec extends PlaySpecification with Mockito with JsonM
      */
     def cookie(value: String): Cookie = Cookie(
       name = settings.cookieName,
-      value = cookieSigner.sign(value),
+      value = signer.sign(value),
       maxAge = Some(settings.expirationTime.toSeconds.toInt),
       path = settings.cookiePath,
       domain = settings.cookieDomain,
       secure = settings.secureCookie,
-      httpOnly = settings.httpOnlyCookie)
+      httpOnly = settings.httpOnlyCookie
+    )
   }
 }


### PR DESCRIPTION
Until now we have only signed cookies, but now we sign also the social state sent to the provider. So we renamed the cookie signer to signer to avoid confusion.