### PR TITLE
Fix build error regarding binary incompatibility between scala 2.13.0 and 2.13.1 compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,31 @@
-sudo: false
 language: scala
-dist: trusty # https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766/7
 scala:
   - 2.11.12
   - 2.12.10
   - 2.13.1
 jdk:
-  - oraclejdk8
+  - openjdk8
   - openjdk11
+  - openjdk12
 env:
   global:
   - ENCRYPTION_ID: "9eb27d59440e"
 before_script:
   - echo "TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG, TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST, TRAVIS_BRANCH=$TRAVIS_BRANCH"
+# caching scala stuff based on
+# https://www.scala-sbt.org/1.x/docs/Travis-CI-with-sbt.html
+before_cache:
+  # Tricks to avoid unnecessary cache updates
+  - rm -fv $HOME/.ivy2/.sbt.ivy.lock
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
+  - find $HOME/.sbt        -name "*.lock"               -print -delete
 cache:
   directories:
-    # caching scala stuff based on
-    # http://www.scala-sbt.org/0.13/docs/Travis-CI-with-sbt.html#%28Experimental%29+Reusing+Ivy+cache
+    - $HOME/.cache/coursier
     - $HOME/.ivy2/cache
-    - $HOME/.sbt/boot/
+    - $HOME/.sbt
 script:
   - scripts/ci-build
-  # cleanup travis trick from
-  # http://www.scala-sbt.org/0.13/docs/Travis-CI-with-sbt.html#%28Experimental%29+Reusing+Ivy+cache
-  - find $HOME/.sbt -name "*.lock" -delete
-  - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
 after_success:
   - scripts/api-doc
   - scripts/coveralls

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -30,28 +30,57 @@ import sbtunidoc.ScalaUnidocPlugin.autoImport._
 object BasicSettings extends AutoPlugin {
   override def trigger = allRequirements
 
+  val `scalacOptions2.11.x` = Seq(
+    "-Ywarn-adapted-args",
+    "-Ywarn-inaccessible",
+    "-Ywarn-infer-any",
+    "-Ywarn-nullary-override",
+    "-Ywarn-dead-code",
+    "-Ywarn-nullary-unit",
+    "-Ywarn-numeric-widen",
+    "-Xmax-classfile-name", "254",
+    "-language:higherKinds"
+  )
+
+  val `scalacOptions2.12.x` = Seq(
+    "-Xlint:adapted-args",
+    "-Ywarn-inaccessible",
+    "-Ywarn-infer-any",
+    "-Xlint:nullary-override",
+    "-Xlint:nullary-unit",
+    "-Xmax-classfile-name", "254",
+    "-language:higherKinds"
+  )
+
+  val `scalacOptions2.13.x` = Seq(
+    "-Xlint:adapted-args",
+    "-Xlint:inaccessible",
+    "-Xlint:infer-any",
+    "-Xlint:nullary-override",
+    "-Xlint:nullary-unit"
+  )
+
+  val scalacOptionsCommon = Seq(
+    "-unchecked",
+    "-deprecation",
+    "-feature",
+    "-encoding", "utf8",
+    "-Xfatal-warnings",
+    "-Xlint"
+  )
+
   override def projectSettings = Seq(
     organization := "com.mohiva",
     version := "6.1.1",
     resolvers ++= Dependencies.resolvers,
-    scalaVersion := Dependencies.Versions.scalaVersion,
-    crossScalaVersions := Dependencies.Versions.crossScala,
-    scalacOptions ++= Seq(
-      "-deprecation",        // Emit warning and location for usages of deprecated APIs.
-      "-feature",            // Emit warning and location for usages of features that should be imported explicitly.
-      "-unchecked",          // Enable additional warnings where generated code depends on assumptions.
-      "-Xfatal-warnings",    // Fail the compilation if there are any warnings.
-      "-Xlint",              // Enable recommended additional warnings.,
-      "-Xlint:inaccessible", // Warn about inaccessible types in method signatures.
-      "-Ywarn-dead-code",    // Warn when dead code is identified.
-      "-Ywarn-numeric-widen" // Warn when numerics are widened.
-    ),
+    scalaVersion := "2.13.1",
+    crossVersion := CrossVersion.full,
     scalacOptions ++= {
-      if(Util.priorTo213(scalaVersion.value)) Seq(
-        "-language:higherKinds",
-        "-Ywarn-adapted-args",    // Warn if an argument list is modified to match the receiver.
-        "-Ywarn-nullary-override" // Warn when non-nullary overrides nullary, e.g. def foo() over def foo.
-      ) else Nil
+      scalacOptionsCommon ++ (scalaBinaryVersion.value match {
+        case "2.11" => `scalacOptions2.11.x`
+        case "2.12" => `scalacOptions2.12.x`
+        case "2.13" => `scalacOptions2.13.x`
+      })
     },
     scalacOptions in Test ~= { options: Seq[String] =>
       options filterNot (_ == "-Ywarn-dead-code") // Allow dead code in tests (to support using mockito).
@@ -214,12 +243,14 @@ object Publish extends AutoPlugin {
   )
 }
 
+////*******************************
+//// Helpers
+////*******************************
 object Util {
-
   def priorTo213(scalaVersion: String): Boolean =
     CrossVersion.partialVersion(scalaVersion) match {
       case Some((2, minor)) if minor < 13 => true
       case _                              => false
     }
-
 }
+

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,12 +16,6 @@
 import sbt._
 
 object Dependencies {
-
-  object Versions {
-    val crossScala = Seq("2.13.1", "2.12.10", "2.11.12")
-    val scalaVersion = crossScala.head
-  }
-
   val resolvers = Seq(
     "Atlassian Releases" at "https://maven.atlassian.com/public/"
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=0.13.18

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ logLevel := Level.Warn
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.3")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.7")
 
@@ -18,3 +18,5 @@ addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.8.2")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.3")
+
+addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.2.0")


### PR DESCRIPTION
As a rule of thumb, a scalac plugin always should be published using the full
scala version in its name, since scalac's internal APIs can change without notice.

This change introduces the sbt-travisci plugin which makes it easier to
maintain a full set of versions, cross compiled and run through the CI.

Fixes build issue with Scala 2.13.1 (See #https://github.com/scala/bug/issues/11742)

