### PR TITLE
GoogleProvider: Suppress Google's default profile picture

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/GoogleProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/GoogleProvider.scala
@@ -92,6 +92,7 @@ class GoogleProfileParser extends SocialProfileParser[JsValue, CommonSocialProfi
     val lastName = (json \ "name" \ "familyName").asOpt[String]
     val fullName = (json \ "displayName").asOpt[String]
     val avatarURL = (json \ "image" \ "url").asOpt[String]
+    val isDefaultAvatar = (json \ "image" \ "isDefault").asOpt[Boolean].getOrElse(false)
 
     // https://developers.google.com/+/api/latest/people#emails.type
     val emailIndex = (json \ "emails" \\ "type").indexWhere(_.as[String] == "account")
@@ -106,7 +107,7 @@ class GoogleProfileParser extends SocialProfileParser[JsValue, CommonSocialProfi
       firstName = firstName,
       lastName = lastName,
       fullName = fullName,
-      avatarURL = avatarURL,
+      avatarURL = if (isDefaultAvatar) None else avatarURL, // skip the default avatar picture
       email = emailValue)
   }
 }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/GoogleProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/GoogleProviderSpec.scala
@@ -197,6 +197,44 @@ class GoogleProviderSpec extends OAuth2ProviderSpec {
         )
       }
     }
+    "return the social profile with an avatar url" in new WithApplication with Context {
+      val wsRequest = mock[MockWSRequest]
+      val wsResponse = mock[MockWSRequest#Response]
+      wsResponse.status returns 200
+      wsResponse.json returns Helper.loadJson("providers/oauth2/google.img.non-default.json")
+      wsRequest.get() returns Future.successful(wsResponse)
+      httpLayer.url(API.format("my.access.token")) returns wsRequest
+
+      profile(provider.retrieveProfile(oAuthInfo.as[OAuth2Info])) { p =>
+        p must be equalTo CommonSocialProfile(
+          loginInfo = LoginInfo(provider.id, "109476598527568979481"),
+          firstName = Some("Apollonia"),
+          lastName = Some("Vanova"),
+          fullName = Some("Apollonia Vanova"),
+          email = Some("apollonia.vanova@watchmen.com"),
+          avatarURL = Some("https://lh6.googleusercontent.com/-m34A6I77dJU/ASASAASADAAI/AVABAAAAAJk/5cg1hcjo_4s/photo.jpg?sz=50")
+        )
+      }
+    }
+    "return the social profile without an avatar url" in new WithApplication with Context {
+      val wsRequest = mock[MockWSRequest]
+      val wsResponse = mock[MockWSRequest#Response]
+      wsResponse.status returns 200
+      wsResponse.json returns Helper.loadJson("providers/oauth2/google.img.default.json")
+      wsRequest.get() returns Future.successful(wsResponse)
+      httpLayer.url(API.format("my.access.token")) returns wsRequest
+
+      profile(provider.retrieveProfile(oAuthInfo.as[OAuth2Info])) { p =>
+        p must be equalTo CommonSocialProfile(
+          loginInfo = LoginInfo(provider.id, "109476598527568979481"),
+          firstName = Some("Apollonia"),
+          lastName = Some("Vanova"),
+          fullName = Some("Apollonia Vanova"),
+          email = Some("apollonia.vanova@watchmen.com"),
+          avatarURL = None
+        )
+      }
+    }
   }
 
   /**

--- a/silhouette/test/resources/providers/oauth2/google.img.default.json
+++ b/silhouette/test/resources/providers/oauth2/google.img.default.json
@@ -1,0 +1,22 @@
+{
+  "emails": [
+    {
+      "value": "home@watchmen.com",
+      "type": "home"
+    },
+    {
+      "value": "apollonia.vanova@watchmen.com",
+      "type": "account"
+    }
+  ],
+  "id": "109476598527568979481",
+  "displayName": "Apollonia Vanova",
+  "name": {
+    "familyName": "Vanova",
+    "givenName": "Apollonia"
+  },
+  "image": {
+    "url": "https://lh6.googleusercontent.com/-m34A6I77dJU/ASASAASADAAI/AVABAAAAAJk/5cg1hcjo_4s/photo.jpg?sz=50",
+    "isDefault" : true
+  }
+}

--- a/silhouette/test/resources/providers/oauth2/google.img.non-default.json
+++ b/silhouette/test/resources/providers/oauth2/google.img.non-default.json
@@ -1,0 +1,22 @@
+{
+  "emails": [
+    {
+      "value": "home@watchmen.com",
+      "type": "home"
+    },
+    {
+      "value": "apollonia.vanova@watchmen.com",
+      "type": "account"
+    }
+  ],
+  "id": "109476598527568979481",
+  "displayName": "Apollonia Vanova",
+  "name": {
+    "familyName": "Vanova",
+    "givenName": "Apollonia"
+  },
+  "image": {
+    "url": "https://lh6.googleusercontent.com/-m34A6I77dJU/ASASAASADAAI/AVABAAAAAJk/5cg1hcjo_4s/photo.jpg?sz=50",
+    "isDefault" : false
+  }
+}


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [X] Have you read through the [contributor guidelines](https://github.com/mohiva/play-silhouette/blob/master/CONTRIBUTING.md)?
* [X] Have you added copyright headers to new files?
-> N/A
* [X] Have you suggest documentation edits?
* [X] Have you added tests for any changed functionality?

## Fixes

n/a, it's an improvement.

## Purpose

Adds functionality to suppress the default Google profile image. 

## Background Context

Silhouette provides it's own placeholder profile image when a user does not have an avatar image set.
The Google+ API however will always return a profile image URL, which is a standard image and looks different from the OOTB Silhouette placeholder image. This change inspects a flag in the response (isDefault) and ignores the returned image URL if true.

## References

Yupp, as discussed on Gitter.
