### PR TITLE
Fixed Auth0ProfileParser to get user id and name

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/Auth0Provider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/Auth0Provider.scala
@@ -42,7 +42,7 @@ import scala.concurrent.Future
  *   auth0.clientSecret=myoauthclientsecret
  *
  *   # Auth0 user's profile information requested
- *   auth0.scope="openid name email picture"
+ *   auth0.scope="openid profile email"
  *
  * See http://auth0.com for more information on the Auth0 Auth 2.0 Provider and Service.
  */
@@ -120,12 +120,14 @@ class Auth0ProfileParser extends SocialProfileParser[JsValue, CommonSocialProfil
    * @return The social profile from given result.
    */
   override def parse(json: JsValue, authInfo: OAuth2Info): Future[CommonSocialProfile] = Future.successful {
-    val userID = (json \ "user_id").as[String]
+    val userID = (json \ "sub").as[String]
+    val fullName = (json \ "name").asOpt[String]
     val avatarURL = (json \ "picture").asOpt[String]
     val email = (json \ "email").asOpt[String]
 
     CommonSocialProfile(
       loginInfo = LoginInfo(ID, userID),
+      fullName = fullName,
       avatarURL = avatarURL,
       email = email)
   }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/Auth0ProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/oauth2/Auth0ProviderSpec.scala
@@ -157,7 +157,8 @@ class Auth0ProviderSpec extends OAuth2ProviderSpec {
 
       profile(provider.retrieveProfile(oAuthInfo.as[OAuth2Info])) { p =>
         p must be equalTo CommonSocialProfile(
-          loginInfo = LoginInfo(provider.id, (userProfile \ "user_id").as[String]),
+          loginInfo = LoginInfo(provider.id, (userProfile \ "sub").as[String]),
+          fullName = (userProfile \ "name").asOpt[String],
           email = (userProfile \ "email").asOpt[String],
           avatarURL = (userProfile \ "picture").asOpt[String]
         )


### PR DESCRIPTION
- Auth0's userinfo API returns sub as user's ID; doesn't have user_id
- It returns name as user's full name
- Also fixed comment of auth0.scope to get user's profile