### PR TITLE
Added support for setting the SameSite option on cookies.

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticator.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticator.scala
@@ -254,7 +254,8 @@ class CookieAuthenticatorService(
         path = settings.cookiePath,
         domain = settings.cookieDomain,
         secure = settings.secureCookie,
-        httpOnly = settings.httpOnlyCookie
+        httpOnly = settings.httpOnlyCookie,
+        sameSite = settings.sameSite
       )
     }.recover {
       case e => throw new AuthenticatorInitializationException(InitError.format(ID, authenticator), e)
@@ -329,7 +330,8 @@ class CookieAuthenticatorService(
         path = settings.cookiePath,
         domain = settings.cookieDomain,
         secure = settings.secureCookie,
-        httpOnly = settings.httpOnlyCookie
+        httpOnly = settings.httpOnlyCookie,
+        sameSite = settings.sameSite
       ))))
     }).recover {
       case e => throw new AuthenticatorUpdateException(UpdateError.format(ID, authenticator), e)
@@ -433,6 +435,7 @@ object CookieAuthenticatorService {
  * @param cookieDomain             The cookie domain.
  * @param secureCookie             Whether this cookie is secured, sent only for HTTPS requests.
  * @param httpOnlyCookie           Whether this cookie is HTTP only, i.e. not accessible from client-side JavaScript code.
+ * @param sameSite                 The SameSite attribute for this cookie (for CSRF protection).
  * @param useFingerprinting        Indicates if a fingerprint of the user should be stored in the authenticator.
  * @param cookieMaxAge             The duration a cookie expires. `None` for a transient cookie.
  * @param authenticatorIdleTimeout The duration an authenticator can be idle before it timed out.
@@ -444,6 +447,7 @@ case class CookieAuthenticatorSettings(
   cookieDomain: Option[String] = None,
   secureCookie: Boolean = true,
   httpOnlyCookie: Boolean = true,
+  sameSite: Option[Cookie.SameSite] = Some(Cookie.SameSite.Lax),
   useFingerprinting: Boolean = true,
   cookieMaxAge: Option[FiniteDuration] = None,
   authenticatorIdleTimeout: Option[FiniteDuration] = None,

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth1/secrets/CookieSecret.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth1/secrets/CookieSecret.scala
@@ -174,7 +174,8 @@ class CookieSecretProvider @Inject() (
       path = settings.cookiePath,
       domain = settings.cookieDomain,
       secure = settings.secureCookie,
-      httpOnly = settings.httpOnlyCookie
+      httpOnly = settings.httpOnlyCookie,
+      sameSite = settings.sameSite
     ))
   }
 }
@@ -197,11 +198,12 @@ object CookieSecretProvider {
 /**
  * The settings for the cookie secret.
  *
- * @param cookieName The cookie name.
- * @param cookiePath The cookie path.
- * @param cookieDomain The cookie domain.
- * @param secureCookie Whether this cookie is secured, sent only for HTTPS requests.
+ * @param cookieName     The cookie name.
+ * @param cookiePath     The cookie path.
+ * @param cookieDomain   The cookie domain.
+ * @param secureCookie   Whether this cookie is secured, sent only for HTTPS requests.
  * @param httpOnlyCookie Whether this cookie is HTTP only, i.e. not accessible from client-side JavaScript code.
+ * @param sameSite       The SameSite attribute for this cookie (for CSRF protection).
  * @param expirationTime Secret expiration. Defaults to 5 minutes which provides sufficient time to log in, but
  *                       not too much. This is a balance between convenience and security.
  */
@@ -211,5 +213,6 @@ case class CookieSecretSettings(
   cookieDomain: Option[String] = None,
   secureCookie: Boolean = true,
   httpOnlyCookie: Boolean = true,
+  sameSite: Option[Cookie.SameSite] = Some(Cookie.SameSite.Lax),
   expirationTime: FiniteDuration = 5 minutes
 )

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/state/CsrfStateItemHandler.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/state/CsrfStateItemHandler.scala
@@ -158,7 +158,8 @@ class CsrfStateItemHandler @Inject() (
       path = settings.cookiePath,
       domain = settings.cookieDomain,
       secure = settings.secureCookie,
-      httpOnly = settings.httpOnlyCookie
+      httpOnly = settings.httpOnlyCookie,
+      sameSite = settings.sameSite
     ))
   }
 
@@ -200,6 +201,7 @@ object CsrfStateItemHandler {
  * @param cookieDomain   The cookie domain.
  * @param secureCookie   Whether this cookie is secured, sent only for HTTPS requests.
  * @param httpOnlyCookie Whether this cookie is HTTP only, i.e. not accessible from client-side JavaScript code.
+ * @param sameSite       The SameSite attribute for this cookie (for CSRF protection).
  * @param expirationTime State expiration. Defaults to 5 minutes which provides sufficient time to log in, but
  *                       not too much. This is a balance between convenience and security.
  */
@@ -209,5 +211,6 @@ case class CsrfStateSettings(
   cookieDomain: Option[String] = None,
   secureCookie: Boolean = true,
   httpOnlyCookie: Boolean = true,
+  sameSite: Option[Cookie.SameSite] = Some(Cookie.SameSite.Lax),
   expirationTime: FiniteDuration = 5 minutes
 )

--- a/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticatorSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/authenticators/CookieAuthenticatorSpec.scala
@@ -633,7 +633,8 @@ class CookieAuthenticatorSpec extends PlaySpecification with Mockito with NoLang
       path = settings.cookiePath,
       domain = settings.cookieDomain,
       secure = settings.secureCookie,
-      httpOnly = settings.httpOnlyCookie
+      httpOnly = settings.httpOnlyCookie,
+      sameSite = settings.sameSite
     )
 
     /**
@@ -646,7 +647,8 @@ class CookieAuthenticatorSpec extends PlaySpecification with Mockito with NoLang
       path = settings.cookiePath,
       domain = settings.cookieDomain,
       secure = settings.secureCookie,
-      httpOnly = settings.httpOnlyCookie
+      httpOnly = settings.httpOnlyCookie,
+      sameSite = settings.sameSite
     )
 
     /**
@@ -661,6 +663,7 @@ class CookieAuthenticatorSpec extends PlaySpecification with Mockito with NoLang
       c.domain must be equalTo settings.cookieDomain
       c.secure must be equalTo settings.secureCookie
       c.httpOnly must be equalTo settings.httpOnlyCookie
+      c.sameSite must be equalTo settings.sameSite
     }
 
     /**
@@ -675,6 +678,7 @@ class CookieAuthenticatorSpec extends PlaySpecification with Mockito with NoLang
       c.domain must be equalTo settings.cookieDomain
       c.secure must be equalTo settings.secureCookie
       c.httpOnly must be equalTo settings.httpOnlyCookie
+      c.sameSite must be equalTo settings.sameSite
     }
 
     /**

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/state/CsrfStateItemHandlerSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/state/CsrfStateItemHandlerSpec.scala
@@ -159,7 +159,8 @@ class CsrfStateItemHandlerSpec extends PlaySpecification with Mockito with JsonM
       path = settings.cookiePath,
       domain = settings.cookieDomain,
       secure = settings.secureCookie,
-      httpOnly = settings.httpOnlyCookie
+      httpOnly = settings.httpOnlyCookie,
+      sameSite = settings.sameSite
     )
   }
 }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/mohiva/play-silhouette/blob/master/CONTRIBUTING.md)?
* [x] Have you added copyright headers to new files?
* [x] Have you suggest documentation edits?
* [x] Have you added tests for any changed functionality?

## Purpose

Makes it possible to set the SameSite option on cookies.

## Background Context

~~I chose to use a String representation, since using the Cookie.SameSite type, would break current solutions using Ficus. Alternatively we could create our own Enumeration and convert that to the Play Cookie.SameSite type.~~ EDIT: We're now using the Cookie.SameSite type.

I chose the default to be `Lax`, since from looking at other settings, we want to recommend a sane default, where as `Strict`, might be too harsh, and `None` would simply do nothing.