### PR TITLE
State handler uses wrong result if a user state item is used

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/SocialStateProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/SocialStateProvider.scala
@@ -311,7 +311,7 @@ class DefaultSocialStateHandler(val handlers: Set[SocialStateItemHandler], signe
   override def publish[B](result: Result, state: SocialState)(implicit request: ExtractableRequest[B]): Result = {
     handlers.collect { case h: PublishableSocialStateItemHandler => h }.foldLeft(result) { (r, handler) =>
       state.items.foldLeft(r) { (r, item) =>
-        handler.canHandle(item).map(item => handler.publish(item, r)).getOrElse(result)
+        handler.canHandle(item).map(item => handler.publish(item, r)).getOrElse(r)
       }
     }
   }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/DefaultSocialStateHandlerSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/DefaultSocialStateHandlerSpec.scala
@@ -74,7 +74,7 @@ class DefaultSocialStateHandlerSpec extends PlaySpecification with Mockito with 
       Publishable.itemHandler.canHandle(Publishable.item) returns Some(Publishable.item)
       Publishable.itemHandler.serialize(Publishable.item) returns Publishable.structure
 
-      stateHandler.serialize(state) must be equalTo s"${Default.structure.asString}.${Publishable.structure.asString}"
+      stateHandler.serialize(state) must be equalTo s"${Publishable.structure.asString}.${Default.structure.asString}"
     }
   }
 
@@ -211,11 +211,11 @@ class DefaultSocialStateHandlerSpec extends PlaySpecification with Mockito with 
     /**
      * The state.
      */
-    val state = SocialState(Set(Default.item, Publishable.item))
+    val state = SocialState(Set(Publishable.item, Default.item))
 
     /**
      * The state handler to test.
      */
-    val stateHandler = new DefaultSocialStateHandler(Set(Default.itemHandler, Publishable.itemHandler), signer)
+    val stateHandler = new DefaultSocialStateHandler(Set(Publishable.itemHandler, Default.itemHandler), signer)
   }
 }


### PR DESCRIPTION
The problem is that the `getOrElse` method returns the result passed to the `publish` method and not the accumulated result. So if a non publishable state items comes after a publishable state item, then it overrides the result with original result and therefore throws away all changes made by the publishable item.

## References

https://gitter.im/mohiva/play-silhouette?at=59e49918b20c6424290ae0e2
