### PR TITLE
Fixed Profile URL as v1 resource is no longer available

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/LinkedInProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/LinkedInProvider.scala
@@ -89,11 +89,11 @@ class LinkedInProfileParser extends SocialProfileParser[JsValue, CommonSocialPro
    */
   override def parse(json: JsValue, authInfo: OAuth2Info) = Future.successful {
     val userID = (json \ "id").as[String]
-    val firstName = (json \ "firstName").asOpt[String]
-    val lastName = (json \ "lastName").asOpt[String]
-    val fullName = (json \ "formattedName").asOpt[String]
-    val avatarURL = (json \ "pictureUrl").asOpt[String]
-    val email = (json \ "emailAddress").asOpt[String]
+    val firstName = (json \ "localizedFirstName").asOpt[String]
+    val lastName = (json \ "localizedLastName").asOpt[String]
+    val fullName = Some(firstName.getOrElse("")+" "+lastName.getOrElse("")).map(_.trim)
+    val avatarURL = None
+    val email = None
 
     CommonSocialProfile(
       loginInfo = LoginInfo(ID, userID),
@@ -151,5 +151,5 @@ object LinkedInProvider {
    * The LinkedIn constants.
    */
   val ID = "linkedin"
-  val API = "https://api.linkedin.com/v1/people/~:(id,first-name,last-name,formatted-name,picture-url,email-address)?format=json&oauth2_access_token=%s"
+  val API = "https://api.linkedin.com/v2/me?oauth2_access_token=%s"
 }

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/LinkedInProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/LinkedInProvider.scala
@@ -24,7 +24,7 @@ import com.mohiva.play.silhouette.api.util.HTTPLayer
 import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
 import com.mohiva.play.silhouette.impl.providers._
 import com.mohiva.play.silhouette.impl.providers.oauth2.LinkedInProvider._
-import play.api.libs.json.JsValue
+import play.api.libs.json.{ JsObject, JsValue }
 
 import scala.concurrent.Future
 
@@ -50,17 +50,15 @@ trait BaseLinkedInProvider extends OAuth2Provider {
   /**
    * Defines the URLs that are needed to retrieve the profile data.
    */
-  override protected val urls = Map("api" -> settings.apiURL.getOrElse(API))
+  override protected val urls = Map(
+    "api" -> settings.apiURL.getOrElse(API),
+    "email" -> settings.customProperties.getOrElse("emailURL", EMAIL),
+    "photo" -> settings.customProperties.getOrElse("photoURL", PHOTO)
+  )
 
-  /**
-   * Builds the social profile.
-   *
-   * @param authInfo The auth info received from the provider.
-   * @return On success the build social profile, otherwise a failure.
-   */
-  override protected def buildProfile(authInfo: OAuth2Info): Future[Profile] = {
-    httpLayer.url(urls("api").format(authInfo.accessToken)).get().flatMap { response =>
-      val json = response.json
+  private def getPartialProfile(url: String, authInfo: OAuth2Info): Future[JsValue] = {
+    httpLayer.url(url.format(authInfo.accessToken)).get().flatMap { response =>
+      val json: JsValue = response.json
       (json \ "errorCode").asOpt[Int] match {
         case Some(error) =>
           val message = (json \ "message").asOpt[String]
@@ -69,8 +67,21 @@ trait BaseLinkedInProvider extends OAuth2Provider {
           val timestamp = (json \ "timestamp").asOpt[Long]
 
           Future.failed(new ProfileRetrievalException(SpecifiedProfileError.format(id, error, message, requestId, status, timestamp)))
-        case _ => profileParser.parse(json, authInfo)
+        case _ => Future.successful(json)
       }
+    }
+  }
+  /**
+   * Builds the social profile.
+   *
+   * @param authInfo The auth info received from the provider.
+   * @return On success the build social profile, otherwise a failure.
+   */
+  override protected def buildProfile(authInfo: OAuth2Info): Future[Profile] = {
+    Future.sequence(Seq(getPartialProfile(urls("api"), authInfo), getPartialProfile(urls("email"), authInfo), getPartialProfile(urls("photo"), authInfo))).flatMap {
+      partial =>
+        val array: JsValue = JsObject(Seq("api" -> partial(0), "email" -> partial(1), "photo" -> partial(2)))
+        profileParser.parse(array, authInfo)
     }
   }
 }
@@ -88,12 +99,12 @@ class LinkedInProfileParser extends SocialProfileParser[JsValue, CommonSocialPro
    * @return The social profile from given result.
    */
   override def parse(json: JsValue, authInfo: OAuth2Info) = Future.successful {
-    val userID = (json \ "id").as[String]
-    val firstName = (json \ "localizedFirstName").asOpt[String]
-    val lastName = (json \ "localizedLastName").asOpt[String]
-    val fullName = Some(firstName.getOrElse("")+" "+lastName.getOrElse("")).map(_.trim)
-    val avatarURL = None
-    val email = None
+    val userID = (json \ "api" \ "id").as[String]
+    val firstName = (json \ "api" \ "localizedFirstName").asOpt[String]
+    val lastName = (json \ "api" \ "localizedLastName").asOpt[String]
+    val fullName = Some(firstName.getOrElse("") + " " + lastName.getOrElse("")).map(_.trim)
+    val avatarURL = (json \\ "identifier")(0).asOpt[String]
+    val email = (json \\ "emailAddress")(0).asOpt[String]
 
     CommonSocialProfile(
       loginInfo = LoginInfo(ID, userID),
@@ -152,4 +163,6 @@ object LinkedInProvider {
    */
   val ID = "linkedin"
   val API = "https://api.linkedin.com/v2/me?oauth2_access_token=%s"
+  val EMAIL = "https://api.linkedin.com/v2/clientAwareMemberHandles?q=members&projection=(elements*(primary,type,handle~))&oauth2_access_token=%s"
+  val PHOTO = "https://api.linkedin.com/v2/me?projection=(id,profilePicture(displayImage~:playableStreams))&oauth2_access_token=%s"
 }

--- a/silhouette/test/resources/providers/oauth2/linkedin.email.json
+++ b/silhouette/test/resources/providers/oauth2/linkedin.email.json
@@ -1,0 +1,12 @@
+{
+  "elements": [
+    {
+      "handle": "urn:li:emailAddress:30919315",
+      "type": "EMAIL",
+      "handle~": {
+        "emailAddress": "apollonia.vanova@watchmen.com"
+      },
+      "primary": true
+    }
+  ]
+}

--- a/silhouette/test/resources/providers/oauth2/linkedin.error.json
+++ b/silhouette/test/resources/providers/oauth2/linkedin.error.json
@@ -5,3 +5,228 @@
   "status": 401,
   "timestamp": 1390421660154
 }
+
+{
+  "api": {
+    "id": "NhZXBl_O6f",
+    "localizedFirstName": "Apollonia",
+    "localizedLastName": "Vanova",
+    "lastName": {
+      "localized": {
+        "en_US": "Vanova"
+      },
+      "preferredLocale": {
+        "country": "US",
+        "language": "en"
+      }
+    },
+    "firstName": {
+      "localized": {
+        "en_US": "Apollonia"
+      },
+      "preferredLocale": {
+        "country": "US",
+        "language": "en"
+      }
+    },
+    "profilePicture": {
+      "displayImage": "urn:li:digitalmediaAsset:Ue2fjKLUZkB2FL6TOe2"
+    }
+  },
+  "email": {
+    "elements": [
+      {
+        "handle": "urn:li:emailAddress:30919315",
+        "type": "EMAIL",
+        "handle~": {
+          "emailAddress": "apollonia.vanova@watchmen.com"
+        },
+        "primary": true
+      }
+    ]
+  },
+  "photo": {
+    "profilePicture": {
+      "displayImage": "urn:li:digitalmediaAsset:Ue2fjKLUZkB2FL6TOe2",
+      "displayImage~": {
+        "paging": {
+          "count": 10,
+          "start": 0,
+          "links": []
+        },
+        "elements": [
+          {
+            "artifact": "urn:li:digitalmediaMediaArtifact:(urn:li:digitalmediaAsset:Ue2fjKLUZkB2FL6TOe2,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_100_100)",
+            "authorizationMethod": "PUBLIC",
+            "data": {
+              "com.linkedin.digitalmedia.mediaartifact.StillImage": {
+                "storageSize": {
+                  "width": 100,
+                  "height": 100
+                },
+                "storageAspectRatio": {
+                  "widthAspect": 1,
+                  "heightAspect": 1,
+                  "formatted": "1.00:1.00"
+                },
+                "mediaType": "image/jpeg",
+                "rawCodecSpec": {
+                  "name": "jpeg",
+                  "type": "image"
+                },
+                "displaySize": {
+                  "uom": "PX",
+                  "width": 100,
+                  "height": 100
+                },
+                "displayAspectRatio": {
+                  "widthAspect": 1,
+                  "heightAspect": 1,
+                  "formatted": "1.00:1.00"
+                }
+              }
+            },
+            "identifiers": [
+              {
+                "identifier": "https://media.licdn.com/dms/image/C4E03AQFBprjocrF2iA/profile-displayphoto-shrink_100_100/0?e=1576108800&v=beta&t=Tn7mA43w8qmTuzjSdtuYQMi2kI5At9XOp8X--s5hpRU",
+                "file": "urn:li:digitalmediaFile:(urn:li:digitalmediaAsset:Ue2fjKLUZkB2FL6TOe2,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_100_100,0)",
+                "index": 0,
+                "mediaType": "image/jpeg",
+                "identifierType": "EXTERNAL_URL",
+                "identifierExpiresInSeconds": 1576108800
+              }
+            ]
+          },
+          {
+            "artifact": "urn:li:digitalmediaMediaArtifact:(urn:li:digitalmediaAsset:Ue2fjKLUZkB2FL6TOe2,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_200_200)",
+            "authorizationMethod": "PUBLIC",
+            "data": {
+              "com.linkedin.digitalmedia.mediaartifact.StillImage": {
+                "storageSize": {
+                  "width": 200,
+                  "height": 200
+                },
+                "storageAspectRatio": {
+                  "widthAspect": 1,
+                  "heightAspect": 1,
+                  "formatted": "1.00:1.00"
+                },
+                "mediaType": "image/jpeg",
+                "rawCodecSpec": {
+                  "name": "jpeg",
+                  "type": "image"
+                },
+                "displaySize": {
+                  "uom": "PX",
+                  "width": 200,
+                  "height": 200
+                },
+                "displayAspectRatio": {
+                  "widthAspect": 1,
+                  "heightAspect": 1,
+                  "formatted": "1.00:1.00"
+                }
+              }
+            },
+            "identifiers": [
+              {
+                "identifier": "https://media.licdn.com/dms/image/Ue2fjKLUZkB2FL6TOe2/profile-displayphoto-shrink_200_200/0?e=1576108800&v=beta&t=pU43JjN8-GKpLS6QytYoNjYt1fyYMEPcMOQ0SOzgd7w",
+                "file": "urn:li:digitalmediaFile:(urn:li:digitalmediaAsset:Ue2fjKLUZkB2FL6TOe2,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_200_200,0)",
+                "index": 0,
+                "mediaType": "image/jpeg",
+                "identifierType": "EXTERNAL_URL",
+                "identifierExpiresInSeconds": 1576108800
+              }
+            ]
+          },
+          {
+            "artifact": "urn:li:digitalmediaMediaArtifact:(urn:li:digitalmediaAsset:Ue2fjKLUZkB2FL6TOe2,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_400_400)",
+            "authorizationMethod": "PUBLIC",
+            "data": {
+              "com.linkedin.digitalmedia.mediaartifact.StillImage": {
+                "storageSize": {
+                  "width": 400,
+                  "height": 400
+                },
+                "storageAspectRatio": {
+                  "widthAspect": 1,
+                  "heightAspect": 1,
+                  "formatted": "1.00:1.00"
+                },
+                "mediaType": "image/jpeg",
+                "rawCodecSpec": {
+                  "name": "jpeg",
+                  "type": "image"
+                },
+                "displaySize": {
+                  "uom": "PX",
+                  "width": 400,
+                  "height": 400
+                },
+                "displayAspectRatio": {
+                  "widthAspect": 1,
+                  "heightAspect": 1,
+                  "formatted": "1.00:1.00"
+                }
+              }
+            },
+            "identifiers": [
+              {
+                "identifier": "https://media.licdn.com/dms/image/Ue2fjKLUZkB2FL6TOe2/profile-displayphoto-shrink_400_400/0?e=1576108800&v=beta&t=AubLKFL_mdAfOaJm2P3cgQh27RjFaUKiw5gX89tks9Y",
+                "file": "urn:li:digitalmediaFile:(urn:li:digitalmediaAsset:C4E03AQFBprjocrF2iA,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_400_400,0)",
+                "index": 0,
+                "mediaType": "image/jpeg",
+                "identifierType": "EXTERNAL_URL",
+                "identifierExpiresInSeconds": 1576108800
+              }
+            ]
+          },
+          {
+            "artifact": "urn:li:digitalmediaMediaArtifact:(urn:li:digitalmediaAsset:C4E03AQFBprjocrF2iA,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_800_800)",
+            "authorizationMethod": "PUBLIC",
+            "data": {
+              "com.linkedin.digitalmedia.mediaartifact.StillImage": {
+                "storageSize": {
+                  "width": 800,
+                  "height": 800
+                },
+                "storageAspectRatio": {
+                  "widthAspect": 1,
+                  "heightAspect": 1,
+                  "formatted": "1.00:1.00"
+                },
+                "mediaType": "image/jpeg",
+                "rawCodecSpec": {
+                  "name": "jpeg",
+                  "type": "image"
+                },
+                "displaySize": {
+                  "uom": "PX",
+                  "width": 800,
+                  "height": 800
+                },
+                "displayAspectRatio": {
+                  "widthAspect": 1,
+                  "heightAspect": 1,
+                  "formatted": "1.00:1.00"
+                }
+              }
+            },
+            "identifiers": [
+              {
+                "identifier": "https://media.licdn.com/dms/image/C4E03AQFBprjocrF2iA/profile-displayphoto-shrink_800_800/0?e=1576108800&v=beta&t=KGJ0FJfhHLYUw9s-Y_kci0eK8nysnG9iFCPUy0UxVAA",
+                "file": "urn:li:digitalmediaFile:(urn:li:digitalmediaAsset:C4E03AQFBprjocrF2iA,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_800_800,0)",
+                "index": 0,
+                "mediaType": "image/jpeg",
+                "identifierType": "EXTERNAL_URL",
+                "identifierExpiresInSeconds": 1576108800
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "id": "NhZXBl_O6f"
+  }
+}
+

--- a/silhouette/test/resources/providers/oauth2/linkedin.photo.json
+++ b/silhouette/test/resources/providers/oauth2/linkedin.photo.json
@@ -1,0 +1,183 @@
+{
+  "profilePicture": {
+    "displayImage": "urn:li:digitalmediaAsset:Ue2fjKLUZkB2FL6TOe2",
+    "displayImage~": {
+      "paging": {
+        "count": 10,
+        "start": 0,
+        "links": []
+      },
+      "elements": [
+        {
+          "artifact": "urn:li:digitalmediaMediaArtifact:(urn:li:digitalmediaAsset:Ue2fjKLUZkB2FL6TOe2,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_100_100)",
+          "authorizationMethod": "PUBLIC",
+          "data": {
+            "com.linkedin.digitalmedia.mediaartifact.StillImage": {
+              "storageSize": {
+                "width": 100,
+                "height": 100
+              },
+              "storageAspectRatio": {
+                "widthAspect": 1.0,
+                "heightAspect": 1.0,
+                "formatted": "1.00:1.00"
+              },
+              "mediaType": "image/jpeg",
+              "rawCodecSpec": {
+                "name": "jpeg",
+                "type": "image"
+              },
+              "displaySize": {
+                "uom": "PX",
+                "width": 100.0,
+                "height": 100.0
+              },
+              "displayAspectRatio": {
+                "widthAspect": 1.0,
+                "heightAspect": 1.0,
+                "formatted": "1.00:1.00"
+              }
+            }
+          },
+          "identifiers": [
+            {
+              "identifier": "https://media.licdn.com/dms/image/C4E03AQFBprjocrF2iA/profile-displayphoto-shrink_100_100/0?e=1576108800&v=beta&t=Tn7mA43w8qmTuzjSdtuYQMi2kI5At9XOp8X--s5hpRU",
+              "file": "urn:li:digitalmediaFile:(urn:li:digitalmediaAsset:Ue2fjKLUZkB2FL6TOe2,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_100_100,0)",
+              "index": 0,
+              "mediaType": "image/jpeg",
+              "identifierType": "EXTERNAL_URL",
+              "identifierExpiresInSeconds": 1576108800
+            }
+          ]
+        },
+        {
+          "artifact": "urn:li:digitalmediaMediaArtifact:(urn:li:digitalmediaAsset:Ue2fjKLUZkB2FL6TOe2,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_200_200)",
+          "authorizationMethod": "PUBLIC",
+          "data": {
+            "com.linkedin.digitalmedia.mediaartifact.StillImage": {
+              "storageSize": {
+                "width": 200,
+                "height": 200
+              },
+              "storageAspectRatio": {
+                "widthAspect": 1.0,
+                "heightAspect": 1.0,
+                "formatted": "1.00:1.00"
+              },
+              "mediaType": "image/jpeg",
+              "rawCodecSpec": {
+                "name": "jpeg",
+                "type": "image"
+              },
+              "displaySize": {
+                "uom": "PX",
+                "width": 200.0,
+                "height": 200.0
+              },
+              "displayAspectRatio": {
+                "widthAspect": 1.0,
+                "heightAspect": 1.0,
+                "formatted": "1.00:1.00"
+              }
+            }
+          },
+          "identifiers": [
+            {
+              "identifier": "https://media.licdn.com/dms/image/Ue2fjKLUZkB2FL6TOe2/profile-displayphoto-shrink_200_200/0?e=1576108800&v=beta&t=pU43JjN8-GKpLS6QytYoNjYt1fyYMEPcMOQ0SOzgd7w",
+              "file": "urn:li:digitalmediaFile:(urn:li:digitalmediaAsset:Ue2fjKLUZkB2FL6TOe2,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_200_200,0)",
+              "index": 0,
+              "mediaType": "image/jpeg",
+              "identifierType": "EXTERNAL_URL",
+              "identifierExpiresInSeconds": 1576108800
+            }
+          ]
+        },
+        {
+          "artifact": "urn:li:digitalmediaMediaArtifact:(urn:li:digitalmediaAsset:Ue2fjKLUZkB2FL6TOe2,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_400_400)",
+          "authorizationMethod": "PUBLIC",
+          "data": {
+            "com.linkedin.digitalmedia.mediaartifact.StillImage": {
+              "storageSize": {
+                "width": 400,
+                "height": 400
+              },
+              "storageAspectRatio": {
+                "widthAspect": 1.0,
+                "heightAspect": 1.0,
+                "formatted": "1.00:1.00"
+              },
+              "mediaType": "image/jpeg",
+              "rawCodecSpec": {
+                "name": "jpeg",
+                "type": "image"
+              },
+              "displaySize": {
+                "uom": "PX",
+                "width": 400.0,
+                "height": 400.0
+              },
+              "displayAspectRatio": {
+                "widthAspect": 1.0,
+                "heightAspect": 1.0,
+                "formatted": "1.00:1.00"
+              }
+            }
+          },
+          "identifiers": [
+            {
+              "identifier": "https://media.licdn.com/dms/image/Ue2fjKLUZkB2FL6TOe2/profile-displayphoto-shrink_400_400/0?e=1576108800&v=beta&t=AubLKFL_mdAfOaJm2P3cgQh27RjFaUKiw5gX89tks9Y",
+              "file": "urn:li:digitalmediaFile:(urn:li:digitalmediaAsset:C4E03AQFBprjocrF2iA,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_400_400,0)",
+              "index": 0,
+              "mediaType": "image/jpeg",
+              "identifierType": "EXTERNAL_URL",
+              "identifierExpiresInSeconds": 1576108800
+            }
+          ]
+        },
+        {
+          "artifact": "urn:li:digitalmediaMediaArtifact:(urn:li:digitalmediaAsset:C4E03AQFBprjocrF2iA,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_800_800)",
+          "authorizationMethod": "PUBLIC",
+          "data": {
+            "com.linkedin.digitalmedia.mediaartifact.StillImage": {
+              "storageSize": {
+                "width": 800,
+                "height": 800
+              },
+              "storageAspectRatio": {
+                "widthAspect": 1.0,
+                "heightAspect": 1.0,
+                "formatted": "1.00:1.00"
+              },
+              "mediaType": "image/jpeg",
+              "rawCodecSpec": {
+                "name": "jpeg",
+                "type": "image"
+              },
+              "displaySize": {
+                "uom": "PX",
+                "width": 800.0,
+                "height": 800.0
+              },
+              "displayAspectRatio": {
+                "widthAspect": 1.0,
+                "heightAspect": 1.0,
+                "formatted": "1.00:1.00"
+              }
+            }
+          },
+          "identifiers": [
+            {
+              "identifier": "https://media.licdn.com/dms/image/C4E03AQFBprjocrF2iA/profile-displayphoto-shrink_800_800/0?e=1576108800&v=beta&t=KGJ0FJfhHLYUw9s-Y_kci0eK8nysnG9iFCPUy0UxVAA",
+              "file": "urn:li:digitalmediaFile:(urn:li:digitalmediaAsset:C4E03AQFBprjocrF2iA,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_800_800,0)",
+              "index": 0,
+              "mediaType": "image/jpeg",
+              "identifierType": "EXTERNAL_URL",
+              "identifierExpiresInSeconds": 1576108800
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "id": "NhZXBl_O6f"
+}

--- a/silhouette/test/resources/providers/oauth2/linkedin.success.json
+++ b/silhouette/test/resources/providers/oauth2/linkedin.success.json
@@ -1,8 +1,26 @@
 {
-  "id":"NhZXBl_O6f",
-  "firstName":"Apollonia",
-  "lastName":"Vanova",
-  "pictureUrl":"http://media.linkedin.com/mpr/mprx/0_fsPnURNRhLhk_Ue2fjKLUZkB2FL6TOe2S4bdUZz61GA9Ysxu_y_sz4THGW5JGJWhaMleN0F61-Dg",
-  "formattedName": "Apollonia Vanova",
-  "emailAddress": "apollonia.vanova@watchmen.com"
+  "id": "NhZXBl_O6f",
+  "localizedFirstName": "Apollonia",
+  "localizedLastName": "Vanova",
+  "lastName": {
+    "localized": {
+      "en_US": "Vanova"
+    },
+    "preferredLocale": {
+      "country": "US",
+      "language": "en"
+    }
+  },
+  "firstName": {
+    "localized": {
+      "en_US": "Apollonia"
+    },
+    "preferredLocale": {
+      "country": "US",
+      "language": "en"
+    }
+  },
+  "profilePicture": {
+    "displayImage": "urn:li:digitalmediaAsset:Ue2fjKLUZkB2FL6TOe2"
+  }
 }


### PR DESCRIPTION


## Fixes

This fix updates the API url to the v2 resource and the parsing of the json response that comes from it.

## Purpose

This PR allows you to user the LinkedIn provider and get the First and Last name of the logged user. Unfortunatelly the email and picture don't come by default anymore and for that reason were left out.

## Background Context

It has been a while since LinkedIn has discontinued its v1 people resource. As a result, the LinkedInProvider was failing to parse the profile of the logged user.

