### PR TITLE
#548: Switch GoogleProvider to People API

### DIFF
--- a/silhouette/test/resources/providers/oauth2/google.error.api.missing.json
+++ b/silhouette/test/resources/providers/oauth2/google.error.api.missing.json
@@ -1,0 +1,18 @@
+{
+  "error": {
+    "code": 403,
+    "message": "People API has not been used in project 1234567890 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/people.googleapis.com/overview?project=1234567890 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.",
+    "status": "PERMISSION_DENIED",
+    "details": [
+      {
+        "@type": "type.googleapis.com/google.rpc.Help",
+        "links": [
+          {
+            "description": "Google developers console API activation",
+            "url": "https://console.developers.google.com/apis/api/people.googleapis.com/overview?project=1234567890"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/silhouette/test/resources/providers/oauth2/google.img.default.json
+++ b/silhouette/test/resources/providers/oauth2/google.img.default.json
@@ -1,22 +1,56 @@
 {
-  "emails": [
+  "resourceName": "people/109476598527568979481",
+  "etag": "%EggBAj0DCT43LohDUMMYVALUEgbwgJCgsMIgxkaGtKb3cwenMxMD1=",
+  "emailAddresses": [
     {
-      "value": "home@watchmen.com",
-      "type": "home"
+      "metadata": {
+        "primary": true,
+        "verified": true,
+        "source": {
+          "type": "ACCOUNT",
+          "id": "109476598527568979481"
+        }
+      },
+      "value": "apollonia.vanova@watchmen.com"
     },
     {
-      "value": "apollonia.vanova@watchmen.com",
-      "type": "account"
+      "metadata": {
+        "primary": true,
+        "verified": true,
+        "source": {
+          "type": "HOME",
+          "id": "109476598527568979481"
+        }
+      },
+      "value": "home@watchmen.com"
     }
   ],
-  "id": "109476598527568979481",
-  "displayName": "Apollonia Vanova",
-  "name": {
-    "familyName": "Vanova",
-    "givenName": "Apollonia"
-  },
-  "image": {
-    "url": "https://lh6.googleusercontent.com/-m34A6I77dJU/ASASAASADAAI/AVABAAAAAJk/5cg1hcjo_4s/photo.jpg?sz=50",
-    "isDefault" : true
-  }
+  "names": [
+    {
+      "metadata": {
+        "primary": true,
+        "source": {
+          "type": "PROFILE",
+          "id": "109476598527568979481"
+        }
+      },
+      "displayName": "Apollonia Vanova",
+      "familyName": "Vanova",
+      "givenName": "Apollonia",
+      "displayNameLastFirst": "Vanova, Apollonia"
+    }
+  ],
+  "photos": [
+    {
+      "metadata": {
+        "primary": true,
+        "source": {
+          "type": "PROFILE",
+          "id": "109476598527568979481"
+        }
+      },
+      "url": "https://lh6.googleusercontent.com/-m34A6I77dJU/ASASAASADAAI/AVABAAAAAJk/5cg1hcjo_4s/photo.jpg?sz=50",
+      "default": true
+    }
+  ]
 }

--- a/silhouette/test/resources/providers/oauth2/google.img.non-default.json
+++ b/silhouette/test/resources/providers/oauth2/google.img.non-default.json
@@ -1,22 +1,55 @@
 {
-  "emails": [
+  "resourceName": "people/109476598527568979481",
+  "etag": "%EggBAj0DCT43LohDUMMYVALUEgbwgJCgsMIgxkaGtKb3cwenMxMD1=",
+  "emailAddresses": [
     {
-      "value": "home@watchmen.com",
-      "type": "home"
+      "metadata": {
+        "primary": true,
+        "verified": true,
+        "source": {
+          "type": "ACCOUNT",
+          "id": "109476598527568979481"
+        }
+      },
+      "value": "apollonia.vanova@watchmen.com"
     },
     {
-      "value": "apollonia.vanova@watchmen.com",
-      "type": "account"
+      "metadata": {
+        "primary": true,
+        "verified": true,
+        "source": {
+          "type": "HOME",
+          "id": "109476598527568979481"
+        }
+      },
+      "value": "home@watchmen.com"
     }
   ],
-  "id": "109476598527568979481",
-  "displayName": "Apollonia Vanova",
-  "name": {
-    "familyName": "Vanova",
-    "givenName": "Apollonia"
-  },
-  "image": {
-    "url": "https://lh6.googleusercontent.com/-m34A6I77dJU/ASASAASADAAI/AVABAAAAAJk/5cg1hcjo_4s/photo.jpg?sz=50",
-    "isDefault" : false
-  }
+  "names": [
+    {
+      "metadata": {
+        "primary": true,
+        "source": {
+          "type": "PROFILE",
+          "id": "109476598527568979481"
+        }
+      },
+      "displayName": "Apollonia Vanova",
+      "familyName": "Vanova",
+      "givenName": "Apollonia",
+      "displayNameLastFirst": "Vanova, Apollonia"
+    }
+  ],
+  "photos": [
+    {
+      "metadata": {
+        "primary": true,
+        "source": {
+          "type": "PROFILE",
+          "id": "109476598527568979481"
+        }
+      },
+      "url": "https://lh6.googleusercontent.com/-m34A6I77dJU/ASASAASADAAI/AVABAAAAAJk/5cg1hcjo_4s/photo.jpg?sz=50"
+    }
+  ]
 }

--- a/silhouette/test/resources/providers/oauth2/google.success.json
+++ b/silhouette/test/resources/providers/oauth2/google.success.json
@@ -1,21 +1,54 @@
 {
-  "emails": [
+  "resourceName": "people/109476598527568979481",
+  "etag": "%EggBAj0DCT43LohDUMMYVALUEgbwgJCgsMIgxkaGtKb3cwenMxMD1=",
+  "emailAddresses": [
     {
-      "value": "home@watchmen.com",
-      "type": "home"
+      "metadata": {
+        "primary": true,
+        "verified": true,
+        "source": {
+          "type": "ACCOUNT",
+          "id": "109476598527568979481"
+        }
+      },
+      "value": "apollonia.vanova@watchmen.com"
     },
     {
-      "value": "apollonia.vanova@watchmen.com",
-      "type": "account"
+      "metadata": {
+        "verified": true,
+        "source": {
+          "type": "ACCOUNT",
+          "id": "109476598527568979481"
+        }
+      },
+      "value": "home@watchmen.com"
     }
   ],
-  "id": "109476598527568979481",
-  "displayName": "Apollonia Vanova",
-  "name": {
-    "familyName": "Vanova",
-    "givenName": "Apollonia"
-  },
-  "image": {
-    "url": "https://lh6.googleusercontent.com/-m34A6I77dJU/ASASAASADAAI/AVABAAAAAJk/5cg1hcjo_4s/photo.jpg?sz=50"
-  }
+  "names": [
+    {
+      "metadata": {
+        "primary": true,
+        "source": {
+          "type": "PROFILE",
+          "id": "109476598527568979481"
+        }
+      },
+      "displayName": "Apollonia Vanova",
+      "familyName": "Vanova",
+      "givenName": "Apollonia",
+      "displayNameLastFirst": "Vanova, Apollonia"
+    }
+  ],
+  "photos": [
+    {
+      "metadata": {
+        "primary": true,
+        "source": {
+          "type": "PROFILE",
+          "id": "109476598527568979481"
+        }
+      },
+      "url": "https://lh6.googleusercontent.com/-m34A6I77dJU/ASASAASADAAI/AVABAAAAAJk/5cg1hcjo_4s/photo.jpg?sz=50"
+    }
+  ]
 }

--- a/silhouette/test/resources/providers/oauth2/google.without.email.json
+++ b/silhouette/test/resources/providers/oauth2/google.without.email.json
@@ -1,11 +1,31 @@
 {
-  "id": "109476598527568979481",
-  "displayName": "Apollonia Vanova",
-  "name": {
-    "familyName": "Vanova",
-    "givenName": "Apollonia"
-  },
-  "image": {
-    "url": "https://lh6.googleusercontent.com/-m34A6I77dJU/ASASAASADAAI/AVABAAAAAJk/5cg1hcjo_4s/photo.jpg?sz=50"
-  }
+  "resourceName": "people/109476598527568979481",
+  "etag": "%EggBAj0DCT43LohDUMMYVALUEgbwgJCgsMIgxkaGtKb3cwenMxMD1=",
+  "names": [
+    {
+      "metadata": {
+        "primary": true,
+        "source": {
+          "type": "PROFILE",
+          "id": "109476598527568979481"
+        }
+      },
+      "displayName": "Apollonia Vanova",
+      "familyName": "Vanova",
+      "givenName": "Apollonia",
+      "displayNameLastFirst": "Vanova, Apollonia"
+    }
+  ],
+  "photos": [
+    {
+      "metadata": {
+        "primary": true,
+        "source": {
+          "type": "PROFILE",
+          "id": "109476598527568979481"
+        }
+      },
+      "url": "https://lh6.googleusercontent.com/-m34A6I77dJU/ASASAASADAAI/AVABAAAAAJk/5cg1hcjo_4s/photo.jpg?sz=50"
+    }
+  ]
 }


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [X] Have you read through the [contributor guidelines](https://github.com/mohiva/play-silhouette/blob/master/CONTRIBUTING.md)?
* [x] Have you added copyright headers to new files?
* [x] Have you suggest documentation edits? 
* [X] Have you added tests for any changed functionality?

## Fixes

Changed the API endpoint and response parsing to new People API.
Updated the test json files. Added a new test if a project is not enabled for the People API.

## Purpose

Google sunsetted the Google+ API and need to switch to the People API.

## Background Context

Current API is going to be retired in March 2019. So it's time to update. 

## References

https://github.com/mohiva/play-silhouette/issues/548
