### PR TITLE
Authenticators should keep other request parts in test mode

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -31,7 +31,7 @@ object BasicSettings extends AutoPlugin {
 
   override def projectSettings = Seq(
     organization := "com.mohiva",
-    version := "5.0.0-RC1",
+    version := "5.0.0-RC2",
     resolvers ++= Dependencies.resolvers,
     scalaVersion := Dependencies.Versions.scalaVersion,
     crossScalaVersions := Dependencies.Versions.crossScala,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,8 +23,7 @@ object Dependencies {
   }
 
   val resolvers = Seq(
-    "Atlassian Releases" at "https://maven.atlassian.com/public/",
-    "Akka Snapshot Repository" at "http://repo.akka.io/snapshots/"
+    "Atlassian Releases" at "https://maven.atlassian.com/public/"
   )
 
   object Library {

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticator.scala
@@ -30,7 +30,6 @@ import com.mohiva.play.silhouette.api.util._
 import com.mohiva.play.silhouette.impl.authenticators.CookieAuthenticatorService._
 import org.joda.time.DateTime
 import play.api.libs.json.Json
-import play.api.libs.typedmap.TypedMap
 import play.api.mvc._
 import play.api.mvc.request.{ Cell, RequestAttrKey }
 
@@ -286,7 +285,7 @@ class CookieAuthenticatorService(
     val combinedCookies = filteredCookies :+ cookie
     val cookies = Cookies(combinedCookies)
 
-    request.withAttrs(TypedMap(RequestAttrKey.Cookies.bindValue(Cell(cookies))))
+    request.withAttrs(request.attrs + RequestAttrKey.Cookies.bindValue(Cell(cookies)))
   }
 
   /**

--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticator.scala
@@ -25,7 +25,6 @@ import com.mohiva.play.silhouette.api.{ Authenticator, ExpirableAuthenticator, L
 import com.mohiva.play.silhouette.impl.authenticators.SessionAuthenticatorService._
 import org.joda.time.DateTime
 import play.api.libs.json.Json
-import play.api.libs.typedmap.TypedMap
 import play.api.mvc._
 import play.api.mvc.request.{ Cell, RequestAttrKey }
 
@@ -218,7 +217,7 @@ class SessionAuthenticatorService(
       case None           => session
     }
 
-    request.withAttrs(TypedMap(RequestAttrKey.Session.bindValue(Cell(s))))
+    request.withAttrs(request.attrs + RequestAttrKey.Session.bindValue(Cell(s)))
   }
 
   /**

--- a/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/BearerTokenAuthenticatorSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/BearerTokenAuthenticatorSpec.scala
@@ -212,6 +212,14 @@ class BearerTokenAuthenticatorSpec extends PlaySpecification with Mockito with N
       request.headers.get(settings.fieldName) should beSome(authenticator.id)
       request.headers.get("test") should beSome("test")
     }
+
+    "keep other request parts" in new Context {
+      val value = authenticator.id
+      val request = service.embed(value, FakeRequest().withSession("test" -> "test"))
+
+      request.headers.get(settings.fieldName) should beSome(authenticator.id)
+      request.session.get("test") should beSome("test")
+    }
   }
 
   "The `touch` method of the service" should {

--- a/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticatorSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticatorSpec.scala
@@ -350,6 +350,13 @@ class CookieAuthenticatorSpec extends PlaySpecification with Mockito with NoLang
         c.value must be equalTo "test"
       }
     }
+
+    "keep other request parts" in new Context {
+      val request = service(Some(repository)).embed(statefulCookie, FakeRequest().withSession("test" -> "test"))
+
+      request.cookies.get(settings.cookieName) should beSome[Cookie].which(requestCookieMatcher(authenticator.id))
+      request.session.get("test") should beSome("test")
+    }
   }
 
   "The `touch` method of the service" should {

--- a/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/JWTAuthenticatorSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/JWTAuthenticatorSpec.scala
@@ -371,6 +371,14 @@ class JWTAuthenticatorSpec extends PlaySpecification with Mockito with JsonMatch
       unserialize(request.headers.get(settings.fieldName).get, authenticatorEncoder, settings).get must be equalTo authenticator
       request.headers.get("test") should beSome("test")
     }
+
+    "keep other request parts" in new WithApplication with Context {
+      val token = serialize(authenticator, authenticatorEncoder, settings)
+      val request = service(Some(repository)).embed(token, FakeRequest().withSession("test" -> "test"))
+
+      unserialize(request.headers.get(settings.fieldName).get, authenticatorEncoder, settings).get must be equalTo authenticator
+      request.session.get("test") should beSome("test")
+    }
   }
 
   "The `touch` method of the service" should {

--- a/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticatorSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticatorSpec.scala
@@ -300,6 +300,17 @@ class SessionAuthenticatorSpec extends PlaySpecification with Mockito with NoLan
       request.session.get("existing") should beSome("test")
       request.session.get(settings.sessionKey) should beSome("test")
     }
+
+    "keep other request parts" in new WithApplication with AppContext {
+      val session = sessionCookieBaker.deserialize(Map(settings.sessionKey -> "test"))
+      val request = service.embed(session, FakeRequest().withCookies(Cookie("test", "test")))
+
+      request.session.get(settings.sessionKey) should beSome("test")
+      request.cookies.get("test") should beSome[Cookie].which { c =>
+        c.name must be equalTo "test"
+        c.value must be equalTo "test"
+      }
+    }
   }
 
   "The `touch` method of the service" should {


### PR DESCRIPTION
Some authenticators override the request attributes and remove all other request parts.