### PR TITLE
Fix VKProvider's deprecated API calls

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/VKProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/VKProvider.scala
@@ -97,10 +97,12 @@ class VKProfileParser extends SocialProfileParser[JsValue, CommonSocialProfile, 
    */
   override def parse(json: JsValue, authInfo: OAuth2Info) = Future.successful {
     val response = (json \ "response").apply(0)
-    val userId = (response \ "id").as[Long]
+    // `uid` field was deprecated in v.5.0
+    val userId = Seq("id", "uid").map(response \ _).flatMap(_.asOpt[Long]).head
     val firstName = (response \ "first_name").asOpt[String]
     val lastName = (response \ "last_name").asOpt[String]
-    val avatarURL = (response \ "photo_max_orig").asOpt[String]
+    // `photo` field was deprecated in v.5.4
+    val avatarURL = Seq("photo_max_orig", "photo").map(response \ _).flatMap(_.asOpt[String]).headOption
 
     CommonSocialProfile(
       loginInfo = LoginInfo(ID, userId.toString),

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/VKProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/VKProvider.scala
@@ -98,11 +98,11 @@ class VKProfileParser extends SocialProfileParser[JsValue, CommonSocialProfile, 
   override def parse(json: JsValue, authInfo: OAuth2Info) = Future.successful {
     val response = (json \ "response").apply(0)
     // `uid` field was deprecated in v.5.0
-    val userId = Seq("id", "uid").map(response \ _).flatMap(_.asOpt[Long]).head
+    val userId = (response \ "uid").asOpt[Long].getOrElse((response \ "id").as[Long])
     val firstName = (response \ "first_name").asOpt[String]
     val lastName = (response \ "last_name").asOpt[String]
     // `photo` field was deprecated in v.5.4
-    val avatarURL = Seq("photo_max_orig", "photo").map(response \ _).flatMap(_.asOpt[String]).headOption
+    val avatarURL = (response \ "photo").asOpt[String].orElse((response \ "photo_max_orig").asOpt[String])
 
     CommonSocialProfile(
       loginInfo = LoginInfo(ID, userId.toString),

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/VKProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/VKProvider.scala
@@ -102,7 +102,7 @@ class VKProfileParser extends SocialProfileParser[JsValue, CommonSocialProfile, 
     val firstName = (response \ "first_name").asOpt[String]
     val lastName = (response \ "last_name").asOpt[String]
     // `photo` field was deprecated in v.5.4
-    val avatarURL = (response \ "photo").asOpt[String].orElse((response \ "photo_max_orig").asOpt[String])
+    val avatarURL = Seq("photo_max_orig", "photo").flatMap(fieldName => (response \ fieldName).asOpt[String]).headOption
 
     CommonSocialProfile(
       loginInfo = LoginInfo(ID, userId.toString),

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/VKProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/VKProvider.scala
@@ -33,9 +33,10 @@ import scala.concurrent.Future
 /**
  * Base Vk OAuth 2 provider.
  *
- * @see http://vk.com/dev/auth_sites
- * @see http://vk.com/dev/api_requests
- * @see http://vk.com/pages.php?o=-1&p=getProfiles
+ * @see https://vk.com/dev/auth_sites
+ * @see https://vk.com/dev/api_requests
+ * @see https://vk.com/dev/users.get
+ * @see https://vk.com/dev/objects/user
  */
 trait BaseVKProvider extends OAuth2Provider {
 
@@ -96,10 +97,10 @@ class VKProfileParser extends SocialProfileParser[JsValue, CommonSocialProfile, 
    */
   override def parse(json: JsValue, authInfo: OAuth2Info) = Future.successful {
     val response = (json \ "response").apply(0)
-    val userId = (response \ "uid").as[Long]
+    val userId = (response \ "id").as[Long]
     val firstName = (response \ "first_name").asOpt[String]
     val lastName = (response \ "last_name").asOpt[String]
-    val avatarURL = (response \ "photo").asOpt[String]
+    val avatarURL = (response \ "photo_max_orig").asOpt[String]
 
     CommonSocialProfile(
       loginInfo = LoginInfo(ID, userId.toString),
@@ -156,7 +157,7 @@ object VKProvider {
    * The VK constants.
    */
   val ID = "vk"
-  val API = "https://api.vk.com/method/getProfiles?fields=uid,first_name,last_name,photo&access_token=%s"
+  val API = "https://api.vk.com/method/users.get?fields=uid,first_name,last_name,photo_max_orig&v=5.73&access_token=%s"
 
   /**
    * Converts the JSON into a [[OAuth2Info]] object.

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/VKProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/VKProvider.scala
@@ -157,7 +157,7 @@ object VKProvider {
    * The VK constants.
    */
   val ID = "vk"
-  val API = "https://api.vk.com/method/users.get?fields=uid,first_name,last_name,photo_max_orig&v=5.73&access_token=%s"
+  val API = "https://api.vk.com/method/users.get?fields=id,first_name,last_name,photo_max_orig&v=5.73&access_token=%s"
 
   /**
    * Converts the JSON into a [[OAuth2Info]] object.

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/VKProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/VKProvider.scala
@@ -102,7 +102,7 @@ class VKProfileParser extends SocialProfileParser[JsValue, CommonSocialProfile, 
     val firstName = (response \ "first_name").asOpt[String]
     val lastName = (response \ "last_name").asOpt[String]
     // `photo` field was deprecated in v.5.4
-    val avatarURL = Seq("photo_max_orig", "photo").flatMap(fieldName => (response \ fieldName).asOpt[String]).headOption
+    val avatarURL = (response \ "photo").asOpt[String].orElse((response \ "photo_max_orig").asOpt[String])
 
     CommonSocialProfile(
       loginInfo = LoginInfo(ID, userId.toString),

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/VKProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/VKProviderSpec.scala
@@ -181,7 +181,7 @@ class VKProviderSpec extends OAuth2ProviderSpec {
       val wsRequest = mock[MockWSRequest]
       val wsResponse = mock[MockWSRequest#Response]
       wsResponse.status returns 200
-      wsResponse.json returns (Helper.loadJson("providers/oauth2/vk.success.json").as[JsObject] - "photo_max_orig")
+      wsResponse.json returns Helper.loadJson("providers/oauth2/vk.success.without.photo.json").as[JsObject]
       wsRequest.get() returns Future.successful(wsResponse)
       httpLayer.url(API.format("my.access.token")) returns wsRequest
 

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/VKProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/VKProviderSpec.scala
@@ -177,6 +177,25 @@ class VKProviderSpec extends OAuth2ProviderSpec {
       }
     }
 
+    "return the social profile with email and deprecated API response" in new WithApplication with Context {
+      val wsRequest = mock[MockWSRequest]
+      val wsResponse = mock[MockWSRequest#Response]
+      wsResponse.status returns 200
+      wsResponse.json returns Helper.loadJson("providers/oauth2/vk.success.deprecated.json")
+      wsRequest.get() returns Future.successful(wsResponse)
+      httpLayer.url(API.format("my.access.token")) returns wsRequest
+
+      profile(provider.retrieveProfile(oAuthInfo.as[OAuth2Info])) { p =>
+        p must be equalTo CommonSocialProfile(
+          loginInfo = LoginInfo(provider.id, "66748"),
+          firstName = Some("Apollonia"),
+          lastName = Some("Vanova"),
+          email = Some("apollonia.vanova@watchmen.com"),
+          avatarURL = Some("http://vk.com/images/camera_b.gif")
+        )
+      }
+    }
+
     "return the social profile without email" in new WithApplication with Context {
       val wsRequest = mock[MockWSRequest]
       val wsResponse = mock[MockWSRequest#Response]

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/VKProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/VKProviderSpec.scala
@@ -177,7 +177,26 @@ class VKProviderSpec extends OAuth2ProviderSpec {
       }
     }
 
-    "return the social profile with email and deprecated API response" in new WithApplication with Context {
+    "return the social profile from response without photo" in new WithApplication with Context {
+      val wsRequest = mock[MockWSRequest]
+      val wsResponse = mock[MockWSRequest#Response]
+      wsResponse.status returns 200
+      wsResponse.json returns (Helper.loadJson("providers/oauth2/vk.success.json").as[JsObject] - "photo_max_orig")
+      wsRequest.get() returns Future.successful(wsResponse)
+      httpLayer.url(API.format("my.access.token")) returns wsRequest
+
+      profile(provider.retrieveProfile(oAuthInfo.as[OAuth2Info])) { p =>
+        p must be equalTo CommonSocialProfile(
+          loginInfo = LoginInfo(provider.id, "66748"),
+          firstName = Some("Apollonia"),
+          lastName = Some("Vanova"),
+          email = Some("apollonia.vanova@watchmen.com"),
+          avatarURL = None
+        )
+      }
+    }
+
+    "return the social profile from deprecated API response" in new WithApplication with Context {
       val wsRequest = mock[MockWSRequest]
       val wsResponse = mock[MockWSRequest#Response]
       wsResponse.status returns 200

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/VKProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/VKProviderSpec.scala
@@ -158,6 +158,21 @@ class VKProviderSpec extends OAuth2ProviderSpec {
       there was one(httpLayer).url(url.format("my.access.token"))
     }
 
+    "use the overridden API URL with deprecated fields" in new WithApplication with Context {
+      val url = "https://custom.api.url?access_token=%s"
+      val wsRequest = mock[MockWSRequest]
+      val wsResponse = mock[MockWSRequest#Response]
+      oAuthSettings.apiURL returns Some(url)
+      wsResponse.status returns 200
+      wsResponse.json returns Helper.loadJson("providers/oauth2/vk.success.deprecated.json")
+      wsRequest.get() returns Future.successful(wsResponse)
+      httpLayer.url(url.format("my.access.token")) returns wsRequest
+
+      await(provider.retrieveProfile(oAuthInfo.as[OAuth2Info]))
+
+      there was one(httpLayer).url(url.format("my.access.token"))
+    }
+
     "return the social profile with email" in new WithApplication with Context {
       val wsRequest = mock[MockWSRequest]
       val wsResponse = mock[MockWSRequest#Response]

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/VKProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/VKProviderSpec.scala
@@ -158,21 +158,6 @@ class VKProviderSpec extends OAuth2ProviderSpec {
       there was one(httpLayer).url(url.format("my.access.token"))
     }
 
-    "use the overridden API URL with deprecated fields" in new WithApplication with Context {
-      val url = "https://custom.api.url?access_token=%s"
-      val wsRequest = mock[MockWSRequest]
-      val wsResponse = mock[MockWSRequest#Response]
-      oAuthSettings.apiURL returns Some(url)
-      wsResponse.status returns 200
-      wsResponse.json returns Helper.loadJson("providers/oauth2/vk.success.deprecated.json")
-      wsRequest.get() returns Future.successful(wsResponse)
-      httpLayer.url(url.format("my.access.token")) returns wsRequest
-
-      await(provider.retrieveProfile(oAuthInfo.as[OAuth2Info]))
-
-      there was one(httpLayer).url(url.format("my.access.token"))
-    }
-
     "return the social profile with email" in new WithApplication with Context {
       val wsRequest = mock[MockWSRequest]
       val wsResponse = mock[MockWSRequest#Response]

--- a/silhouette/test/resources/providers/oauth2/vk.success.deprecated.json
+++ b/silhouette/test/resources/providers/oauth2/vk.success.deprecated.json
@@ -1,10 +1,10 @@
 {
   "response": [
     {
-      "id": 66748,
+      "uid": 66748,
       "first_name": "Apollonia",
       "last_name": "Vanova",
-      "photo_max_orig": "https://vk.com/images/camera_400.png"
+      "photo": "http://vk.com/images/camera_b.gif"
     }
   ]
 }

--- a/silhouette/test/resources/providers/oauth2/vk.success.json
+++ b/silhouette/test/resources/providers/oauth2/vk.success.json
@@ -4,7 +4,7 @@
       "id": 66748,
       "first_name": "Apollonia",
       "last_name": "Vanova",
-      "photo_max_orig": "https://vk.com/images/camera_400.png"
+      "photo_max_orig": "http://vk.com/images/camera_b.gif"
     }
   ]
 }

--- a/silhouette/test/resources/providers/oauth2/vk.success.without.photo.json
+++ b/silhouette/test/resources/providers/oauth2/vk.success.without.photo.json
@@ -1,0 +1,9 @@
+{
+  "response": [
+    {
+      "id": 66748,
+      "first_name": "Apollonia",
+      "last_name": "Vanova"
+    }
+  ]
+}


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/mohiva/play-silhouette/blob/master/CONTRIBUTING.md)?
* [x] Have you added copyright headers to new files?
* [x] Have you suggest documentation edits?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes VKProvider's API calls resulting in an error:
```
{
  "error_code":8,
  "error_msg":"Invalid request: v (version) is required"
}
```

## Purpose

Update VKProvider's API calls according to VK API changes.

## Background Context

VK has updated their API so now calls to `https://api.vk.com/method/getProfiles` without v-for-version parameter result in an error. See References for details.

## References

https://vk.com/dev/version_update