### PR TITLE
Fix for CookieAuthenticator not working with Play 2.6.0-RC2

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/api/services/AuthenticatorService.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/api/services/AuthenticatorService.scala
@@ -59,9 +59,9 @@ class AuthenticatorResult(result: Result)
   override def copy(
     header: ResponseHeader,
     body: HttpEntity,
-    newSession: Option[Session] = None,
-    newFlash: Option[Flash] = None,
-    newCookies: Seq[Cookie] = Seq.empty
+    newSession: Option[Session],
+    newFlash: Option[Flash],
+    newCookies: Seq[Cookie]
   ) = {
     AuthenticatorResult(super.copy(header, body, newSession, newFlash, newCookies))
   }


### PR DESCRIPTION
In play-silhouette with play 2.6.0-RC2, authenticator cookie is not getting returned after successful sign in. This fix removes the default values for copy method in AuthenticatorResult which was leading to cleaning up of authenticator cookie.

Providing default for copy leads to emptying out of parameters in scala. Here is a simple program to understand this behavior in scala:

```scala
case class Foo(p1: String, p2: String) {}
class Bar(p1: String, p2: String) extends Foo(p1, p2) {
  override def copy(arg1: String = "", arg2: String = ""): Foo = { Foo(arg1, arg2) }
}
val x = new Bar("hello", "world")
val y: Foo = x
val z = y.copy(p2 = "blah")
```

Now z is Foo(,blah) instead of Foo("hello", "blah")

